### PR TITLE
fix(cli): remove default model from init templates

### DIFF
--- a/.changeset/remove-init-model.md
+++ b/.changeset/remove-init-model.md
@@ -1,0 +1,6 @@
+---
+"herdctl": patch
+---
+
+Remove default model from init templates - SDK uses its own sensible default
+

--- a/packages/cli/src/commands/__tests__/init.test.ts
+++ b/packages/cli/src/commands/__tests__/init.test.ts
@@ -146,7 +146,8 @@ describe("initCommand", () => {
         "utf-8"
       );
       expect(content).toContain("defaults:");
-      expect(content).toContain("model: claude-sonnet-4-20250514");
+      expect(content).toContain("max_turns: 50");
+      expect(content).not.toContain("model:"); // model should not be set - SDK uses its own default
 
       const agentPath = path.join(tempDir, "agents", "example-agent.yaml");
       expect(fs.existsSync(agentPath)).toBe(true);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -42,7 +42,6 @@ fleet:
   description: {{FLEET_DESCRIPTION}}
 
 defaults:
-  model: claude-sonnet-4-20250514
   max_turns: 50
   permission_mode: default
 
@@ -131,7 +130,6 @@ fleet:
   description: {{FLEET_DESCRIPTION}}
 
 defaults:
-  model: claude-sonnet-4-20250514
   max_turns: 100
   permission_mode: acceptEdits
 


### PR DESCRIPTION
## Summary
- Removed `model: claude-sonnet-4-20250514` from `herdctl init` templates
- The Claude Agent SDK uses sensible model defaults, so there's no need to hardcode a specific model
- This prevents the config from becoming stale when new models are released

**Note:** The `model` field in herdctl config is currently informational only - it's displayed in status queries but not actually passed to the SDK (see `toSDKOptions` in `sdk-adapter.ts`).

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all 103 CLI tests)
- [x] Updated test to verify model is NOT present in generated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)