### PR TITLE
Add README files for npm packages

### DIFF
--- a/.changeset/add-package-readmes.md
+++ b/.changeset/add-package-readmes.md
@@ -1,0 +1,14 @@
+---
+"@herdctl/core": patch
+"@herdctl/discord": patch
+"herdctl": patch
+---
+
+Add README files for npm package pages
+
+Each package now has a README that appears on npmjs.com with:
+- Package overview and purpose
+- Installation instructions
+- Quick start examples
+- Links to full documentation at herdctl.dev
+- Related packages

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,95 @@
+# herdctl
+
+> Autonomous Agent Fleet Management for Claude Code
+
+[![npm version](https://img.shields.io/npm/v/herdctl.svg)](https://www.npmjs.com/package/herdctl)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+**Documentation**: [herdctl.dev](https://herdctl.dev)
+
+## Overview
+
+Herdctl is an open-source CLI for running fleets of autonomous AI agents powered by Claude Code. Define your agents in YAML, configure schedules and triggers, and let them work autonomously on your codebase.
+
+Think of it as "Kubernetes for AI agents" - declarative configuration, pluggable integrations, and continuous operation.
+
+## Installation
+
+```bash
+npm install -g herdctl
+```
+
+## Quick Start
+
+```bash
+# Initialize a new project
+herdctl init
+
+# Start your agent fleet
+herdctl start
+
+# Check fleet status
+herdctl status
+
+# Manually trigger an agent
+herdctl trigger my-agent
+```
+
+## Configuration
+
+Create a `herdctl.yaml` in your project root:
+
+```yaml
+fleet:
+  name: my-fleet
+
+agents:
+  - path: ./agents/my-agent.yaml
+```
+
+Then define your agent in `agents/my-agent.yaml`:
+
+```yaml
+name: my-agent
+model: claude-sonnet-4-20250514
+
+schedules:
+  daily-review:
+    type: cron
+    cron: "0 9 * * *"
+    prompt: "Review open PRs and provide feedback"
+
+permissions:
+  mode: bypassPermissions
+  allowed_tools:
+    - Read
+    - Glob
+    - Grep
+```
+
+## Features
+
+- **Fleet Management** - Run multiple Claude Code agents with a single command
+- **Declarative Config** - Define agents, schedules, and permissions in YAML
+- **Multiple Triggers** - Interval, cron, webhooks, chat messages
+- **Work Sources** - GitHub Issues integration (Jira/Linear planned)
+- **Execution Hooks** - Shell commands, webhooks, Discord notifications
+- **Chat Integration** - Discord connector for conversational agents
+
+## Documentation
+
+For complete documentation, visit [herdctl.dev](https://herdctl.dev):
+
+- [Getting Started](https://herdctl.dev/getting-started/installation/)
+- [Configuration Reference](https://herdctl.dev/configuration/fleet/)
+- [CLI Reference](https://herdctl.dev/cli-reference/commands/)
+- [Guides](https://herdctl.dev/guides/github-issues/)
+
+## Related Packages
+
+- [`@herdctl/core`](https://www.npmjs.com/package/@herdctl/core) - Core library for programmatic fleet management
+- [`@herdctl/discord`](https://www.npmjs.com/package/@herdctl/discord) - Discord connector for chat-based agents
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,106 @@
+# @herdctl/core
+
+> Core library for herdctl fleet management
+
+[![npm version](https://img.shields.io/npm/v/@herdctl/core.svg)](https://www.npmjs.com/package/@herdctl/core)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+**Documentation**: [herdctl.dev](https://herdctl.dev)
+
+## Overview
+
+`@herdctl/core` is the programmatic foundation for herdctl. Use it to embed autonomous Claude Code agents directly in your Node.js applications - build custom dashboards, integrate with your existing tools, or create entirely new agent orchestration systems.
+
+## Installation
+
+```bash
+npm install @herdctl/core
+```
+
+## Quick Start
+
+```typescript
+import { FleetManager } from "@herdctl/core";
+
+// Initialize from config file
+const fleet = new FleetManager();
+await fleet.initialize();
+
+// Start the fleet
+await fleet.start();
+
+// Manually trigger an agent
+const result = await fleet.trigger("my-agent", undefined, {
+  prompt: "Review the latest changes",
+});
+
+console.log(`Job ${result.jobId} started`);
+
+// Stop gracefully
+await fleet.stop();
+```
+
+## Features
+
+- **FleetManager** - Core orchestration class for managing agent fleets
+- **Configuration** - Load and validate herdctl YAML configs programmatically
+- **Job Control** - Trigger, cancel, and fork agent jobs
+- **Scheduling** - Built-in scheduler for cron and interval triggers
+- **Event System** - Subscribe to fleet events (job:created, job:completed, etc.)
+- **State Management** - Persistent state for jobs, sessions, and fleet status
+- **Hook Execution** - Run shell commands, webhooks, and Discord notifications
+
+## Usage
+
+### Loading Configuration
+
+```typescript
+import { loadConfig } from "@herdctl/core";
+
+const config = await loadConfig("./herdctl.yaml");
+console.log(`Loaded ${config.agents.length} agents`);
+```
+
+### Event Handling
+
+```typescript
+fleet.on("job:completed", (event) => {
+  console.log(`Job ${event.job.id} completed for ${event.agentName}`);
+});
+
+fleet.on("job:failed", (event) => {
+  console.error(`Job failed: ${event.error.message}`);
+});
+```
+
+### Programmatic Triggers
+
+```typescript
+// Trigger with custom prompt
+const result = await fleet.trigger("code-reviewer", undefined, {
+  prompt: "Review PR #123 for security issues",
+  onMessage: (message) => {
+    // Stream agent output in real-time
+    if (message.type === "assistant") {
+      process.stdout.write(message.content);
+    }
+  },
+});
+```
+
+## Documentation
+
+For complete API documentation, visit [herdctl.dev](https://herdctl.dev):
+
+- [Library Reference](https://herdctl.dev/library-reference/fleet-manager/)
+- [Configuration](https://herdctl.dev/configuration/fleet/)
+- [Concepts](https://herdctl.dev/concepts/architecture/)
+
+## Related Packages
+
+- [`herdctl`](https://www.npmjs.com/package/herdctl) - CLI for running agent fleets
+- [`@herdctl/discord`](https://www.npmjs.com/package/@herdctl/discord) - Discord connector
+
+## License
+
+MIT

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -1,0 +1,95 @@
+# @herdctl/discord
+
+> Discord connector for herdctl fleet management
+
+[![npm version](https://img.shields.io/npm/v/@herdctl/discord.svg)](https://www.npmjs.com/package/@herdctl/discord)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+**Documentation**: [herdctl.dev](https://herdctl.dev)
+
+## Overview
+
+`@herdctl/discord` enables your herdctl agents to interact via Discord. Users can chat with agents in DMs or channels, and agents can send notifications when jobs complete. The connector handles session management automatically, maintaining conversation context across messages.
+
+## Installation
+
+```bash
+npm install @herdctl/discord
+```
+
+> **Note**: This package is typically used automatically by `@herdctl/core` when Discord is configured in your agent YAML. Direct installation is only needed for advanced use cases.
+
+## Configuration
+
+Add Discord chat configuration to your agent YAML:
+
+```yaml
+name: my-assistant
+model: claude-sonnet-4-20250514
+
+chat:
+  discord:
+    bot_token_env: DISCORD_BOT_TOKEN
+    mode: auto  # Respond to all DMs automatically
+    allowed_channels:
+      - "123456789"  # Specific channel IDs
+    allowed_roles:
+      - "987654321"  # Role IDs that can interact
+```
+
+### Chat Modes
+
+- **`auto`** - Respond to all messages in allowed channels/DMs
+- **`mention`** - Only respond when the bot is @mentioned
+
+## Features
+
+- **Conversation Continuity** - Sessions persist across messages using Claude SDK session resumption
+- **DM Support** - Users can chat privately with agents
+- **Channel Support** - Agents can participate in server channels
+- **Role-Based Access** - Restrict which users can interact
+- **Slash Commands** - Built-in `/status`, `/reset`, and `/help` commands
+- **Typing Indicators** - Visual feedback while agent is processing
+- **Message Splitting** - Long responses are automatically split to fit Discord's limits
+
+## Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show available commands and usage |
+| `/status` | Show agent status and current session info |
+| `/reset` | Clear conversation context (start fresh) |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DISCORD_BOT_TOKEN` | Your Discord bot token (or use custom env var name in config) |
+
+## Bot Setup
+
+1. Create a Discord application at [discord.com/developers](https://discord.com/developers/applications)
+2. Add a bot to your application
+3. Enable the "Message Content Intent" in bot settings
+4. Generate an invite URL with these permissions:
+   - Send Messages
+   - Read Message History
+   - Use Slash Commands
+5. Invite the bot to your server
+6. Set `DISCORD_BOT_TOKEN` environment variable
+
+## Documentation
+
+For complete setup instructions, visit [herdctl.dev](https://herdctl.dev):
+
+- [Discord Integration Guide](https://herdctl.dev/integrations/discord/)
+- [Chat Configuration](https://herdctl.dev/configuration/agent/#chat)
+
+## Related Packages
+
+- [`herdctl`](https://www.npmjs.com/package/herdctl) - CLI for running agent fleets
+- [`@herdctl/core`](https://www.npmjs.com/package/@herdctl/core) - Core library for programmatic use
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Adds README files for all three npm packages so they display properly on npmjs.com.

## Changes

Each package now has a README with:
- Package overview and purpose
- Installation instructions
- Quick start / usage examples
- Links to full documentation at herdctl.dev
- Related packages section
- npm version and license badges

### Package READMEs

| Package | Content Highlights |
|---------|-------------------|
| `herdctl` | CLI commands, YAML config examples, feature list |
| `@herdctl/core` | FleetManager API, event handling, programmatic usage |
| `@herdctl/discord` | Bot setup guide, chat modes, slash commands |

## Test plan

- [x] READMEs render correctly in GitHub
- [ ] Verify appearance on npmjs.com after release

🤖 Generated with [Claude Code](https://claude.ai/code)