### PR TITLE
fix(cli): init templates use incorrect workspace schema

### DIFF
--- a/.changeset/fix-init-workspace.md
+++ b/.changeset/fix-init-workspace.md
@@ -1,0 +1,6 @@
+---
+"herdctl": patch
+---
+
+Fix init templates using incorrect `workspace.path` key instead of `workspace: path` string format
+

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -63,8 +63,7 @@ system_prompt: |
   analyze the task and provide a useful response.
 
 # Workspace - where the agent operates
-workspace:
-  path: ./workspace
+workspace: ./workspace
 
 # Schedules - when the agent runs
 schedules:
@@ -152,8 +151,7 @@ system_prompt: |
   analyze the requirements and implement the requested changes.
   Follow best practices and write clean, tested code.
 
-workspace:
-  path: ./workspace
+workspace: ./workspace
 
 schedules:
   process-issues:


### PR DESCRIPTION
## Summary
- Fixed `herdctl init` templates generating invalid `workspace.path` instead of the correct format
- The schema accepts either a string (`workspace: ./path`) or an object with `root` key (`workspace: { root: ./path }`)
- Templates were incorrectly using `workspace: { path: ./path }` which doesn't match the schema

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all 103 CLI tests)
- [ ] Manual: Run `herdctl init` and verify generated agent config has `workspace: ./workspace` instead of nested `path` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)