### PR TITLE
feat(slack): add Slack integration for agent chat

### DIFF
--- a/.changeset/slack-integration.md
+++ b/.changeset/slack-integration.md
@@ -1,0 +1,15 @@
+---
+"@herdctl/core": minor
+"@herdctl/slack": minor
+---
+
+feat: add Slack integration for agent chat
+
+Adds `@herdctl/slack` package and integrates it into `@herdctl/core`:
+
+- New `@herdctl/slack` package with SlackConnector (Bolt/Socket Mode), SessionManager, CommandHandler, error handling, and mrkdwn formatting
+- Config schema: `AgentChatSlackSchema` and `SlackHookConfigSchema` for agent chat and hook configuration
+- Core: `SlackManager` for single-connector-per-workspace lifecycle management with channel-to-agent routing
+- Core: `SlackHookRunner` for posting schedule results to Slack channels
+- Core: FleetManager wiring (initialize/start/stop), status queries, and event types for Slack connector
+- Example: `examples/slack-chat-bot/` with setup instructions

--- a/examples/slack-chat-bot/.env.example
+++ b/examples/slack-chat-bot/.env.example
@@ -1,0 +1,32 @@
+# Slack App Configuration
+# ======================
+#
+# Copy this file to .env and fill in your values.
+# The .env file will be automatically loaded by herdctl.
+#
+# To get these values:
+# 1. Create a Slack app at https://api.slack.com/apps
+# 2. Enable Socket Mode (Settings > Socket Mode)
+# 3. Generate an App-Level Token with connections:write scope
+# 4. Install the app to your workspace (Install App > Install to Workspace)
+# 5. Copy the Bot User OAuth Token and App-Level Token below
+# 6. Add the bot to your desired channel in Slack
+# 7. Get the channel ID by right-clicking the channel name > "View channel details"
+#
+# Required Bot Token Scopes:
+# - app_mentions:read (to detect @mentions)
+# - chat:write (to send messages)
+# - channels:history (to read channel messages)
+#
+# Required Socket Mode Event Subscriptions:
+# - app_mention
+# - message.channels
+
+# Bot User OAuth Token (starts with xoxb-)
+SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+
+# App-Level Token (starts with xapp-)
+SLACK_APP_TOKEN=xapp-your-app-token-here
+
+# The Slack channel ID where the bot operates (starts with C)
+SLACK_CHANNEL_ID=C0123456789

--- a/examples/slack-chat-bot/.gitignore
+++ b/examples/slack-chat-bot/.gitignore
@@ -1,0 +1,2 @@
+.env
+.herdctl/

--- a/examples/slack-chat-bot/agents/assistant.yaml
+++ b/examples/slack-chat-bot/agents/assistant.yaml
@@ -1,0 +1,45 @@
+name: assistant
+description: General-purpose assistant with Slack chat interface
+
+max_turns: 15
+
+default_prompt: "Check for new messages and respond."
+
+system_prompt: |
+  You are a helpful assistant available through Slack. When users @mention you
+  in a channel or reply in a thread, answer their questions clearly and concisely.
+
+  ## Guidelines
+  - Be helpful and friendly
+  - Use Slack formatting (bold with *text*, code with `backticks`)
+  - Keep responses concise for chat
+  - If asked to perform a task, do it and report back
+
+allowed_tools:
+  - WebSearch
+  - WebFetch
+  - Read
+  - Write
+  - Edit
+denied_tools:
+  - Bash
+  - TodoWrite
+  - Task
+
+# Slack chat integration
+# Users @mention the bot to start a conversation, replies continue in-thread
+chat:
+  slack:
+    bot_token_env: SLACK_BOT_TOKEN
+    app_token_env: SLACK_APP_TOKEN
+    session_expiry_hours: 24
+    log_level: standard
+    channels:
+      - id: "${SLACK_CHANNEL_ID}"
+
+# Post schedule results to Slack
+hooks:
+  after_run:
+    - type: slack
+      channel_id: "${SLACK_CHANNEL_ID}"
+      bot_token_env: SLACK_BOT_TOKEN

--- a/examples/slack-chat-bot/herdctl.yaml
+++ b/examples/slack-chat-bot/herdctl.yaml
@@ -1,0 +1,8 @@
+version: 1
+
+fleet:
+  name: slack-chat-bot-example
+  description: Example fleet with Slack chat integration
+
+agents:
+  - path: agents/assistant.yaml

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -40,11 +40,15 @@ export {
   DiscordChannelSchema,
   DiscordGuildSchema,
   AgentChatDiscordSchema,
+  // Agent Chat Slack schemas
+  SlackChannelSchema,
+  AgentChatSlackSchema,
   // Hook schemas
   HookEventSchema,
   ShellHookConfigSchema,
   WebhookHookConfigSchema,
   DiscordHookConfigSchema,
+  SlackHookConfigSchema,
   HookConfigSchema,
   AgentHooksSchema,
   // Types
@@ -83,17 +87,22 @@ export {
   type DiscordChannel,
   type DiscordGuild,
   type AgentChatDiscord,
+  // Agent Chat Slack types
+  type SlackChannel,
+  type AgentChatSlack,
   // Hook types
   type HookEvent,
   type ShellHookConfig,
   type WebhookHookConfig,
   type DiscordHookConfig,
+  type SlackHookConfig,
   type HookConfig,
   type AgentHooks,
   // Hook input types (for construction, allow optional fields)
   type ShellHookConfigInput,
   type WebhookHookConfigInput,
   type DiscordHookConfigInput,
+  type SlackHookConfigInput,
   type HookConfigInput,
   type AgentHooksInput,
 } from "./schema.js";

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -607,12 +607,66 @@ export const AgentChatDiscordSchema = z.object({
 });
 
 // =============================================================================
+// Agent Chat Slack Schemas (per-agent Slack bot configuration)
+// =============================================================================
+
+/**
+ * Slack channel configuration for an agent's bot
+ *
+ * @example
+ * ```yaml
+ * channels:
+ *   - id: "C0123456789"
+ *     name: "#support"
+ * ```
+ */
+export const SlackChannelSchema = z.object({
+  /** Slack channel ID */
+  id: z.string(),
+  /** Human-readable channel name (for documentation) */
+  name: z.string().optional(),
+});
+
+/**
+ * Per-agent Slack bot configuration schema
+ *
+ * Unlike Discord where each agent has its own bot token,
+ * Slack uses a single app with one bot token per workspace.
+ * All agents share the same bot + app token pair.
+ *
+ * @example
+ * ```yaml
+ * chat:
+ *   slack:
+ *     bot_token_env: SLACK_BOT_TOKEN
+ *     app_token_env: SLACK_APP_TOKEN
+ *     session_expiry_hours: 24
+ *     log_level: standard
+ *     channels:
+ *       - id: "C0123456789"
+ *         name: "#support"
+ * ```
+ */
+export const AgentChatSlackSchema = z.object({
+  /** Environment variable name containing the bot token (xoxb-...) */
+  bot_token_env: z.string().default("SLACK_BOT_TOKEN"),
+  /** Environment variable name containing the app token for Socket Mode (xapp-...) */
+  app_token_env: z.string().default("SLACK_APP_TOKEN"),
+  /** Session expiry in hours (default: 24) */
+  session_expiry_hours: z.number().int().positive().default(24),
+  /** Log level for this agent's Slack connector */
+  log_level: z.enum(["minimal", "standard", "verbose"]).default("standard"),
+  /** Channels this agent listens in */
+  channels: z.array(SlackChannelSchema),
+});
+
+// =============================================================================
 // Agent Chat Schema (agent-specific chat config)
 // =============================================================================
 
 export const AgentChatSchema = z.object({
   discord: AgentChatDiscordSchema.optional(),
-  // slack: AgentChatSlackSchema.optional(), // Future
+  slack: AgentChatSlackSchema.optional(),
 });
 
 // =============================================================================
@@ -676,12 +730,24 @@ export const DiscordHookConfigSchema = BaseHookConfigSchema.extend({
 });
 
 /**
+ * Slack hook configuration - sends notification to a Slack channel
+ */
+export const SlackHookConfigSchema = BaseHookConfigSchema.extend({
+  type: z.literal("slack"),
+  /** Slack channel ID to post to */
+  channel_id: z.string().min(1),
+  /** Environment variable name containing the bot token */
+  bot_token_env: z.string().min(1).default("SLACK_BOT_TOKEN"),
+});
+
+/**
  * Union of all hook configuration types
  */
 export const HookConfigSchema = z.discriminatedUnion("type", [
   ShellHookConfigSchema,
   WebhookHookConfigSchema,
   DiscordHookConfigSchema,
+  SlackHookConfigSchema,
 ]);
 
 /**
@@ -860,6 +926,9 @@ export type DiscordChannel = z.infer<typeof DiscordChannelSchema>;
 export type DiscordGuild = z.infer<typeof DiscordGuildSchema>;
 export type AgentChatDiscord = z.infer<typeof AgentChatDiscordSchema>;
 export type AgentChat = z.infer<typeof AgentChatSchema>;
+// Agent Chat Slack types
+export type SlackChannel = z.infer<typeof SlackChannelSchema>;
+export type AgentChatSlack = z.infer<typeof AgentChatSlackSchema>;
 export type AgentWorkingDirectory = z.infer<
   typeof AgentWorkingDirectorySchema
 >;
@@ -869,11 +938,13 @@ export type HookEvent = z.infer<typeof HookEventSchema>;
 export type ShellHookConfig = z.infer<typeof ShellHookConfigSchema>;
 export type WebhookHookConfig = z.infer<typeof WebhookHookConfigSchema>;
 export type DiscordHookConfig = z.infer<typeof DiscordHookConfigSchema>;
+export type SlackHookConfig = z.infer<typeof SlackHookConfigSchema>;
 export type HookConfig = z.infer<typeof HookConfigSchema>;
 export type AgentHooks = z.infer<typeof AgentHooksSchema>;
 // Hook types - Input types (for constructing configs, allows optional fields)
 export type ShellHookConfigInput = z.input<typeof ShellHookConfigSchema>;
 export type WebhookHookConfigInput = z.input<typeof WebhookHookConfigSchema>;
 export type DiscordHookConfigInput = z.input<typeof DiscordHookConfigSchema>;
+export type SlackHookConfigInput = z.input<typeof SlackHookConfigSchema>;
 export type HookConfigInput = z.input<typeof HookConfigSchema>;
 export type AgentHooksInput = z.input<typeof AgentHooksSchema>;

--- a/packages/core/src/fleet-manager/__tests__/slack-manager.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/slack-manager.test.ts
@@ -1,0 +1,1471 @@
+/**
+ * Tests for SlackManager
+ *
+ * Tests the SlackManager class which manages a single Slack connector
+ * shared across agents with chat.slack configured.
+ *
+ * Since @herdctl/slack is not a dependency of @herdctl/core, we mock the
+ * dynamic import to test the full initialization and lifecycle paths.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+import type { FleetManagerContext } from "../context.js";
+import type {
+  ResolvedConfig,
+  ResolvedAgent,
+  AgentChatSlack,
+} from "../../config/index.js";
+
+// ---------------------------------------------------------------------------
+// Mock Factories
+// ---------------------------------------------------------------------------
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function createMockEmitter() {
+  const emitter = new EventEmitter();
+  vi.spyOn(emitter, "emit");
+  return emitter;
+}
+
+function createMockContext(
+  config: ResolvedConfig | null = null,
+  emitter: EventEmitter = createMockEmitter()
+): FleetManagerContext {
+  return {
+    getConfig: () => config,
+    getStateDir: () => "/tmp/test-state",
+    getStateDirInfo: () => null,
+    getLogger: () => mockLogger,
+    getScheduler: () => null,
+    getStatus: () => "initialized",
+    getInitializedAt: () => null,
+    getStartedAt: () => null,
+    getStoppedAt: () => null,
+    getLastError: () => null,
+    getCheckInterval: () => 1000,
+    emit: (event: string, ...args: unknown[]) => emitter.emit(event, ...args),
+    getEmitter: () => emitter,
+  };
+}
+
+function createSlackAgent(
+  name: string,
+  slackConfig: AgentChatSlack
+): ResolvedAgent {
+  return {
+    name,
+    model: "sonnet",
+    runtime: "sdk",
+    schedules: {},
+    chat: { slack: slackConfig },
+    configPath: "/test/herdctl.yaml",
+  } as ResolvedAgent;
+}
+
+function createNonSlackAgent(name: string): ResolvedAgent {
+  return {
+    name,
+    model: "sonnet",
+    schedules: {},
+    configPath: "/test/herdctl.yaml",
+  } as ResolvedAgent;
+}
+
+const defaultSlackConfig: AgentChatSlack = {
+  bot_token_env: "SLACK_BOT_TOKEN",
+  app_token_env: "SLACK_APP_TOKEN",
+  session_expiry_hours: 24,
+  log_level: "standard",
+  channels: [{ id: "C0123456789" }],
+};
+
+function createConfigWithAgents(
+  ...agents: ResolvedAgent[]
+): ResolvedConfig {
+  return {
+    fleet: { name: "test-fleet" } as unknown as ResolvedConfig["fleet"],
+    agents,
+    configPath: "/test/herdctl.yaml",
+    configDir: "/test",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock SlackConnector and SessionManager
+// ---------------------------------------------------------------------------
+
+function createMockConnector() {
+  const connector = new EventEmitter() as EventEmitter & {
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    isConnected: ReturnType<typeof vi.fn>;
+    getState: ReturnType<typeof vi.fn>;
+  };
+  connector.connect = vi.fn().mockResolvedValue(undefined);
+  connector.disconnect = vi.fn().mockResolvedValue(undefined);
+  connector.isConnected = vi.fn().mockReturnValue(false);
+  connector.getState = vi.fn().mockReturnValue({
+    status: "disconnected",
+    connectedAt: null,
+    disconnectedAt: null,
+    reconnectAttempts: 0,
+    lastError: null,
+    botUser: null,
+    messageStats: { received: 0, sent: 0, ignored: 0 },
+  });
+  return connector;
+}
+
+function createMockSessionManager(agentName: string) {
+  return {
+    agentName,
+    getOrCreateSession: vi.fn().mockResolvedValue({ sessionId: "session-1", isNew: true }),
+    getSession: vi.fn().mockResolvedValue(null),
+    setSession: vi.fn().mockResolvedValue(undefined),
+    touchSession: vi.fn().mockResolvedValue(undefined),
+    clearSession: vi.fn().mockResolvedValue(true),
+    cleanupExpiredSessions: vi.fn().mockResolvedValue(0),
+    getActiveSessionCount: vi.fn().mockResolvedValue(0),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests – No Mock (real import fails because @herdctl/slack not installed)
+// ---------------------------------------------------------------------------
+
+describe("SlackManager (no @herdctl/slack)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // We import fresh each time to avoid stale module state
+  async function getSlackManager() {
+    const mod = await import("../slack-manager.js");
+    return mod.SlackManager;
+  }
+
+  describe("constructor", () => {
+    it("creates instance with context", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext();
+      const manager = new SlackManager(ctx);
+      expect(manager).toBeDefined();
+    });
+  });
+
+  describe("initialize", () => {
+    it("skips initialization when no config is available", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "No config available, skipping Slack initialization"
+      );
+    });
+
+    it("skips when @herdctl/slack is not installed (no slack agents)", async () => {
+      const SlackManager = await getSlackManager();
+      const config = createConfigWithAgents(
+        createNonSlackAgent("agent1"),
+        createNonSlackAgent("agent2")
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "@herdctl/slack not installed, skipping Slack connector"
+      );
+    });
+
+    it("skips when @herdctl/slack is not installed (with slack agents)", async () => {
+      const SlackManager = await getSlackManager();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "@herdctl/slack not installed, skipping Slack connector"
+      );
+    });
+
+    it("allows retry when no config (initialized not set)", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.initialize();
+
+      const calls = mockLogger.debug.mock.calls.filter(
+        (c: string[]) =>
+          c[0] === "No config available, skipping Slack initialization"
+      );
+      expect(calls.length).toBe(2);
+    });
+  });
+
+  describe("start", () => {
+    it("does nothing when no connector exists", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "No Slack connector to start"
+      );
+    });
+  });
+
+  describe("stop", () => {
+    it("does nothing when no connector exists", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.stop();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "No Slack connector to stop"
+      );
+    });
+  });
+
+  describe("hasAgent", () => {
+    it("returns false when not initialized", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      expect(manager.hasAgent("test-agent")).toBe(false);
+    });
+  });
+
+  describe("getState", () => {
+    it("returns null when no connector", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      expect(manager.getState()).toBeNull();
+    });
+  });
+
+  describe("isConnected", () => {
+    it("returns false when no connector", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      expect(manager.isConnected()).toBe(false);
+    });
+  });
+
+  describe("getConnector", () => {
+    it("returns null when no connector", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      expect(manager.getConnector()).toBeNull();
+    });
+  });
+
+  describe("getChannelAgentMap", () => {
+    it("returns empty map when not initialized", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      expect(manager.getChannelAgentMap().size).toBe(0);
+    });
+  });
+
+  describe("splitResponse", () => {
+    it("returns single chunk for short text", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      const result = manager.splitResponse("Hello, world!");
+      expect(result).toEqual(["Hello, world!"]);
+    });
+
+    it("splits long text at natural breaks", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      // Build a text larger than 4000 chars
+      const line = "This is a test line that is moderately long. ";
+      const longText = line.repeat(100); // ~4500 chars
+      const chunks = manager.splitResponse(longText);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(4000);
+      }
+      // All content preserved
+      expect(chunks.join("")).toBe(longText);
+    });
+
+    it("splits at double newlines when available", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      const part1 = "A".repeat(3800);
+      const part2 = "B".repeat(200);
+      const longText = part1 + "\n\n" + part2;
+      const chunks = manager.splitResponse(longText);
+
+      expect(chunks.length).toBe(2);
+      expect(chunks[0]).toBe(part1 + "\n\n");
+    });
+
+    it("splits at single newline when no double newline", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      const part1 = "A".repeat(3900);
+      const part2 = "B".repeat(200);
+      const longText = part1 + "\n" + part2;
+      const chunks = manager.splitResponse(longText);
+
+      expect(chunks.length).toBe(2);
+      expect(chunks[0]).toBe(part1 + "\n");
+    });
+
+    it("splits at space when no newline", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      const part1 = "A".repeat(3950);
+      const part2 = "B".repeat(200);
+      const longText = part1 + " " + part2;
+      const chunks = manager.splitResponse(longText);
+
+      expect(chunks.length).toBe(2);
+      expect(chunks[0]).toBe(part1 + " ");
+    });
+  });
+
+  describe("formatErrorMessage", () => {
+    it("formats an error with !reset suggestion", async () => {
+      const SlackManager = await getSlackManager();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      const result = manager.formatErrorMessage(new Error("Something broke"));
+      expect(result).toContain("Something broke");
+      expect(result).toContain("!reset");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests – With Mocked @herdctl/slack (full initialization paths)
+// ---------------------------------------------------------------------------
+
+describe("SlackManager (mocked @herdctl/slack)", () => {
+  let mockConnector: ReturnType<typeof createMockConnector>;
+  let MockSlackConnector: ReturnType<typeof vi.fn>;
+  let MockSessionManager: ReturnType<typeof vi.fn>;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    originalEnv = { ...process.env };
+
+    // Set required env vars
+    process.env.SLACK_BOT_TOKEN = "xoxb-test-bot-token";
+    process.env.SLACK_APP_TOKEN = "xapp-test-app-token";
+
+    // Create mock implementations
+    mockConnector = createMockConnector();
+
+    // Must use function expressions (not arrows) so they work with `new`
+    MockSlackConnector = vi.fn().mockImplementation(function () {
+      return mockConnector;
+    });
+    MockSessionManager = vi.fn().mockImplementation(function (
+      this: unknown,
+      opts: { agentName: string }
+    ) {
+      return createMockSessionManager(opts.agentName);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  async function getSlackManagerWithMock() {
+    // Mock the dynamic import. vi.resetModules() in beforeEach ensures
+    // the import cache is cleared so our mock takes effect.
+    vi.doMock("@herdctl/slack", () => ({
+      SlackConnector: MockSlackConnector,
+      SessionManager: MockSessionManager,
+    }));
+
+    // Force fresh import of the slack-manager module
+    const mod = await import("../slack-manager.js");
+    return mod.SlackManager;
+  }
+
+  describe("initialize", () => {
+    it("creates connector when slack agents exist and tokens are set", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(MockSessionManager).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentName: "agent1",
+          stateDir: "/tmp/test-state",
+          sessionExpiryHours: 24,
+        })
+      );
+      expect(MockSlackConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          botToken: "xoxb-test-bot-token",
+          appToken: "xapp-test-app-token",
+          stateDir: "/tmp/test-state",
+        })
+      );
+      expect(manager.hasAgent("agent1")).toBe(true);
+      expect(manager.getConnector()).toBe(mockConnector);
+    });
+
+    it("builds channel→agent routing map", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", {
+          ...defaultSlackConfig,
+          channels: [{ id: "C001" }, { id: "C002" }],
+        }),
+        createSlackAgent("agent2", {
+          ...defaultSlackConfig,
+          channels: [{ id: "C003" }],
+        })
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      const channelMap = manager.getChannelAgentMap();
+      expect(channelMap.get("C001")).toBe("agent1");
+      expect(channelMap.get("C002")).toBe("agent1");
+      expect(channelMap.get("C003")).toBe("agent2");
+      expect(channelMap.size).toBe(3);
+    });
+
+    it("warns about overlapping channel mappings", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", {
+          ...defaultSlackConfig,
+          channels: [{ id: "C001" }],
+        }),
+        createSlackAgent("agent2", {
+          ...defaultSlackConfig,
+          channels: [{ id: "C001" }], // Same channel as agent1
+        })
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Channel C001 is already mapped")
+      );
+      // Second agent wins
+      expect(manager.getChannelAgentMap().get("C001")).toBe("agent2");
+    });
+
+    it("skips when no agents have Slack configured", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createNonSlackAgent("agent1")
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "No agents with Slack configured"
+      );
+      expect(MockSlackConnector).not.toHaveBeenCalled();
+    });
+
+    it("warns and skips when bot token env var is missing", async () => {
+      delete process.env.SLACK_BOT_TOKEN;
+
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Slack bot token not found")
+      );
+      expect(MockSlackConnector).not.toHaveBeenCalled();
+    });
+
+    it("warns and skips when app token env var is missing", async () => {
+      delete process.env.SLACK_APP_TOKEN;
+
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Slack app token not found")
+      );
+      expect(MockSlackConnector).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent after successful initialization", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.initialize();
+
+      // Constructor only called once
+      expect(MockSlackConnector).toHaveBeenCalledTimes(1);
+    });
+
+    it("is idempotent after no-agents path", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(createNonSlackAgent("agent1"));
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.initialize();
+
+      const calls = mockLogger.debug.mock.calls.filter(
+        (c: string[]) => c[0] === "No agents with Slack configured"
+      );
+      expect(calls.length).toBe(1);
+    });
+
+    it("logs info about successful initialization", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Slack manager initialized with 1 agent(s)")
+      );
+    });
+
+    it("handles connector creation failure", async () => {
+      MockSlackConnector.mockImplementation(() => {
+        throw new Error("Failed to create Bolt app");
+      });
+
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to create Slack connector")
+      );
+      expect(manager.getConnector()).toBeNull();
+    });
+
+    it("creates multiple session managers for multiple agents", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", {
+          ...defaultSlackConfig,
+          channels: [{ id: "C001" }],
+        }),
+        createSlackAgent("agent2", {
+          ...defaultSlackConfig,
+          channels: [{ id: "C002" }],
+        }),
+        createNonSlackAgent("agent3")
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(MockSessionManager).toHaveBeenCalledTimes(2);
+      expect(manager.hasAgent("agent1")).toBe(true);
+      expect(manager.hasAgent("agent2")).toBe(true);
+      expect(manager.hasAgent("agent3")).toBe(false);
+    });
+  });
+
+  describe("start", () => {
+    it("connects the connector and subscribes to events", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      expect(mockConnector.connect).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info).toHaveBeenCalledWith("Slack connector started");
+    });
+
+    it("handles connection failure", async () => {
+      mockConnector.connect.mockRejectedValue(new Error("Connection refused"));
+
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to connect Slack")
+      );
+    });
+
+    it("logs debug message when no connector to start", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const ctx = createMockContext(null);
+      const manager = new SlackManager(ctx);
+
+      await manager.start();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "No Slack connector to start"
+      );
+    });
+  });
+
+  describe("stop", () => {
+    it("disconnects the connector", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.stop();
+
+      expect(mockConnector.disconnect).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info).toHaveBeenCalledWith("Slack connector stopped");
+    });
+
+    it("handles disconnect failure", async () => {
+      mockConnector.disconnect.mockRejectedValue(
+        new Error("Disconnect timeout")
+      );
+
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.stop();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Error disconnecting Slack")
+      );
+    });
+
+    it("logs active session counts before stopping", async () => {
+      const mockSessionMgr = createMockSessionManager("agent1");
+      mockSessionMgr.getActiveSessionCount.mockResolvedValue(3);
+      MockSessionManager.mockImplementation(function () {
+        return mockSessionMgr;
+      });
+
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.stop();
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Preserving 3 active Slack session(s)")
+      );
+    });
+
+    it("handles session count query failure gracefully", async () => {
+      const mockSessionMgr = createMockSessionManager("agent1");
+      mockSessionMgr.getActiveSessionCount.mockRejectedValue(
+        new Error("File read error")
+      );
+      MockSessionManager.mockImplementation(function () {
+        return mockSessionMgr;
+      });
+
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.stop();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to get Slack session count")
+      );
+    });
+  });
+
+  describe("isConnected", () => {
+    it("delegates to connector.isConnected()", async () => {
+      mockConnector.isConnected.mockReturnValue(true);
+
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(manager.isConnected()).toBe(true);
+    });
+  });
+
+  describe("getState", () => {
+    it("delegates to connector.getState()", async () => {
+      const state = {
+        status: "connected" as const,
+        connectedAt: "2026-01-01T00:00:00Z",
+        disconnectedAt: null,
+        reconnectAttempts: 0,
+        lastError: null,
+        botUser: { id: "U123", username: "testbot" },
+        messageStats: { received: 5, sent: 3, ignored: 1 },
+      };
+      mockConnector.getState.mockReturnValue(state);
+
+      const SlackManager = await getSlackManagerWithMock();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+
+      expect(manager.getState()).toBe(state);
+    });
+  });
+
+  describe("message handling (via connector events)", () => {
+    it("emits slack:error event when connector error fires", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      // Simulate error from connector
+      mockConnector.emit("error", {
+        agentName: "agent1",
+        error: new Error("Socket closed"),
+      });
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Slack connector error for agent 'agent1'")
+      );
+      expect(emitter.emit).toHaveBeenCalledWith(
+        "slack:error",
+        expect.objectContaining({
+          agentName: "agent1",
+          error: "Socket closed",
+        })
+      );
+    });
+
+    it("handles message for unknown agent", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+
+      // Simulate message for an agent not in config
+      mockConnector.emit("message", {
+        agentName: "unknown-agent",
+        prompt: "Hello there",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      // Give time for the async handler to run
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Agent 'unknown-agent' not found in configuration"
+      );
+      expect(replyFn).toHaveBeenCalledWith(
+        expect.stringContaining("not properly configured")
+      );
+    });
+
+    it("handles message with successful trigger", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      // Add a trigger method to the emitter (FleetManager exposes this)
+      const triggerMock = vi.fn().mockResolvedValue({
+        jobId: "job-123",
+        success: true,
+        sessionId: "session-abc",
+      });
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+      const stopIndicator = vi.fn();
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Help me with coding",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => stopIndicator,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(triggerMock).toHaveBeenCalledWith(
+        "agent1",
+        undefined,
+        expect.objectContaining({
+          prompt: "Help me with coding",
+        })
+      );
+      expect(stopIndicator).toHaveBeenCalled();
+      expect(emitter.emit).toHaveBeenCalledWith(
+        "slack:message:handled",
+        expect.objectContaining({
+          agentName: "agent1",
+          jobId: "job-123",
+        })
+      );
+    });
+
+    it("sends fallback when no messages streamed and job succeeds", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      const triggerMock = vi.fn().mockResolvedValue({
+        jobId: "job-123",
+        success: true,
+        sessionId: null,
+      });
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Do something",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should send fallback message
+      expect(replyFn).toHaveBeenCalledWith(
+        expect.stringContaining("completed the task")
+      );
+    });
+
+    it("sends error fallback when job fails and no messages streamed", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      const triggerMock = vi.fn().mockResolvedValue({
+        jobId: "job-123",
+        success: false,
+        error: new Error("API rate limit"),
+        errorDetails: { message: "API rate limit exceeded" },
+      });
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Do something",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(replyFn).toHaveBeenCalledWith(
+        expect.stringContaining("API rate limit exceeded")
+      );
+    });
+
+    it("handles trigger throw and sends error message", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      const triggerMock = vi.fn().mockRejectedValue(new Error("Trigger failed"));
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Do something",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Slack message handling failed")
+      );
+      expect(replyFn).toHaveBeenCalledWith(
+        expect.stringContaining("Trigger failed")
+      );
+      expect(emitter.emit).toHaveBeenCalledWith(
+        "slack:message:error",
+        expect.objectContaining({
+          agentName: "agent1",
+          error: "Trigger failed",
+        })
+      );
+    });
+
+    it("resumes existing session when one exists", async () => {
+      const mockSessionMgr = createMockSessionManager("agent1");
+      mockSessionMgr.getSession.mockResolvedValue({
+        sessionId: "existing-session-456",
+        lastMessageAt: "2026-02-15T10:00:00Z",
+        channelId: "C0123456789",
+      });
+      MockSessionManager.mockImplementation(function () {
+        return mockSessionMgr;
+      });
+
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      const triggerMock = vi.fn().mockResolvedValue({
+        jobId: "job-123",
+        success: true,
+        sessionId: "new-session-789",
+      });
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Continue our conversation",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: false,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should pass the existing session for resume
+      expect(triggerMock).toHaveBeenCalledWith(
+        "agent1",
+        undefined,
+        expect.objectContaining({
+          resume: "existing-session-456",
+        })
+      );
+
+      // Should store the new session
+      expect(mockSessionMgr.setSession).toHaveBeenCalledWith(
+        "1707930000.123456",
+        "new-session-789",
+        "C0123456789"
+      );
+    });
+
+    it("streams assistant messages via onMessage callback", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      let capturedOnMessage: ((msg: unknown) => Promise<void>) | null = null;
+      const triggerMock = vi.fn().mockImplementation(
+        async (_name: string, _schedule: unknown, opts: { onMessage?: (msg: unknown) => Promise<void> }) => {
+          capturedOnMessage = opts?.onMessage ?? null;
+          // Simulate streaming messages
+          if (capturedOnMessage) {
+            await capturedOnMessage({ type: "assistant", content: "Hello from agent!" });
+          }
+          return { jobId: "job-123", success: true, sessionId: "s1" };
+        }
+      );
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Say hello",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Should have sent the streamed message
+      expect(replyFn).toHaveBeenCalledWith("Hello from agent!");
+    });
+
+    it("handles non-Error string in error handler", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      // Simulate non-Error (string) error from connector
+      mockConnector.emit("error", {
+        agentName: "agent1",
+        error: "string error",
+      });
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Slack connector error for agent 'agent1': string error")
+      );
+    });
+
+    it("handles reply failure during error handling gracefully", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      const triggerMock = vi.fn().mockRejectedValue(new Error("Boom"));
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockRejectedValue(new Error("Reply failed too"));
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Do something",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should log both the original error and the reply failure
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Slack message handling failed")
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to send error reply")
+      );
+    });
+
+    it("handles error from reply during agent-not-found", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockRejectedValue(new Error("Reply error"));
+
+      mockConnector.emit("message", {
+        agentName: "nonexistent",
+        prompt: "Hello",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Agent 'nonexistent' not found")
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to send error reply")
+      );
+    });
+
+    it("extracts text from message.message.content array", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      let capturedOnMessage: ((msg: unknown) => Promise<void>) | null = null;
+      const triggerMock = vi.fn().mockImplementation(
+        async (_name: string, _schedule: unknown, opts: { onMessage?: (msg: unknown) => Promise<void> }) => {
+          capturedOnMessage = opts?.onMessage ?? null;
+          if (capturedOnMessage) {
+            // Simulate content array format
+            await capturedOnMessage({
+              type: "assistant",
+              message: {
+                content: [
+                  { type: "text", text: "Part 1 " },
+                  { type: "text", text: "Part 2" },
+                ],
+              },
+            });
+          }
+          return { jobId: "job-123", success: true, sessionId: null };
+        }
+      );
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Test",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(replyFn).toHaveBeenCalledWith("Part 1 Part 2");
+    });
+
+    it("extracts text from message.message.content string", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      let capturedOnMessage: ((msg: unknown) => Promise<void>) | null = null;
+      const triggerMock = vi.fn().mockImplementation(
+        async (_name: string, _schedule: unknown, opts: { onMessage?: (msg: unknown) => Promise<void> }) => {
+          capturedOnMessage = opts?.onMessage ?? null;
+          if (capturedOnMessage) {
+            await capturedOnMessage({
+              type: "assistant",
+              message: { content: "Direct string content" },
+            });
+          }
+          return { jobId: "job-123", success: true, sessionId: null };
+        }
+      );
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Test",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(replyFn).toHaveBeenCalledWith("Direct string content");
+    });
+
+    it("ignores non-assistant messages in onMessage callback", async () => {
+      const SlackManager = await getSlackManagerWithMock();
+      const emitter = createMockEmitter();
+      const config = createConfigWithAgents(
+        createSlackAgent("agent1", defaultSlackConfig)
+      );
+
+      let capturedOnMessage: ((msg: unknown) => Promise<void>) | null = null;
+      const triggerMock = vi.fn().mockImplementation(
+        async (_name: string, _schedule: unknown, opts: { onMessage?: (msg: unknown) => Promise<void> }) => {
+          capturedOnMessage = opts?.onMessage ?? null;
+          if (capturedOnMessage) {
+            await capturedOnMessage({ type: "system", content: "System msg" });
+            await capturedOnMessage({ type: "assistant", content: "Real response" });
+          }
+          return { jobId: "job-123", success: true, sessionId: null };
+        }
+      );
+      (emitter as unknown as Record<string, unknown>).trigger = triggerMock;
+
+      const ctx = createMockContext(config, emitter);
+      const manager = new SlackManager(ctx);
+
+      await manager.initialize();
+      await manager.start();
+
+      const replyFn = vi.fn().mockResolvedValue(undefined);
+
+      mockConnector.emit("message", {
+        agentName: "agent1",
+        prompt: "Test",
+        metadata: {
+          channelId: "C0123456789",
+          threadTs: "1707930000.123456",
+          messageTs: "1707930001.000000",
+          userId: "U0123456789",
+          wasMentioned: true,
+        },
+        reply: replyFn,
+        startProcessingIndicator: () => () => {},
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Should only send the assistant message, not the system one
+      expect(replyFn).toHaveBeenCalledWith("Real response");
+      expect(replyFn).not.toHaveBeenCalledWith("System msg");
+    });
+  });
+});

--- a/packages/core/src/fleet-manager/context.ts
+++ b/packages/core/src/fleet-manager/context.ts
@@ -91,4 +91,9 @@ export interface FleetManagerContext {
    * Get the Discord manager instance (may return undefined if not initialized)
    */
   getDiscordManager?(): unknown;
+
+  /**
+   * Get the Slack manager instance (may return undefined if not initialized)
+   */
+  getSlackManager?(): unknown;
 }

--- a/packages/core/src/fleet-manager/event-types.ts
+++ b/packages/core/src/fleet-manager/event-types.ts
@@ -235,6 +235,42 @@ export interface DiscordConnectorErrorPayload {
 }
 
 // =============================================================================
+// Slack Connector Events
+// =============================================================================
+
+/**
+ * Payload for slack:connector:connected event
+ */
+export interface SlackConnectorConnectedPayload {
+  /** Bot username */
+  botUsername: string;
+  /** Number of channel→agent mappings */
+  channelCount: number;
+  /** ISO timestamp when the connector connected */
+  timestamp: string;
+}
+
+/**
+ * Payload for slack:connector:disconnected event
+ */
+export interface SlackConnectorDisconnectedPayload {
+  /** Reason for disconnection (if available) */
+  reason?: string;
+  /** ISO timestamp when the connector disconnected */
+  timestamp: string;
+}
+
+/**
+ * Payload for slack:connector:error event
+ */
+export interface SlackConnectorErrorPayload {
+  /** Error message */
+  error: string;
+  /** ISO timestamp when the error occurred */
+  timestamp: string;
+}
+
+// =============================================================================
 // Fleet Manager Event Map
 // =============================================================================
 
@@ -380,6 +416,25 @@ export interface FleetManagerEventMap {
    * Emitted when a Discord connector encounters an error.
    */
   "discord:connector:error": [payload: DiscordConnectorErrorPayload];
+
+  // ===========================================================================
+  // Slack Events
+  // ===========================================================================
+
+  /**
+   * Emitted when the Slack connector successfully connects.
+   */
+  "slack:connector:connected": [payload: SlackConnectorConnectedPayload];
+
+  /**
+   * Emitted when the Slack connector disconnects.
+   */
+  "slack:connector:disconnected": [payload: SlackConnectorDisconnectedPayload];
+
+  /**
+   * Emitted when the Slack connector encounters an error.
+   */
+  "slack:connector:error": [payload: SlackConnectorErrorPayload];
 
   // ===========================================================================
   // Error Events

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -59,6 +59,7 @@ import { JobControl } from "./job-control.js";
 import { LogStreaming } from "./log-streaming.js";
 import { ScheduleExecutor } from "./schedule-executor.js";
 import { DiscordManager } from "./discord-manager.js";
+import { SlackManager } from "./slack-manager.js";
 
 const DEFAULT_CHECK_INTERVAL = 1000;
 
@@ -104,6 +105,7 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   private logStreaming!: LogStreaming;
   private scheduleExecutor!: ScheduleExecutor;
   private discordManager!: DiscordManager;
+  private slackManager!: SlackManager;
 
   constructor(options: FleetManagerOptions) {
     super();
@@ -133,6 +135,7 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   getCheckInterval(): number { return this.checkInterval; }
   getEmitter(): EventEmitter { return this; }
   getDiscordManager(): DiscordManager { return this.discordManager; }
+  getSlackManager(): SlackManager { return this.slackManager; }
 
   // ===========================================================================
   // Public State Accessors
@@ -182,6 +185,9 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
       // Initialize Discord connectors for agents with Discord configuration
       await this.discordManager.initialize();
 
+      // Initialize Slack connector for agents with Slack configuration
+      await this.slackManager.initialize();
+
       this.status = "initialized";
       this.initializedAt = new Date().toISOString();
       this.lastError = null;
@@ -209,6 +215,9 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
 
       // Start Discord connectors
       await this.discordManager.start();
+
+      // Start Slack connector
+      await this.slackManager.start();
 
       this.status = "running";
       this.startedAt = new Date().toISOString();
@@ -238,6 +247,9 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
     try {
       // Stop Discord connectors first (graceful disconnect)
       await this.discordManager.stop();
+
+      // Stop Slack connector
+      await this.slackManager.stop();
 
       if (this.scheduler) {
         try {
@@ -313,6 +325,7 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
     this.logStreaming = new LogStreaming(this);
     this.scheduleExecutor = new ScheduleExecutor(this);
     this.discordManager = new DiscordManager(this);
+    this.slackManager = new SlackManager(this);
   }
 
   private async loadConfiguration(): Promise<ResolvedConfig> {

--- a/packages/core/src/fleet-manager/slack-manager.ts
+++ b/packages/core/src/fleet-manager/slack-manager.ts
@@ -1,0 +1,778 @@
+/**
+ * Slack Manager Module
+ *
+ * Manages a single Slack connector shared across agents that have `chat.slack` configured.
+ * This module is responsible for:
+ * - Creating ONE SlackConnector instance for the workspace
+ * - Building channel→agent routing from agent configs
+ * - Managing connector lifecycle (start/stop)
+ *
+ * Key difference from Discord:
+ * - DiscordManager has Map<string, IDiscordConnector> (N connectors, one per agent)
+ * - SlackManager has one connector + Map<string, string> (channel→agent routing)
+ *
+ * Note: This module dynamically imports @herdctl/slack at runtime to avoid
+ * a hard dependency. The @herdctl/core package can be used without Slack support.
+ *
+ * @module slack-manager
+ */
+
+import type { FleetManagerContext } from "./context.js";
+import type { ResolvedAgent } from "../config/index.js";
+
+// =============================================================================
+// Local Type Definitions
+// =============================================================================
+
+/**
+ * Slack connection status (mirrors @herdctl/slack types)
+ */
+export type SlackConnectionStatus =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnecting"
+  | "error";
+
+/**
+ * Slack connector state (mirrors @herdctl/slack types)
+ */
+export interface SlackConnectorState {
+  status: SlackConnectionStatus;
+  connectedAt: string | null;
+  disconnectedAt: string | null;
+  reconnectAttempts: number;
+  lastError: string | null;
+  botUser: {
+    id: string;
+    username: string;
+  } | null;
+  messageStats: {
+    received: number;
+    sent: number;
+    ignored: number;
+  };
+}
+
+/**
+ * Message event payload from SlackConnector
+ */
+export interface SlackMessageEvent {
+  agentName: string;
+  prompt: string;
+  metadata: {
+    channelId: string;
+    threadTs: string;
+    messageTs: string;
+    userId: string;
+    wasMentioned: boolean;
+  };
+  reply: (content: string) => Promise<void>;
+  startProcessingIndicator: () => () => void;
+}
+
+/**
+ * Error event payload from SlackConnector
+ */
+export interface SlackErrorEvent {
+  agentName: string;
+  error: Error;
+}
+
+/**
+ * Logger interface for Slack operations
+ */
+interface SlackLogger {
+  debug(message: string, data?: Record<string, unknown>): void;
+  info(message: string, data?: Record<string, unknown>): void;
+  warn(message: string, data?: Record<string, unknown>): void;
+  error(message: string, data?: Record<string, unknown>): void;
+}
+
+/**
+ * Minimal interface for a Slack connector
+ */
+interface ISlackConnector {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  isConnected(): boolean;
+  getState(): SlackConnectorState;
+  on(event: "message", listener: (payload: SlackMessageEvent) => void): this;
+  on(event: "error", listener: (payload: SlackErrorEvent) => void): this;
+  on(event: string, listener: (...args: unknown[]) => void): this;
+  off(event: string, listener: (...args: unknown[]) => void): this;
+}
+
+/**
+ * Session manager interface for Slack (minimal for our needs)
+ */
+interface ISlackSessionManager {
+  readonly agentName: string;
+  getOrCreateSession(threadTs: string, channelId: string): Promise<{ sessionId: string; isNew: boolean }>;
+  getSession(threadTs: string): Promise<{ sessionId: string; lastMessageAt: string; channelId: string } | null>;
+  setSession(threadTs: string, sessionId: string, channelId: string): Promise<void>;
+  touchSession(threadTs: string): Promise<void>;
+  clearSession(threadTs: string): Promise<boolean>;
+  cleanupExpiredSessions(): Promise<number>;
+  getActiveSessionCount(): Promise<number>;
+}
+
+/**
+ * Dynamically imported Slack module structure
+ */
+interface SlackModule {
+  SlackConnector: new (options: {
+    botToken: string;
+    appToken: string;
+    channelAgentMap: Map<string, string>;
+    sessionManagers: Map<string, ISlackSessionManager>;
+    logger?: SlackLogger;
+    stateDir?: string;
+  }) => ISlackConnector;
+  SessionManager: new (options: {
+    agentName: string;
+    stateDir: string;
+    sessionExpiryHours?: number;
+    logger?: SlackLogger;
+  }) => ISlackSessionManager;
+}
+
+/**
+ * Lazy import the Slack package to avoid hard dependency
+ */
+async function importSlackPackage(): Promise<SlackModule | null> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pkg = (await import("@herdctl/slack" as string)) as unknown as SlackModule;
+    return pkg;
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// Streaming Responder (adapted for Slack mrkdwn)
+// =============================================================================
+
+interface StreamingResponderOptions {
+  reply: (content: string) => Promise<void>;
+  splitResponse: (text: string) => string[];
+  logger: SlackLogger;
+  agentName: string;
+  minMessageInterval?: number;
+  maxBufferSize?: number;
+}
+
+class StreamingResponder {
+  private buffer: string = "";
+  private lastSendTime: number = 0;
+  private messagesSent: number = 0;
+  private readonly reply: (content: string) => Promise<void>;
+  private readonly splitResponse: (text: string) => string[];
+  private readonly logger: SlackLogger;
+  private readonly agentName: string;
+  private readonly minMessageInterval: number;
+  private readonly maxBufferSize: number;
+
+  constructor(options: StreamingResponderOptions) {
+    this.reply = options.reply;
+    this.splitResponse = options.splitResponse;
+    this.logger = options.logger;
+    this.agentName = options.agentName;
+    this.minMessageInterval = options.minMessageInterval ?? 1000;
+    this.maxBufferSize = options.maxBufferSize ?? 3500; // Leave room for Slack's ~4K practical limit
+  }
+
+  async addMessageAndSend(content: string): Promise<void> {
+    if (!content || content.trim().length === 0) {
+      return;
+    }
+
+    this.buffer += content;
+    await this.sendAll();
+  }
+
+  private async sendAll(): Promise<void> {
+    if (this.buffer.trim().length === 0) {
+      return;
+    }
+
+    const content = this.buffer.trim();
+    this.buffer = "";
+
+    const now = Date.now();
+    const timeSinceLastSend = now - this.lastSendTime;
+    if (timeSinceLastSend < this.minMessageInterval && this.lastSendTime > 0) {
+      const waitTime = this.minMessageInterval - timeSinceLastSend;
+      await this.sleep(waitTime);
+    }
+
+    const chunks = this.splitResponse(content);
+
+    for (const chunk of chunks) {
+      try {
+        await this.reply(chunk);
+        this.messagesSent++;
+        this.lastSendTime = Date.now();
+        this.logger.debug(`Streamed message to Slack`, {
+          agentName: this.agentName,
+          chunkLength: chunk.length,
+          totalSent: this.messagesSent,
+        });
+
+        if (chunks.length > 1) {
+          await this.sleep(500);
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        this.logger.error(`Failed to send Slack message`, {
+          agentName: this.agentName,
+          error: errorMessage,
+        });
+        throw error;
+      }
+    }
+  }
+
+  async flush(): Promise<void> {
+    await this.sendAll();
+  }
+
+  hasSentMessages(): boolean {
+    return this.messagesSent > 0;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+// =============================================================================
+// Slack Manager
+// =============================================================================
+
+/**
+ * SlackManager handles Slack connections for agents
+ *
+ * Unlike DiscordManager which creates N connectors (one per agent),
+ * SlackManager creates ONE connector shared across all Slack-enabled agents,
+ * with channel→agent routing.
+ */
+export class SlackManager {
+  private connector: ISlackConnector | null = null;
+  private sessionManagers: Map<string, ISlackSessionManager> = new Map();
+  private channelAgentMap: Map<string, string> = new Map();
+  private initialized: boolean = false;
+
+  constructor(private ctx: FleetManagerContext) {}
+
+  /**
+   * Initialize the Slack connector for all configured agents
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    const logger = this.ctx.getLogger();
+    const config = this.ctx.getConfig();
+
+    if (!config) {
+      logger.debug("No config available, skipping Slack initialization");
+      return;
+    }
+
+    // Try to import the slack package
+    const slackPkg = await importSlackPackage();
+    if (!slackPkg) {
+      logger.debug("@herdctl/slack not installed, skipping Slack connector");
+      return;
+    }
+
+    const { SlackConnector, SessionManager } = slackPkg;
+    const stateDir = this.ctx.getStateDir();
+
+    // Find agents with Slack configured
+    const slackAgents = config.agents.filter(
+      (agent): agent is ResolvedAgent & { chat: { slack: NonNullable<ResolvedAgent["chat"]>["slack"] } } =>
+        agent.chat?.slack !== undefined
+    );
+
+    if (slackAgents.length === 0) {
+      logger.debug("No agents with Slack configured");
+      this.initialized = true;
+      return;
+    }
+
+    logger.info(`Initializing Slack connector for ${slackAgents.length} agent(s)`);
+
+    // All agents share the same bot + app token.
+    // Take the first agent's config for token resolution.
+    const firstSlackConfig = slackAgents[0].chat.slack;
+    if (!firstSlackConfig) {
+      this.initialized = true;
+      return;
+    }
+
+    const botToken = process.env[firstSlackConfig.bot_token_env];
+    if (!botToken) {
+      logger.warn(
+        `Slack bot token not found in environment variable '${firstSlackConfig.bot_token_env}'`
+      );
+      this.initialized = true;
+      return;
+    }
+
+    const appToken = process.env[firstSlackConfig.app_token_env];
+    if (!appToken) {
+      logger.warn(
+        `Slack app token not found in environment variable '${firstSlackConfig.app_token_env}'`
+      );
+      this.initialized = true;
+      return;
+    }
+
+    // Build channel→agent routing map and create session managers
+    for (const agent of slackAgents) {
+      const slackConfig = agent.chat.slack;
+      if (!slackConfig) continue;
+
+      // Create logger adapter for this agent
+      const createAgentLogger = (prefix: string): SlackLogger => ({
+        debug: (msg: string, data?: Record<string, unknown>) =>
+          logger.debug(`${prefix} ${msg}${data ? ` ${JSON.stringify(data)}` : ""}`),
+        info: (msg: string, data?: Record<string, unknown>) =>
+          logger.info(`${prefix} ${msg}${data ? ` ${JSON.stringify(data)}` : ""}`),
+        warn: (msg: string, data?: Record<string, unknown>) =>
+          logger.warn(`${prefix} ${msg}${data ? ` ${JSON.stringify(data)}` : ""}`),
+        error: (msg: string, data?: Record<string, unknown>) =>
+          logger.error(`${prefix} ${msg}${data ? ` ${JSON.stringify(data)}` : ""}`),
+      });
+
+      // Create session manager for this agent
+      const sessionManager = new SessionManager({
+        agentName: agent.name,
+        stateDir,
+        sessionExpiryHours: slackConfig.session_expiry_hours,
+        logger: createAgentLogger(`[slack:${agent.name}:session]`),
+      });
+
+      this.sessionManagers.set(agent.name, sessionManager);
+
+      // Map channels to this agent
+      for (const channel of slackConfig.channels) {
+        if (this.channelAgentMap.has(channel.id)) {
+          logger.warn(
+            `Channel ${channel.id} is already mapped to agent '${this.channelAgentMap.get(channel.id)}', ` +
+              `overriding with agent '${agent.name}'`
+          );
+        }
+        this.channelAgentMap.set(channel.id, agent.name);
+      }
+
+      logger.debug(`Configured Slack routing for agent '${agent.name}' with ${slackConfig.channels.length} channel(s)`);
+    }
+
+    // Create the single connector
+    try {
+      this.connector = new SlackConnector({
+        botToken,
+        appToken,
+        channelAgentMap: this.channelAgentMap,
+        sessionManagers: this.sessionManagers,
+        stateDir,
+        logger: {
+          debug: (msg: string, data?: Record<string, unknown>) =>
+            logger.debug(`[slack] ${msg}${data ? ` ${JSON.stringify(data)}` : ""}`),
+          info: (msg: string, data?: Record<string, unknown>) =>
+            logger.info(`[slack] ${msg}${data ? ` ${JSON.stringify(data)}` : ""}`),
+          warn: (msg: string, data?: Record<string, unknown>) =>
+            logger.warn(`[slack] ${msg}${data ? ` ${JSON.stringify(data)}` : ""}`),
+          error: (msg: string, data?: Record<string, unknown>) =>
+            logger.error(`[slack] ${msg}${data ? ` ${JSON.stringify(data)}` : ""}`),
+        },
+      });
+
+      logger.debug(`Created Slack connector with ${this.channelAgentMap.size} channel mapping(s)`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to create Slack connector: ${errorMessage}`);
+    }
+
+    this.initialized = true;
+    logger.info(
+      `Slack manager initialized with ${this.sessionManagers.size} agent(s), ` +
+        `${this.channelAgentMap.size} channel mapping(s)`
+    );
+  }
+
+  /**
+   * Connect the Slack connector and subscribe to events
+   */
+  async start(): Promise<void> {
+    const logger = this.ctx.getLogger();
+
+    if (!this.connector) {
+      logger.debug("No Slack connector to start");
+      return;
+    }
+
+    logger.info("Starting Slack connector...");
+
+    // Subscribe to events before connecting
+    this.connector.on("message", (event: SlackMessageEvent) => {
+      this.handleMessage(event.agentName, event).catch((error: unknown) => {
+        this.handleError(event.agentName, error);
+      });
+    });
+
+    this.connector.on("error", (event: SlackErrorEvent) => {
+      this.handleError(event.agentName, event.error);
+    });
+
+    try {
+      await this.connector.connect();
+      logger.info("Slack connector started");
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to connect Slack: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Disconnect the Slack connector gracefully
+   */
+  async stop(): Promise<void> {
+    const logger = this.ctx.getLogger();
+
+    if (!this.connector) {
+      logger.debug("No Slack connector to stop");
+      return;
+    }
+
+    logger.info("Stopping Slack connector...");
+
+    // Log session state before shutdown
+    for (const [agentName, sessionManager] of this.sessionManagers) {
+      try {
+        const activeSessionCount = await sessionManager.getActiveSessionCount();
+        if (activeSessionCount > 0) {
+          logger.info(`Preserving ${activeSessionCount} active Slack session(s) for agent '${agentName}'`);
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.warn(`Failed to get Slack session count for agent '${agentName}': ${errorMessage}`);
+      }
+    }
+
+    try {
+      await this.connector.disconnect();
+      logger.info("Slack connector stopped");
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(`Error disconnecting Slack: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Get the connector (if any)
+   */
+  getConnector(): ISlackConnector | null {
+    return this.connector;
+  }
+
+  /**
+   * Check if the connector is connected
+   */
+  isConnected(): boolean {
+    return this.connector?.isConnected() ?? false;
+  }
+
+  /**
+   * Get the state of the connector
+   */
+  getState(): SlackConnectorState | null {
+    return this.connector?.getState() ?? null;
+  }
+
+  /**
+   * Get the channel→agent routing map
+   */
+  getChannelAgentMap(): Map<string, string> {
+    return this.channelAgentMap;
+  }
+
+  /**
+   * Check if a specific agent has Slack configured
+   */
+  hasAgent(agentName: string): boolean {
+    return this.sessionManagers.has(agentName);
+  }
+
+  // ===========================================================================
+  // Message Handling Pipeline
+  // ===========================================================================
+
+  private async handleMessage(
+    agentName: string,
+    event: SlackMessageEvent
+  ): Promise<void> {
+    const logger = this.ctx.getLogger();
+    const emitter = this.ctx.getEmitter();
+
+    logger.info(`Slack message for agent '${agentName}': ${event.prompt.substring(0, 50)}...`);
+
+    // Get the agent configuration
+    const config = this.ctx.getConfig();
+    const agent = config?.agents.find((a) => a.name === agentName);
+
+    if (!agent) {
+      logger.error(`Agent '${agentName}' not found in configuration`);
+      try {
+        await event.reply("Sorry, I'm not properly configured. Please contact an administrator.");
+      } catch (replyError) {
+        logger.error(`Failed to send error reply: ${(replyError as Error).message}`);
+      }
+      return;
+    }
+
+    // Get existing session for this thread
+    const sessionManager = this.sessionManagers.get(agentName);
+    let existingSessionId: string | undefined;
+    if (sessionManager) {
+      try {
+        const existingSession = await sessionManager.getSession(event.metadata.threadTs);
+        if (existingSession) {
+          existingSessionId = existingSession.sessionId;
+          logger.debug(`Resuming session for thread ${event.metadata.threadTs}: ${existingSessionId}`);
+        } else {
+          logger.debug(`No existing session for thread ${event.metadata.threadTs}, starting new conversation`);
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.warn(`Failed to get session: ${errorMessage}`);
+      }
+    }
+
+    // Create streaming responder
+    const streamer = new StreamingResponder({
+      reply: event.reply,
+      splitResponse: (text) => this.splitResponse(text),
+      logger,
+      agentName,
+    });
+
+    // Start processing indicator (hourglass emoji)
+    const stopProcessing = event.startProcessingIndicator();
+    let processingStopped = false;
+
+    try {
+      const fleetManager = emitter as unknown as {
+        trigger: (
+          agentName: string,
+          scheduleName?: string,
+          options?: {
+            prompt?: string;
+            resume?: string;
+            onMessage?: (message: { type: string; content?: string; message?: { content?: unknown } }) => void | Promise<void>;
+          }
+        ) => Promise<import("./types.js").TriggerResult>;
+      };
+
+      const result = await fleetManager.trigger(agentName, undefined, {
+        prompt: event.prompt,
+        resume: existingSessionId,
+        onMessage: async (message) => {
+          if (message.type === "assistant") {
+            const content = this.extractMessageContent(message);
+            if (content) {
+              await streamer.addMessageAndSend(content);
+            }
+          }
+        },
+      });
+
+      // Stop processing indicator
+      if (!processingStopped) {
+        stopProcessing();
+        processingStopped = true;
+      }
+
+      // Flush remaining content
+      await streamer.flush();
+
+      logger.info(`Slack job completed: ${result.jobId} for agent '${agentName}'${result.sessionId ? ` (session: ${result.sessionId})` : ""}`);
+
+      // Fallback message if nothing was sent
+      if (!streamer.hasSentMessages()) {
+        if (result.success) {
+          await event.reply("I've completed the task, but I don't have a specific response to share.");
+        } else {
+          const errorMessage = result.errorDetails?.message ?? result.error?.message ?? "An unknown error occurred";
+          await event.reply(`*Error:* ${errorMessage}\n\nThe task could not be completed. Please check the logs for more details.`);
+        }
+
+        if (!processingStopped) {
+          stopProcessing();
+          processingStopped = true;
+        }
+      }
+
+      // Store the SDK session ID for future conversation continuity
+      if (sessionManager && result.sessionId && result.success) {
+        try {
+          await sessionManager.setSession(
+            event.metadata.threadTs,
+            result.sessionId,
+            event.metadata.channelId
+          );
+          logger.debug(`Stored session ${result.sessionId} for thread ${event.metadata.threadTs}`);
+        } catch (sessionError) {
+          const errorMessage = sessionError instanceof Error ? sessionError.message : String(sessionError);
+          logger.warn(`Failed to store session: ${errorMessage}`);
+        }
+      }
+
+      // Emit event for tracking
+      emitter.emit("slack:message:handled", {
+        agentName,
+        channelId: event.metadata.channelId,
+        threadTs: event.metadata.threadTs,
+        messageTs: event.metadata.messageTs,
+        jobId: result.jobId,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error(`Slack message handling failed for agent '${agentName}': ${err.message}`);
+
+      try {
+        await event.reply(this.formatErrorMessage(err));
+      } catch (replyError) {
+        logger.error(`Failed to send error reply: ${(replyError as Error).message}`);
+      }
+
+      emitter.emit("slack:message:error", {
+        agentName,
+        channelId: event.metadata.channelId,
+        threadTs: event.metadata.threadTs,
+        messageTs: event.metadata.messageTs,
+        error: err.message,
+        timestamp: new Date().toISOString(),
+      });
+    } finally {
+      if (!processingStopped) {
+        stopProcessing();
+      }
+    }
+  }
+
+  /**
+   * Extract text content from an SDK message
+   */
+  private extractMessageContent(message: {
+    type: string;
+    content?: string;
+    message?: { content?: unknown };
+  }): string | undefined {
+    if (typeof message.content === "string" && message.content) {
+      return message.content;
+    }
+
+    const apiMessage = message.message as { content?: unknown } | undefined;
+    const content = apiMessage?.content;
+
+    if (!content) return undefined;
+
+    if (typeof content === "string") {
+      return content;
+    }
+
+    if (Array.isArray(content)) {
+      const textParts: string[] = [];
+      for (const block of content) {
+        if (block && typeof block === "object" && "type" in block) {
+          if (block.type === "text" && "text" in block && typeof block.text === "string") {
+            textParts.push(block.text);
+          }
+        }
+      }
+      return textParts.length > 0 ? textParts.join("") : undefined;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Handle errors from the Slack connector
+   */
+  private handleError(agentName: string, error: unknown): void {
+    const logger = this.ctx.getLogger();
+    const emitter = this.ctx.getEmitter();
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(`Slack connector error for agent '${agentName}': ${errorMessage}`);
+
+    emitter.emit("slack:error", {
+      agentName,
+      error: errorMessage,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  // ===========================================================================
+  // Response Formatting and Splitting
+  // ===========================================================================
+
+  private static readonly MAX_MESSAGE_LENGTH = 4000;
+
+  formatErrorMessage(error: Error): string {
+    return `*Error:* ${error.message}\n\nPlease try again or use \`!reset\` to start a new session.`;
+  }
+
+  splitResponse(text: string): string[] {
+    const MAX_LENGTH = SlackManager.MAX_MESSAGE_LENGTH;
+
+    if (text.length <= MAX_LENGTH) {
+      return [text];
+    }
+
+    const chunks: string[] = [];
+    let remaining = text;
+
+    while (remaining.length > 0) {
+      if (remaining.length <= MAX_LENGTH) {
+        chunks.push(remaining);
+        break;
+      }
+
+      const splitIndex = this.findNaturalBreak(remaining, MAX_LENGTH);
+      chunks.push(remaining.substring(0, splitIndex));
+      remaining = remaining.substring(splitIndex);
+    }
+
+    return chunks;
+  }
+
+  private findNaturalBreak(text: string, maxLength: number): number {
+    const searchEnd = Math.min(maxLength, text.length);
+
+    const doubleNewline = text.lastIndexOf("\n\n", searchEnd);
+    if (doubleNewline > 0 && doubleNewline > searchEnd - 500) {
+      return doubleNewline + 2;
+    }
+
+    const singleNewline = text.lastIndexOf("\n", searchEnd);
+    if (singleNewline > 0 && singleNewline > searchEnd - 200) {
+      return singleNewline + 1;
+    }
+
+    const space = text.lastIndexOf(" ", searchEnd);
+    if (space > 0 && space > searchEnd - 100) {
+      return space + 1;
+    }
+
+    return searchEnd;
+  }
+}

--- a/packages/core/src/fleet-manager/types.ts
+++ b/packages/core/src/fleet-manager/types.ts
@@ -33,6 +33,10 @@ export type {
   DiscordConnectorConnectedPayload,
   DiscordConnectorDisconnectedPayload,
   DiscordConnectorErrorPayload,
+  // Slack connector events
+  SlackConnectorConnectedPayload,
+  SlackConnectorDisconnectedPayload,
+  SlackConnectorErrorPayload,
 } from "./event-types.js";
 
 // =============================================================================
@@ -242,6 +246,31 @@ export interface AgentDiscordStatus {
   lastError?: string;
 }
 
+/**
+ * Slack connector status within AgentInfo
+ */
+export interface AgentSlackStatus {
+  /**
+   * Whether this agent has Slack configured
+   */
+  configured: boolean;
+
+  /**
+   * Connection status (only present if configured)
+   */
+  connectionStatus?: "disconnected" | "connecting" | "connected" | "reconnecting" | "disconnecting" | "error";
+
+  /**
+   * Bot username (only present if connected)
+   */
+  botUsername?: string;
+
+  /**
+   * Last error message (only present if status is 'error')
+   */
+  lastError?: string;
+}
+
 export interface AgentInfo {
   /**
    * Agent name (unique identifier)
@@ -307,6 +336,11 @@ export interface AgentInfo {
    * Discord connector status (if Discord is configured for this agent)
    */
   discord?: AgentDiscordStatus;
+
+  /**
+   * Slack connector status (if Slack is configured for this agent)
+   */
+  slack?: AgentSlackStatus;
 }
 
 /**

--- a/packages/core/src/hooks/__tests__/slack-runner.test.ts
+++ b/packages/core/src/hooks/__tests__/slack-runner.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Tests for SlackHookRunner
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SlackHookRunner } from "../runners/slack.js";
+import type { HookContext, SlackHookConfigInput } from "../types.js";
+
+type SlackHookConfig = SlackHookConfigInput;
+
+describe("SlackHookRunner", () => {
+  const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const sampleContext: HookContext = {
+    event: "completed",
+    job: {
+      id: "job-2024-01-15-abc123",
+      agentId: "test-agent",
+      scheduleName: "daily-run",
+      startedAt: "2024-01-15T10:00:00.000Z",
+      completedAt: "2024-01-15T10:05:00.000Z",
+      durationMs: 300000,
+    },
+    result: {
+      success: true,
+      output: "Job completed successfully",
+    },
+    agent: {
+      id: "test-agent",
+      name: "Test Agent",
+    },
+  };
+
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.SLACK_BOT_TOKEN = "xoxb-test-token-12345";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("execute", () => {
+    it("should POST to Slack API successfully", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: () => Promise.resolve('{"ok": true, "ts": "1234567890.123456"}'),
+      });
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      const result = await runner.execute(config, sampleContext);
+
+      expect(result.success).toBe(true);
+      expect(result.hookType).toBe("slack");
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://slack.com/api/chat.postMessage",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer xoxb-test-token-12345",
+            "Content-Type": "application/json; charset=utf-8",
+          }),
+        })
+      );
+    });
+
+    it("should include channel in the payload", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('{"ok": true}'),
+      });
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      await runner.execute(config, sampleContext);
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+      expect(body.channel).toBe("C0123456789");
+      expect(body.attachments).toHaveLength(1);
+      expect(body.attachments[0].title).toBe("Job Completed");
+      expect(body.attachments[0].footer).toBe("herdctl");
+    });
+
+    it("should fail when token env var is not set", async () => {
+      delete process.env.SLACK_BOT_TOKEN;
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      const result = await runner.execute(config, sampleContext);
+
+      expect(result.success).toBe(false);
+      expect(result.hookType).toBe("slack");
+      expect(result.error).toContain("SLACK_BOT_TOKEN");
+    });
+
+    it("should use default bot_token_env when not specified", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('{"ok": true}'),
+      });
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+      };
+
+      await runner.execute(config, sampleContext);
+
+      // Should use SLACK_BOT_TOKEN by default
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it("should handle Slack API error (ok: false)", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () =>
+          Promise.resolve('{"ok": false, "error": "channel_not_found"}'),
+      });
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C_INVALID",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      const result = await runner.execute(config, sampleContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("channel_not_found");
+    });
+
+    it("should handle HTTP errors", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: () => Promise.resolve("Server Error"),
+      });
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      const result = await runner.execute(config, sampleContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("500");
+    });
+
+    it("should handle network errors", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockRejectedValue(new Error("fetch failed"));
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      const result = await runner.execute(config, sampleContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("fetch failed");
+    });
+
+    it("should handle timeout errors", async () => {
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+
+      const mockFetch = vi.fn().mockRejectedValue(abortError);
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      const result = await runner.execute(config, sampleContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("timed out");
+    });
+
+    it("should include error in attachment for failed events", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('{"ok": true}'),
+      });
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const failedContext: HookContext = {
+        ...sampleContext,
+        event: "failed",
+        result: {
+          success: false,
+          output: "",
+          error: "Process exited with code 1",
+        },
+      };
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      await runner.execute(config, failedContext);
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+      const attachment = body.attachments[0];
+
+      expect(attachment.title).toBe("Job Failed");
+      expect(attachment.color).toBe("#ef4444");
+
+      const errorField = attachment.fields.find(
+        (f: { title: string }) => f.title === "Error"
+      );
+      expect(errorField).toBeDefined();
+      expect(errorField.value).toContain("Process exited with code 1");
+    });
+
+    it("should include metadata in attachment when present", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('{"ok": true}'),
+      });
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const contextWithMetadata: HookContext = {
+        ...sampleContext,
+        metadata: { shouldNotify: true, count: 42 },
+      };
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      await runner.execute(config, contextWithMetadata);
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+      const attachment = body.attachments[0];
+
+      const metaField = attachment.fields.find(
+        (f: { title: string }) => f.title === "Metadata"
+      );
+      expect(metaField).toBeDefined();
+      expect(metaField.value).toContain("shouldNotify");
+    });
+
+    it("should handle invalid JSON response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve("not valid json"),
+      });
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      const result = await runner.execute(config, sampleContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("parse");
+    });
+
+    it("should handle different event types", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('{"ok": true}'),
+      });
+
+      const runner = new SlackHookRunner({
+        logger: mockLogger,
+        fetch: mockFetch,
+      });
+
+      const config: SlackHookConfig = {
+        type: "slack",
+        channel_id: "C0123456789",
+        bot_token_env: "SLACK_BOT_TOKEN",
+      };
+
+      for (const event of ["completed", "failed", "timeout", "cancelled"] as const) {
+        const ctx = { ...sampleContext, event };
+        await runner.execute(config, ctx);
+      }
+
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("constructor", () => {
+    it("creates runner with default logger", () => {
+      const runner = new SlackHookRunner();
+      expect(runner).toBeDefined();
+    });
+
+    it("creates runner with custom logger", () => {
+      const runner = new SlackHookRunner({ logger: mockLogger });
+      expect(runner).toBeDefined();
+    });
+  });
+});

--- a/packages/core/src/hooks/hook-executor.ts
+++ b/packages/core/src/hooks/hook-executor.ts
@@ -14,12 +14,14 @@ import type {
   ShellHookConfigInput,
   WebhookHookConfigInput,
   DiscordHookConfigInput,
+  SlackHookConfigInput,
   HookConfigInput,
 } from "./types.js";
 import type { AgentHooksInput } from "../config/schema.js";
 import { ShellHookRunner, type ShellHookRunnerLogger } from "./runners/shell.js";
 import { WebhookHookRunner, type WebhookHookRunnerLogger } from "./runners/webhook.js";
 import { DiscordHookRunner, type DiscordHookRunnerLogger } from "./runners/discord.js";
+import { SlackHookRunner, type SlackHookRunnerLogger } from "./runners/slack.js";
 
 /**
  * Logger interface for HookExecutor
@@ -126,6 +128,7 @@ export class HookExecutor {
   private shellRunner: ShellHookRunner;
   private webhookRunner: WebhookHookRunner;
   private discordRunner: DiscordHookRunner;
+  private slackRunner: SlackHookRunner;
 
   constructor(options: HookExecutorOptions = {}) {
     this.logger = options.logger ?? {
@@ -150,6 +153,11 @@ export class HookExecutor {
     // Create discord runner with same logger
     this.discordRunner = new DiscordHookRunner({
       logger: this.logger as DiscordHookRunnerLogger,
+    });
+
+    // Create slack runner with same logger
+    this.slackRunner = new SlackHookRunner({
+      logger: this.logger as SlackHookRunnerLogger,
     });
   }
 
@@ -262,6 +270,9 @@ export class HookExecutor {
 
       case "discord":
         return this.discordRunner.execute(config as DiscordHookConfigInput, context);
+
+      case "slack":
+        return this.slackRunner.execute(config as SlackHookConfigInput, context);
 
       default:
         return {

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -21,6 +21,7 @@ export type {
   ShellHookConfigInput,
   WebhookHookConfigInput,
   DiscordHookConfigInput,
+  SlackHookConfigInput,
   HookConfigInput,
 } from "./types.js";
 
@@ -52,3 +53,10 @@ export {
   type DiscordHookRunnerOptions,
   type DiscordHookRunnerLogger,
 } from "./runners/discord.js";
+
+// Slack Hook Runner
+export {
+  SlackHookRunner,
+  type SlackHookRunnerOptions,
+  type SlackHookRunnerLogger,
+} from "./runners/slack.js";

--- a/packages/core/src/hooks/runners/slack.ts
+++ b/packages/core/src/hooks/runners/slack.ts
@@ -1,0 +1,414 @@
+/**
+ * Slack Hook Runner
+ *
+ * Posts job notifications to a Slack channel using rich message formatting.
+ * Used for team visibility into fleet activity.
+ */
+
+import type { HookContext, HookResult, SlackHookConfigInput } from "../types.js";
+
+/**
+ * Default timeout for Slack API requests in milliseconds
+ */
+const DEFAULT_TIMEOUT = 10000;
+
+/**
+ * Maximum output length for message text (Slack limit: ~40K, practical: 4000)
+ */
+const MAX_TEXT_LENGTH = 3500;
+
+/**
+ * Maximum length for attachment fields
+ */
+const MAX_FIELD_LENGTH = 900;
+
+/**
+ * Colors for different event types
+ */
+const EVENT_COLORS = {
+  completed: "#22c55e", // green
+  failed: "#ef4444", // red
+  timeout: "#f59e0b", // amber
+  cancelled: "#6b7280", // gray
+} as const;
+
+/**
+ * Logger interface for SlackHookRunner
+ */
+export interface SlackHookRunnerLogger {
+  debug: (message: string) => void;
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+}
+
+/**
+ * Options for SlackHookRunner
+ */
+export interface SlackHookRunnerOptions {
+  /**
+   * Logger for hook execution output
+   */
+  logger?: SlackHookRunnerLogger;
+
+  /**
+   * Custom fetch implementation (for testing)
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * Slack attachment field
+ */
+interface SlackField {
+  title: string;
+  value: string;
+  short?: boolean;
+}
+
+/**
+ * Slack attachment structure
+ */
+interface SlackAttachment {
+  color: string;
+  fallback: string;
+  title: string;
+  text?: string;
+  fields: SlackField[];
+  footer: string;
+  ts: number;
+}
+
+/**
+ * Slack message payload for API
+ */
+interface SlackMessagePayload {
+  channel: string;
+  attachments: SlackAttachment[];
+}
+
+/**
+ * Truncates a string to a maximum length, adding ellipsis if truncated
+ */
+function truncateOutput(output: string, maxLength: number): string {
+  if (output.length <= maxLength) {
+    return output;
+  }
+  return output.slice(0, maxLength - 3) + "...";
+}
+
+/**
+ * Formats duration in milliseconds to a human-readable string
+ */
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) {
+    return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+/**
+ * Gets the title for the event
+ */
+function getEventTitle(event: HookContext["event"]): string {
+  switch (event) {
+    case "completed":
+      return "Job Completed";
+    case "failed":
+      return "Job Failed";
+    case "timeout":
+      return "Job Timed Out";
+    case "cancelled":
+      return "Job Cancelled";
+    default:
+      return "Job Event";
+  }
+}
+
+/**
+ * Gets the fallback text for the event (plain text for notifications)
+ */
+function getEventFallback(event: HookContext["event"], agentName: string): string {
+  switch (event) {
+    case "completed":
+      return `Job completed for ${agentName}`;
+    case "failed":
+      return `Job failed for ${agentName}`;
+    case "timeout":
+      return `Job timed out for ${agentName}`;
+    case "cancelled":
+      return `Job cancelled for ${agentName}`;
+    default:
+      return `Job event for ${agentName}`;
+  }
+}
+
+/**
+ * Builds a Slack attachment from the hook context
+ */
+function buildAttachment(context: HookContext): SlackAttachment {
+  const agentName = context.agent.name || context.agent.id;
+
+  const fields: SlackField[] = [
+    {
+      title: "Agent",
+      value: agentName,
+      short: true,
+    },
+    {
+      title: "Job ID",
+      value: `\`${context.job.id}\``,
+      short: true,
+    },
+    {
+      title: "Duration",
+      value: formatDuration(context.job.durationMs),
+      short: true,
+    },
+  ];
+
+  // Add schedule name if present
+  if (context.job.scheduleName) {
+    fields.push({
+      title: "Schedule",
+      value: context.job.scheduleName,
+      short: true,
+    });
+  }
+
+  // Add error message if present
+  if (context.result.error) {
+    fields.push({
+      title: "Error",
+      value: `\`\`\`${truncateOutput(context.result.error, MAX_FIELD_LENGTH)}\`\`\``,
+      short: false,
+    });
+  }
+
+  // Add metadata JSON if present
+  if (context.metadata && Object.keys(context.metadata).length > 0) {
+    fields.push({
+      title: "Metadata",
+      value: `\`\`\`${truncateOutput(JSON.stringify(context.metadata, null, 2), MAX_FIELD_LENGTH)}\`\`\``,
+      short: false,
+    });
+  }
+
+  // Build the attachment with output in text field
+  const output = context.result.output.trim();
+  let text: string | undefined;
+  if (output && output.length > 0) {
+    text = truncateOutput(output, MAX_TEXT_LENGTH);
+  }
+
+  return {
+    color: EVENT_COLORS[context.event] ?? EVENT_COLORS.completed,
+    fallback: getEventFallback(context.event, agentName),
+    title: getEventTitle(context.event),
+    text,
+    fields,
+    footer: "herdctl",
+    ts: Math.floor(new Date(context.job.completedAt).getTime() / 1000),
+  };
+}
+
+/**
+ * SlackHookRunner posts job notifications to a Slack channel
+ *
+ * Uses the Slack Web API (chat.postMessage) with attachments for rich formatting.
+ *
+ * @example
+ * ```typescript
+ * const runner = new SlackHookRunner({ logger: console });
+ *
+ * const result = await runner.execute(
+ *   {
+ *     type: 'slack',
+ *     channel_id: 'C1234567890',
+ *     bot_token_env: 'SLACK_BOT_TOKEN'
+ *   },
+ *   hookContext
+ * );
+ * ```
+ */
+export class SlackHookRunner {
+  private logger: SlackHookRunnerLogger;
+  private fetchFn: typeof globalThis.fetch;
+
+  constructor(options: SlackHookRunnerOptions = {}) {
+    this.logger = options.logger ?? {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * Execute a Slack hook with the given context
+   *
+   * @param config - Slack hook configuration
+   * @param context - Hook context to send in the notification
+   * @returns Promise resolving to the hook result
+   */
+  async execute(config: SlackHookConfigInput, context: HookContext): Promise<HookResult> {
+    const startTime = Date.now();
+
+    this.logger.debug(`Executing Slack hook for channel: ${config.channel_id}`);
+
+    // Read bot token from environment variable
+    const tokenEnv = config.bot_token_env ?? "SLACK_BOT_TOKEN";
+    const botToken = process.env[tokenEnv];
+    if (!botToken) {
+      const durationMs = Date.now() - startTime;
+      const errorMessage = `Slack bot token not found in environment variable: ${tokenEnv}`;
+      this.logger.error(errorMessage);
+      return {
+        success: false,
+        hookType: "slack",
+        durationMs,
+        error: errorMessage,
+      };
+    }
+
+    try {
+      // Build the Slack attachment
+      const attachment = buildAttachment(context);
+      const payload: SlackMessagePayload = {
+        channel: config.channel_id,
+        attachments: [attachment],
+      };
+
+      // Slack Web API endpoint for posting messages
+      const url = "https://slack.com/api/chat.postMessage";
+
+      // Create abort controller for timeout
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
+
+      try {
+        const response = await this.fetchFn(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            Authorization: `Bearer ${botToken}`,
+          },
+          body: JSON.stringify(payload),
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        const durationMs = Date.now() - startTime;
+
+        // Read response body
+        let responseBody: string | undefined;
+        try {
+          responseBody = await response.text();
+        } catch {
+          // Ignore response body read errors
+        }
+
+        // Slack API always returns 200 with ok: true/false in body
+        if (response.ok && responseBody) {
+          try {
+            const json = JSON.parse(responseBody);
+            if (json.ok) {
+              this.logger.info(
+                `Slack hook completed successfully in ${durationMs}ms: channel ${config.channel_id}`
+              );
+              return {
+                success: true,
+                hookType: "slack",
+                durationMs,
+                output: responseBody,
+              };
+            } else {
+              // Slack API error (ok: false)
+              const errorDetail = `Slack API error: ${json.error || "unknown"}`;
+              this.logger.warn(`Slack hook failed: ${errorDetail}`);
+              return {
+                success: false,
+                hookType: "slack",
+                durationMs,
+                error: errorDetail,
+                output: responseBody,
+              };
+            }
+          } catch {
+            // JSON parse error
+            const errorDetail = `Failed to parse Slack API response`;
+            this.logger.warn(`Slack hook failed: ${errorDetail}`);
+            return {
+              success: false,
+              hookType: "slack",
+              durationMs,
+              error: errorDetail,
+              output: responseBody,
+            };
+          }
+        } else {
+          // HTTP error
+          const errorDetail = `HTTP ${response.status}: ${response.statusText}`;
+          this.logger.warn(`Slack hook failed with status ${response.status}: ${errorDetail}`);
+          return {
+            success: false,
+            hookType: "slack",
+            durationMs,
+            error: errorDetail,
+            output: responseBody,
+          };
+        }
+      } catch (fetchError) {
+        clearTimeout(timeoutId);
+
+        const durationMs = Date.now() - startTime;
+
+        // Handle abort (timeout)
+        if (fetchError instanceof Error && fetchError.name === "AbortError") {
+          this.logger.error(`Slack hook timed out after ${DEFAULT_TIMEOUT}ms`);
+          return {
+            success: false,
+            hookType: "slack",
+            durationMs,
+            error: `Slack hook timed out after ${DEFAULT_TIMEOUT}ms`,
+          };
+        }
+
+        // Handle other fetch errors (network errors, etc.)
+        const errorMessage = fetchError instanceof Error ? fetchError.message : String(fetchError);
+        this.logger.error(`Slack hook error: ${errorMessage}`);
+        return {
+          success: false,
+          hookType: "slack",
+          durationMs,
+          error: errorMessage,
+        };
+      }
+    } catch (error) {
+      const durationMs = Date.now() - startTime;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      this.logger.error(`Slack hook error: ${errorMessage}`);
+
+      return {
+        success: false,
+        hookType: "slack",
+        durationMs,
+        error: errorMessage,
+      };
+    }
+  }
+}

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -17,18 +17,20 @@ import type {
   ShellHookConfig,
   WebhookHookConfig,
   DiscordHookConfig,
+  SlackHookConfig,
   AgentHooks,
   // Input types allow optional fields (for test construction)
   ShellHookConfigInput,
   WebhookHookConfigInput,
   DiscordHookConfigInput,
+  SlackHookConfigInput,
   HookConfigInput,
 } from "../config/schema.js";
 
 // Re-export for convenience within the hooks module
 // Export both output types (for processed config) and input types (for test construction)
-export type { HookEvent, HookConfig, ShellHookConfig, WebhookHookConfig, DiscordHookConfig };
-export type { ShellHookConfigInput, WebhookHookConfigInput, DiscordHookConfigInput, HookConfigInput };
+export type { HookEvent, HookConfig, ShellHookConfig, WebhookHookConfig, DiscordHookConfig, SlackHookConfig };
+export type { ShellHookConfigInput, WebhookHookConfigInput, DiscordHookConfigInput, SlackHookConfigInput, HookConfigInput };
 
 // =============================================================================
 // Hook Context (Runtime Type)
@@ -177,7 +179,7 @@ export interface HookResult {
   /**
    * Hook type that was executed
    */
-  hookType: "shell" | "webhook" | "discord";
+  hookType: "shell" | "webhook" | "discord" | "slack";
 
   /**
    * Duration of hook execution in milliseconds

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@herdctl/slack",
+  "version": "0.1.0",
+  "description": "Slack connector for herdctl fleet management",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@herdctl/core": "workspace:*",
+    "@slack/bolt": "^4.1.0",
+    "@slack/web-api": "^7.8.0",
+    "yaml": "^2.3.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.0.17",
+    "typescript": "^5",
+    "vitest": "^4.0.17"
+  },
+  "homepage": "https://herdctl.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/edspencer/herdctl"
+  },
+  "keywords": [
+    "claude",
+    "agent",
+    "fleet",
+    "orchestration",
+    "anthropic",
+    "slack"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/slack/src/__tests__/command-handler.test.ts
+++ b/packages/slack/src/__tests__/command-handler.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  CommandHandler,
+  type PrefixCommand,
+  type CommandContext,
+} from "../commands/command-handler.js";
+import type { SlackConnectorState, ISlackSessionManager } from "../types.js";
+
+const createMockContext = (
+  overrides: Partial<CommandContext> = {}
+): CommandContext => ({
+  agentName: "test-agent",
+  threadTs: "1707930000.123456",
+  channelId: "C0123456789",
+  userId: "U0123456789",
+  reply: vi.fn().mockResolvedValue(undefined),
+  sessionManager: {
+    getOrCreateSession: vi.fn(),
+    touchSession: vi.fn(),
+    getSession: vi.fn(),
+    setSession: vi.fn(),
+    clearSession: vi.fn(),
+    cleanupExpiredSessions: vi.fn(),
+    getActiveSessionCount: vi.fn(),
+  } as unknown as ISlackSessionManager,
+  connectorState: {
+    status: "connected",
+    botUser: { id: "UBOT", username: "test-bot" },
+    connectedAt: new Date().toISOString(),
+    reconnectAttempts: 0,
+    lastError: null,
+  } as SlackConnectorState,
+  ...overrides,
+});
+
+const createTestCommand = (
+  name: string,
+  executeFn?: PrefixCommand["execute"]
+): PrefixCommand => ({
+  name,
+  description: `Test ${name} command`,
+  execute: executeFn ?? vi.fn().mockResolvedValue(undefined),
+});
+
+describe("CommandHandler", () => {
+  describe("registerCommand", () => {
+    it("registers a command", () => {
+      const handler = new CommandHandler();
+      const command = createTestCommand("test");
+
+      handler.registerCommand(command);
+
+      expect(handler.getCommands()).toHaveLength(1);
+      expect(handler.getCommands()[0].name).toBe("test");
+    });
+
+    it("registers multiple commands", () => {
+      const handler = new CommandHandler();
+
+      handler.registerCommand(createTestCommand("cmd1"));
+      handler.registerCommand(createTestCommand("cmd2"));
+
+      expect(handler.getCommands()).toHaveLength(2);
+    });
+  });
+
+  describe("isCommand", () => {
+    it("returns true for registered commands", () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(createTestCommand("reset"));
+
+      expect(handler.isCommand("!reset")).toBe(true);
+    });
+
+    it("returns false for unregistered commands", () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(createTestCommand("reset"));
+
+      expect(handler.isCommand("!unknown")).toBe(false);
+    });
+
+    it("returns false for non-command messages", () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(createTestCommand("reset"));
+
+      expect(handler.isCommand("hello")).toBe(false);
+    });
+
+    it("is case-insensitive", () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(createTestCommand("Reset"));
+
+      expect(handler.isCommand("!RESET")).toBe(true);
+      expect(handler.isCommand("!reset")).toBe(true);
+    });
+
+    it("handles commands with extra whitespace", () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(createTestCommand("reset"));
+
+      expect(handler.isCommand("  !reset  ")).toBe(true);
+    });
+
+    it("handles commands with arguments", () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(createTestCommand("reset"));
+
+      expect(handler.isCommand("!reset --force")).toBe(true);
+    });
+  });
+
+  describe("executeCommand", () => {
+    it("executes a registered command", async () => {
+      const executeFn = vi.fn().mockResolvedValue(undefined);
+      const handler = new CommandHandler();
+      handler.registerCommand(createTestCommand("test", executeFn));
+
+      const context = createMockContext();
+      const result = await handler.executeCommand("!test", context);
+
+      expect(result).toBe(true);
+      expect(executeFn).toHaveBeenCalledWith(context);
+    });
+
+    it("returns false for non-command messages", async () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(createTestCommand("test"));
+
+      const context = createMockContext();
+      const result = await handler.executeCommand("hello", context);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false for unregistered commands", async () => {
+      const handler = new CommandHandler();
+
+      const context = createMockContext();
+      const result = await handler.executeCommand("!unknown", context);
+
+      expect(result).toBe(false);
+    });
+
+    it("handles command execution errors", async () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(
+        createTestCommand("fail", async () => {
+          throw new Error("Command failed");
+        })
+      );
+
+      const context = createMockContext();
+      const result = await handler.executeCommand("!fail", context);
+
+      expect(result).toBe(true); // Command was attempted
+      expect(context.reply).toHaveBeenCalledWith(
+        expect.stringContaining("error")
+      );
+    });
+
+    it("handles reply error during error handling", async () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(
+        createTestCommand("fail", async () => {
+          throw new Error("Command failed");
+        })
+      );
+
+      const context = createMockContext({
+        reply: vi.fn().mockRejectedValue(new Error("Reply failed")),
+      });
+
+      // Should not throw
+      const result = await handler.executeCommand("!fail", context);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("getCommands", () => {
+    it("returns empty array when no commands registered", () => {
+      const handler = new CommandHandler();
+      expect(handler.getCommands()).toEqual([]);
+    });
+
+    it("returns all registered commands", () => {
+      const handler = new CommandHandler();
+      handler.registerCommand(createTestCommand("cmd1"));
+      handler.registerCommand(createTestCommand("cmd2"));
+      handler.registerCommand(createTestCommand("cmd3"));
+
+      const commands = handler.getCommands();
+      expect(commands).toHaveLength(3);
+    });
+  });
+});

--- a/packages/slack/src/__tests__/error-handler.test.ts
+++ b/packages/slack/src/__tests__/error-handler.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  ErrorCategory,
+  USER_ERROR_MESSAGES,
+  classifyError,
+  safeExecute,
+  safeExecuteWithReply,
+} from "../error-handler.js";
+
+const createMockLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+describe("ErrorCategory", () => {
+  it("has all expected categories", () => {
+    expect(ErrorCategory.AUTH).toBe("auth");
+    expect(ErrorCategory.RATE_LIMIT).toBe("rate_limit");
+    expect(ErrorCategory.NETWORK).toBe("network");
+    expect(ErrorCategory.API).toBe("api");
+    expect(ErrorCategory.INTERNAL).toBe("internal");
+    expect(ErrorCategory.UNKNOWN).toBe("unknown");
+  });
+});
+
+describe("USER_ERROR_MESSAGES", () => {
+  it("has messages for all categories", () => {
+    expect(USER_ERROR_MESSAGES.auth).toBeDefined();
+    expect(USER_ERROR_MESSAGES.rate_limit).toBeDefined();
+    expect(USER_ERROR_MESSAGES.network).toBeDefined();
+    expect(USER_ERROR_MESSAGES.api).toBeDefined();
+    expect(USER_ERROR_MESSAGES.internal).toBeDefined();
+    expect(USER_ERROR_MESSAGES.unknown).toBeDefined();
+  });
+
+  it("error messages are user-friendly", () => {
+    const messages = Object.values(USER_ERROR_MESSAGES);
+    for (const message of messages) {
+      expect(message).not.toMatch(/^Error:/);
+      expect(message).not.toContain(".ts:");
+      expect(message).not.toContain(".js:");
+    }
+  });
+});
+
+describe("classifyError", () => {
+  it("classifies auth errors", () => {
+    const result = classifyError(new Error("invalid_auth"));
+
+    expect(result.category).toBe(ErrorCategory.AUTH);
+    expect(result.isRetryable).toBe(false);
+    expect(result.userMessage).toBe(USER_ERROR_MESSAGES.auth);
+  });
+
+  it("classifies token errors as auth", () => {
+    const result = classifyError(new Error("token_expired"));
+
+    expect(result.category).toBe(ErrorCategory.AUTH);
+    expect(result.isRetryable).toBe(false);
+  });
+
+  it("classifies rate limit errors", () => {
+    const result = classifyError(new Error("rate_limited"));
+
+    expect(result.category).toBe(ErrorCategory.RATE_LIMIT);
+    expect(result.isRetryable).toBe(true);
+    expect(result.userMessage).toBe(USER_ERROR_MESSAGES.rate_limit);
+  });
+
+  it("classifies ratelimited errors", () => {
+    const result = classifyError(new Error("ratelimited"));
+
+    expect(result.category).toBe(ErrorCategory.RATE_LIMIT);
+    expect(result.isRetryable).toBe(true);
+  });
+
+  it("classifies network errors (ECONNREFUSED)", () => {
+    const result = classifyError(new Error("connect ECONNREFUSED"));
+
+    expect(result.category).toBe(ErrorCategory.NETWORK);
+    expect(result.isRetryable).toBe(true);
+    expect(result.userMessage).toBe(USER_ERROR_MESSAGES.network);
+  });
+
+  it("classifies network errors (ENOTFOUND)", () => {
+    const result = classifyError(new Error("getaddrinfo ENOTFOUND"));
+
+    expect(result.category).toBe(ErrorCategory.NETWORK);
+    expect(result.isRetryable).toBe(true);
+  });
+
+  it("classifies timeout errors", () => {
+    const result = classifyError(new Error("Request timeout"));
+
+    expect(result.category).toBe(ErrorCategory.NETWORK);
+    expect(result.isRetryable).toBe(true);
+  });
+
+  it("classifies Slack API errors", () => {
+    const result = classifyError(new Error("Slack API returned error"));
+
+    expect(result.category).toBe(ErrorCategory.API);
+    expect(result.isRetryable).toBe(true);
+    expect(result.userMessage).toBe(USER_ERROR_MESSAGES.api);
+  });
+
+  it("classifies unknown errors", () => {
+    const result = classifyError(new Error("Something unexpected"));
+
+    expect(result.category).toBe(ErrorCategory.UNKNOWN);
+    expect(result.isRetryable).toBe(false);
+    expect(result.userMessage).toBe(USER_ERROR_MESSAGES.unknown);
+  });
+
+  it("preserves original error", () => {
+    const error = new Error("test error");
+    const result = classifyError(error);
+
+    expect(result.originalError).toBe(error);
+  });
+});
+
+describe("safeExecute", () => {
+  it("returns result on success", async () => {
+    const logger = createMockLogger();
+    const result = await safeExecute(
+      async () => "success",
+      logger,
+      "test operation"
+    );
+
+    expect(result).toBe("success");
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined and logs error on failure", async () => {
+    const logger = createMockLogger();
+    const result = await safeExecute(
+      async () => {
+        throw new Error("Operation failed");
+      },
+      logger,
+      "test operation"
+    );
+
+    expect(result).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      "Error in test operation: Operation failed"
+    );
+  });
+
+  it("handles non-Error throws", async () => {
+    const logger = createMockLogger();
+    const result = await safeExecute(
+      async () => {
+        throw "string error";
+      },
+      logger,
+      "test"
+    );
+
+    expect(result).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      "Error in test: string error"
+    );
+  });
+});
+
+describe("safeExecuteWithReply", () => {
+  it("executes function on success", async () => {
+    const logger = createMockLogger();
+    const reply = vi.fn();
+    const fn = vi.fn().mockResolvedValue(undefined);
+
+    await safeExecuteWithReply(fn, reply, logger, "test");
+
+    expect(fn).toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it("sends error reply on failure", async () => {
+    const logger = createMockLogger();
+    const reply = vi.fn();
+
+    await safeExecuteWithReply(
+      async () => {
+        throw new Error("connect ECONNREFUSED");
+      },
+      reply,
+      logger,
+      "test"
+    );
+
+    expect(reply).toHaveBeenCalledWith(USER_ERROR_MESSAGES.network);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("handles reply failure gracefully", async () => {
+    const logger = createMockLogger();
+    const reply = vi.fn().mockRejectedValue(new Error("Reply failed"));
+
+    await safeExecuteWithReply(
+      async () => {
+        throw new Error("Original error");
+      },
+      reply,
+      logger,
+      "test"
+    );
+
+    // Should log both errors
+    expect(logger.error).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles non-Error throws", async () => {
+    const logger = createMockLogger();
+    const reply = vi.fn();
+
+    await safeExecuteWithReply(
+      async () => {
+        throw "string error";
+      },
+      reply,
+      logger,
+      "test"
+    );
+
+    expect(reply).toHaveBeenCalled();
+  });
+});

--- a/packages/slack/src/__tests__/errors.test.ts
+++ b/packages/slack/src/__tests__/errors.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import {
+  SlackErrorCode,
+  SlackConnectorError,
+  SlackConnectionError,
+  AlreadyConnectedError,
+  MissingTokenError,
+  InvalidTokenError,
+  isSlackConnectorError,
+} from "../errors.js";
+
+describe("SlackConnectorError", () => {
+  it("creates error with correct properties", () => {
+    const error = new SlackConnectorError(
+      "Test error message",
+      SlackErrorCode.CONNECTION_FAILED
+    );
+
+    expect(error.message).toBe("Test error message");
+    expect(error.code).toBe(SlackErrorCode.CONNECTION_FAILED);
+    expect(error.name).toBe("SlackConnectorError");
+  });
+
+  it("extends Error", () => {
+    const error = new SlackConnectorError(
+      "Test",
+      SlackErrorCode.CONNECTION_FAILED
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(SlackConnectorError);
+  });
+
+  it("preserves cause when provided", () => {
+    const cause = new Error("Original error");
+    const error = new SlackConnectorError(
+      "Wrapped error",
+      SlackErrorCode.CONNECTION_FAILED,
+      { cause }
+    );
+
+    expect(error.cause).toBe(cause);
+  });
+});
+
+describe("SlackConnectionError", () => {
+  it("creates error with correct properties", () => {
+    const error = new SlackConnectionError("Connection timed out");
+
+    expect(error.message).toBe("Connection timed out");
+    expect(error.code).toBe(SlackErrorCode.CONNECTION_FAILED);
+    expect(error.name).toBe("SlackConnectionError");
+  });
+
+  it("extends SlackConnectorError", () => {
+    const error = new SlackConnectionError("Test");
+
+    expect(error).toBeInstanceOf(SlackConnectorError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("preserves cause when provided", () => {
+    const cause = new Error("Socket error");
+    const error = new SlackConnectionError("Connection lost", { cause });
+
+    expect(error.cause).toBe(cause);
+  });
+});
+
+describe("AlreadyConnectedError", () => {
+  it("creates error with correct message", () => {
+    const error = new AlreadyConnectedError();
+
+    expect(error.message).toBe("Slack connector is already connected");
+    expect(error.code).toBe(SlackErrorCode.ALREADY_CONNECTED);
+    expect(error.name).toBe("AlreadyConnectedError");
+  });
+
+  it("extends SlackConnectorError", () => {
+    const error = new AlreadyConnectedError();
+
+    expect(error).toBeInstanceOf(SlackConnectorError);
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe("MissingTokenError", () => {
+  it("creates error for bot token", () => {
+    const error = new MissingTokenError("bot", "SLACK_BOT_TOKEN");
+
+    expect(error.message).toBe(
+      "Slack bot token not found in environment variable 'SLACK_BOT_TOKEN'"
+    );
+    expect(error.code).toBe(SlackErrorCode.MISSING_TOKEN);
+    expect(error.tokenType).toBe("bot");
+    expect(error.name).toBe("MissingTokenError");
+  });
+
+  it("creates error for app token", () => {
+    const error = new MissingTokenError("app", "SLACK_APP_TOKEN");
+
+    expect(error.message).toBe(
+      "Slack app token not found in environment variable 'SLACK_APP_TOKEN'"
+    );
+    expect(error.tokenType).toBe("app");
+  });
+
+  it("extends SlackConnectorError", () => {
+    const error = new MissingTokenError("bot", "TOKEN");
+
+    expect(error).toBeInstanceOf(SlackConnectorError);
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe("InvalidTokenError", () => {
+  it("creates error with message", () => {
+    const error = new InvalidTokenError("Token format is wrong");
+
+    expect(error.message).toBe("Token format is wrong");
+    expect(error.code).toBe(SlackErrorCode.INVALID_TOKEN);
+    expect(error.name).toBe("InvalidTokenError");
+  });
+
+  it("extends SlackConnectorError", () => {
+    const error = new InvalidTokenError("Test");
+
+    expect(error).toBeInstanceOf(SlackConnectorError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("preserves cause when provided", () => {
+    const cause = new Error("Auth error");
+    const error = new InvalidTokenError("Bad token", { cause });
+
+    expect(error.cause).toBe(cause);
+  });
+});
+
+describe("isSlackConnectorError", () => {
+  it("returns true for SlackConnectorError", () => {
+    const error = new SlackConnectorError(
+      "Test",
+      SlackErrorCode.CONNECTION_FAILED
+    );
+    expect(isSlackConnectorError(error)).toBe(true);
+  });
+
+  it("returns true for SlackConnectionError", () => {
+    const error = new SlackConnectionError("Test");
+    expect(isSlackConnectorError(error)).toBe(true);
+  });
+
+  it("returns true for AlreadyConnectedError", () => {
+    const error = new AlreadyConnectedError();
+    expect(isSlackConnectorError(error)).toBe(true);
+  });
+
+  it("returns true for MissingTokenError", () => {
+    const error = new MissingTokenError("bot", "TOKEN");
+    expect(isSlackConnectorError(error)).toBe(true);
+  });
+
+  it("returns true for InvalidTokenError", () => {
+    const error = new InvalidTokenError("Test");
+    expect(isSlackConnectorError(error)).toBe(true);
+  });
+
+  it("returns false for regular Error", () => {
+    expect(isSlackConnectorError(new Error("Test"))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isSlackConnectorError(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isSlackConnectorError(undefined)).toBe(false);
+  });
+
+  it("returns false for string", () => {
+    expect(isSlackConnectorError("error message")).toBe(false);
+  });
+});
+
+describe("SlackErrorCode", () => {
+  it("has all expected error codes", () => {
+    expect(SlackErrorCode.CONNECTION_FAILED).toBe("SLACK_CONNECTION_FAILED");
+    expect(SlackErrorCode.ALREADY_CONNECTED).toBe("SLACK_ALREADY_CONNECTED");
+    expect(SlackErrorCode.MISSING_TOKEN).toBe("SLACK_MISSING_TOKEN");
+    expect(SlackErrorCode.INVALID_TOKEN).toBe("SLACK_INVALID_TOKEN");
+    expect(SlackErrorCode.MESSAGE_SEND_FAILED).toBe("SLACK_MESSAGE_SEND_FAILED");
+    expect(SlackErrorCode.SOCKET_MODE_ERROR).toBe("SLACK_SOCKET_MODE_ERROR");
+  });
+});

--- a/packages/slack/src/__tests__/formatting.test.ts
+++ b/packages/slack/src/__tests__/formatting.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "vitest";
+import {
+  markdownToMrkdwn,
+  splitMessage,
+  findSplitPoint,
+  needsSplit,
+  createContextAttachment,
+  truncateMessage,
+  formatCodeBlock,
+  escapeMrkdwn,
+  SLACK_MAX_MESSAGE_LENGTH,
+  MIN_CHUNK_SIZE,
+} from "../formatting.js";
+
+describe("markdownToMrkdwn", () => {
+  it("converts bold markdown to mrkdwn", () => {
+    expect(markdownToMrkdwn("**hello**")).toBe("*hello*");
+  });
+
+  it("converts multiple bold segments", () => {
+    expect(markdownToMrkdwn("**hello** world **foo**")).toBe(
+      "*hello* world *foo*"
+    );
+  });
+
+  it("preserves italic (same in both formats)", () => {
+    expect(markdownToMrkdwn("_hello_")).toBe("_hello_");
+  });
+
+  it("converts links to mrkdwn format", () => {
+    expect(markdownToMrkdwn("[click here](https://example.com)")).toBe(
+      "<https://example.com|click here>"
+    );
+  });
+
+  it("handles multiple links", () => {
+    const input = "[link1](https://a.com) and [link2](https://b.com)";
+    const expected = "<https://a.com|link1> and <https://b.com|link2>";
+    expect(markdownToMrkdwn(input)).toBe(expected);
+  });
+
+  it("preserves inline code", () => {
+    expect(markdownToMrkdwn("`code here`")).toBe("`code here`");
+  });
+
+  it("preserves code blocks and does not transform inside them", () => {
+    const input = "text **bold** ```\n**not bold**\n``` after";
+    const result = markdownToMrkdwn(input);
+    expect(result).toContain("*bold*");
+    expect(result).toContain("**not bold**");
+  });
+
+  it("preserves inline code content", () => {
+    const input = "text **bold** `**not bold**` after";
+    const result = markdownToMrkdwn(input);
+    expect(result).toContain("*bold*");
+    expect(result).toContain("`**not bold**`");
+  });
+
+  it("handles text with no markdown", () => {
+    expect(markdownToMrkdwn("plain text")).toBe("plain text");
+  });
+
+  it("handles empty string", () => {
+    expect(markdownToMrkdwn("")).toBe("");
+  });
+});
+
+describe("splitMessage", () => {
+  it("returns single chunk for short messages", () => {
+    const result = splitMessage("Hello world");
+
+    expect(result.chunks).toEqual(["Hello world"]);
+    expect(result.wasSplit).toBe(false);
+    expect(result.originalLength).toBe(11);
+  });
+
+  it("splits long messages at paragraph boundaries", () => {
+    const paragraph1 = "a".repeat(2000);
+    const paragraph2 = "b".repeat(2000);
+    const content = `${paragraph1}\n\n${paragraph2}`;
+
+    const result = splitMessage(content);
+
+    expect(result.wasSplit).toBe(true);
+    expect(result.chunks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("splits at sentence boundaries when no paragraphs", () => {
+    const sentence = "This is a sentence. ";
+    const content = sentence.repeat(300); // ~6000 chars
+
+    const result = splitMessage(content);
+
+    expect(result.wasSplit).toBe(true);
+    for (const chunk of result.chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SLACK_MAX_MESSAGE_LENGTH);
+    }
+  });
+
+  it("respects custom maxLength", () => {
+    const content = "a".repeat(500);
+    const result = splitMessage(content, { maxLength: 200 });
+
+    expect(result.wasSplit).toBe(true);
+    for (const chunk of result.chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it("handles preserveBoundaries=false", () => {
+    const content = "a".repeat(500);
+    const result = splitMessage(content, {
+      maxLength: 200,
+      preserveBoundaries: false,
+    });
+
+    expect(result.wasSplit).toBe(true);
+  });
+});
+
+describe("findSplitPoint", () => {
+  it("returns text length if under max", () => {
+    expect(findSplitPoint("hello", 100)).toBe(5);
+  });
+
+  it("splits at paragraph boundary", () => {
+    const text = "a".repeat(200) + "\n\n" + "b".repeat(200);
+    const splitIndex = findSplitPoint(text, 250);
+
+    expect(splitIndex).toBeLessThanOrEqual(250);
+    expect(splitIndex).toBeGreaterThan(MIN_CHUNK_SIZE);
+  });
+
+  it("splits at newline if no paragraph boundary", () => {
+    const text = "a".repeat(200) + "\n" + "b".repeat(200);
+    const splitIndex = findSplitPoint(text, 250);
+
+    expect(splitIndex).toBeLessThanOrEqual(250);
+    expect(splitIndex).toBeGreaterThan(MIN_CHUNK_SIZE);
+  });
+
+  it("falls back to hard split at maxLength", () => {
+    const text = "a".repeat(500); // No split points
+    const splitIndex = findSplitPoint(text, 200);
+
+    expect(splitIndex).toBe(200);
+  });
+});
+
+describe("needsSplit", () => {
+  it("returns false for short messages", () => {
+    expect(needsSplit("Hello")).toBe(false);
+  });
+
+  it("returns true for messages exceeding default limit", () => {
+    expect(needsSplit("a".repeat(SLACK_MAX_MESSAGE_LENGTH + 1))).toBe(true);
+  });
+
+  it("respects custom maxLength", () => {
+    expect(needsSplit("hello world", 5)).toBe(true);
+    expect(needsSplit("hello world", 100)).toBe(false);
+  });
+});
+
+describe("createContextAttachment", () => {
+  it("creates green attachment for high context", () => {
+    const attachment = createContextAttachment(80);
+
+    expect(attachment.footer).toBe("Context: 80% remaining");
+    expect(attachment.color).toBe("#36a64f");
+  });
+
+  it("creates red attachment for low context", () => {
+    const attachment = createContextAttachment(15);
+
+    expect(attachment.footer).toBe("Context: 15% remaining");
+    expect(attachment.color).toBe("#ff0000");
+  });
+
+  it("uses red threshold at 20%", () => {
+    expect(createContextAttachment(20).color).toBe("#36a64f");
+    expect(createContextAttachment(19).color).toBe("#ff0000");
+  });
+
+  it("rounds the percentage", () => {
+    expect(createContextAttachment(33.7).footer).toBe(
+      "Context: 34% remaining"
+    );
+  });
+});
+
+describe("truncateMessage", () => {
+  it("returns message unchanged if under limit", () => {
+    expect(truncateMessage("hello")).toBe("hello");
+  });
+
+  it("truncates and adds ellipsis", () => {
+    const result = truncateMessage("hello world", 8);
+    expect(result).toBe("hello...");
+    expect(result.length).toBe(8);
+  });
+
+  it("uses custom ellipsis", () => {
+    const result = truncateMessage("hello world", 9, " [more]");
+    expect(result).toBe("he [more]");
+  });
+
+  it("uses default max length", () => {
+    const shortMsg = "a".repeat(100);
+    expect(truncateMessage(shortMsg)).toBe(shortMsg);
+  });
+});
+
+describe("formatCodeBlock", () => {
+  it("formats code without language", () => {
+    expect(formatCodeBlock("const x = 1")).toBe("```\nconst x = 1\n```");
+  });
+
+  it("formats code with language", () => {
+    expect(formatCodeBlock("const x = 1", "typescript")).toBe(
+      "```typescript\nconst x = 1\n```"
+    );
+  });
+});
+
+describe("escapeMrkdwn", () => {
+  it("escapes mrkdwn special characters", () => {
+    expect(escapeMrkdwn("*bold*")).toBe("\\*bold\\*");
+    expect(escapeMrkdwn("_italic_")).toBe("\\_italic\\_");
+    expect(escapeMrkdwn("~strike~")).toBe("\\~strike\\~");
+    expect(escapeMrkdwn("<link>")).toBe("\\<link\\>");
+  });
+
+  it("handles text with no special characters", () => {
+    expect(escapeMrkdwn("plain text")).toBe("plain text");
+  });
+
+  it("handles empty string", () => {
+    expect(escapeMrkdwn("")).toBe("");
+  });
+});

--- a/packages/slack/src/__tests__/logger.test.ts
+++ b/packages/slack/src/__tests__/logger.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createSlackLogger, createDefaultSlackLogger } from "../logger.js";
+
+describe("createSlackLogger", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("standard level (default)", () => {
+    it("logs info messages", () => {
+      const logger = createSlackLogger({ prefix: "[test]" });
+      logger.info("test message");
+      expect(console.info).toHaveBeenCalledWith("[test] test message", "");
+    });
+
+    it("logs warn messages", () => {
+      const logger = createSlackLogger({ prefix: "[test]" });
+      logger.warn("warning");
+      expect(console.warn).toHaveBeenCalledWith("[test] warning", "");
+    });
+
+    it("logs error messages", () => {
+      const logger = createSlackLogger({ prefix: "[test]" });
+      logger.error("error");
+      expect(console.error).toHaveBeenCalledWith("[test] error", "");
+    });
+
+    it("does not log debug messages", () => {
+      const logger = createSlackLogger({ prefix: "[test]" });
+      logger.debug("debug");
+      expect(console.debug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("minimal level", () => {
+    it("logs warn and error only", () => {
+      const logger = createSlackLogger({
+        prefix: "[test]",
+        logLevel: "minimal",
+      });
+
+      logger.debug("debug");
+      logger.info("info");
+      logger.warn("warn");
+      logger.error("error");
+
+      expect(console.debug).not.toHaveBeenCalled();
+      expect(console.info).not.toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("verbose level", () => {
+    it("logs all message levels", () => {
+      const logger = createSlackLogger({
+        prefix: "[test]",
+        logLevel: "verbose",
+      });
+
+      logger.debug("debug");
+      logger.info("info");
+      logger.warn("warn");
+      logger.error("error");
+
+      expect(console.debug).toHaveBeenCalled();
+      expect(console.info).toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("data parameter", () => {
+    it("includes stringified data when provided", () => {
+      const logger = createSlackLogger({
+        prefix: "[test]",
+        logLevel: "verbose",
+      });
+      const data = { key: "value" };
+
+      logger.debug("msg", data);
+
+      expect(console.debug).toHaveBeenCalledWith(
+        "[test] msg",
+        JSON.stringify(data)
+      );
+    });
+  });
+});
+
+describe("createDefaultSlackLogger", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates logger with agent name prefix", () => {
+    const logger = createDefaultSlackLogger("my-agent");
+    logger.info("test");
+    expect(console.info).toHaveBeenCalledWith("[slack:my-agent] test", "");
+  });
+
+  it("creates logger without agent name", () => {
+    const logger = createDefaultSlackLogger();
+    logger.info("test");
+    expect(console.info).toHaveBeenCalledWith("[slack] test", "");
+  });
+});

--- a/packages/slack/src/__tests__/message-handler.test.ts
+++ b/packages/slack/src/__tests__/message-handler.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  isBotMentioned,
+  stripBotMention,
+  stripMentions,
+  shouldProcessMessage,
+  processMessage,
+} from "../message-handler.js";
+
+const BOT_USER_ID = "U0123456789";
+
+describe("isBotMentioned", () => {
+  it("returns true when bot is mentioned", () => {
+    expect(isBotMentioned(`<@${BOT_USER_ID}> hello`, BOT_USER_ID)).toBe(true);
+  });
+
+  it("returns false when bot is not mentioned", () => {
+    expect(isBotMentioned("hello world", BOT_USER_ID)).toBe(false);
+  });
+
+  it("returns false for different user mention", () => {
+    expect(isBotMentioned("<@UOTHER123> hello", BOT_USER_ID)).toBe(false);
+  });
+
+  it("returns true when bot is mentioned in the middle", () => {
+    expect(
+      isBotMentioned(`hey <@${BOT_USER_ID}> do something`, BOT_USER_ID)
+    ).toBe(true);
+  });
+});
+
+describe("stripBotMention", () => {
+  it("removes bot mention from start", () => {
+    expect(stripBotMention(`<@${BOT_USER_ID}> hello`, BOT_USER_ID)).toBe(
+      "hello"
+    );
+  });
+
+  it("removes bot mention from middle", () => {
+    expect(
+      stripBotMention(`hey <@${BOT_USER_ID}> do this`, BOT_USER_ID)
+    ).toBe("hey  do this");
+  });
+
+  it("removes multiple bot mentions", () => {
+    const text = `<@${BOT_USER_ID}> hello <@${BOT_USER_ID}>`;
+    expect(stripBotMention(text, BOT_USER_ID)).toBe("hello");
+  });
+
+  it("handles text with no mentions", () => {
+    expect(stripBotMention("hello world", BOT_USER_ID)).toBe("hello world");
+  });
+
+  it("trims resulting text", () => {
+    expect(stripBotMention(`  <@${BOT_USER_ID}>  `, BOT_USER_ID)).toBe("");
+  });
+});
+
+describe("stripMentions", () => {
+  it("removes all user mentions", () => {
+    expect(stripMentions("<@U123> hello <@U456>")).toBe("hello");
+  });
+
+  it("handles text with no mentions", () => {
+    expect(stripMentions("hello world")).toBe("hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(stripMentions("")).toBe("");
+  });
+});
+
+describe("shouldProcessMessage", () => {
+  it("returns true for regular user messages", () => {
+    expect(
+      shouldProcessMessage({ user: "UUSER123" }, BOT_USER_ID)
+    ).toBe(true);
+  });
+
+  it("returns false for bot messages", () => {
+    expect(
+      shouldProcessMessage({ bot_id: "BBOT123" }, BOT_USER_ID)
+    ).toBe(false);
+  });
+
+  it("returns false for bot_message subtype", () => {
+    expect(
+      shouldProcessMessage(
+        { subtype: "bot_message", user: "UUSER123" },
+        BOT_USER_ID
+      )
+    ).toBe(false);
+  });
+
+  it("returns false for messages from the bot itself", () => {
+    expect(
+      shouldProcessMessage({ user: BOT_USER_ID }, BOT_USER_ID)
+    ).toBe(false);
+  });
+
+  it("returns true for thread replies from users", () => {
+    expect(
+      shouldProcessMessage(
+        { user: "UUSER123", thread_ts: "1707930000.123456" },
+        BOT_USER_ID
+      )
+    ).toBe(true);
+  });
+});
+
+describe("processMessage", () => {
+  it("strips bot mention and returns prompt", () => {
+    expect(processMessage(`<@${BOT_USER_ID}> help me`, BOT_USER_ID)).toBe(
+      "help me"
+    );
+  });
+
+  it("trims whitespace", () => {
+    expect(processMessage(`  <@${BOT_USER_ID}>   hello  `, BOT_USER_ID)).toBe(
+      "hello"
+    );
+  });
+
+  it("returns full text if no bot mention", () => {
+    expect(processMessage("just a message", BOT_USER_ID)).toBe(
+      "just a message"
+    );
+  });
+
+  it("handles empty text after mention removal", () => {
+    expect(processMessage(`<@${BOT_USER_ID}>`, BOT_USER_ID)).toBe("");
+  });
+});

--- a/packages/slack/src/__tests__/session-manager.test.ts
+++ b/packages/slack/src/__tests__/session-manager.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SessionManager } from "../session-manager/session-manager.js";
+import {
+  createInitialSessionState,
+  createThreadSession,
+} from "../session-manager/types.js";
+import {
+  SessionManagerError,
+  SessionStateReadError,
+  SessionStateWriteError,
+  SessionDirectoryCreateError,
+  SessionErrorCode,
+} from "../session-manager/errors.js";
+
+const createMockLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+describe("SessionManager", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "slack-session-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const createManager = (agentName = "test-agent", expiryHours = 24) => {
+    return new SessionManager({
+      agentName,
+      stateDir: tempDir,
+      sessionExpiryHours: expiryHours,
+      logger: createMockLogger(),
+    });
+  };
+
+  describe("getOrCreateSession", () => {
+    it("creates a new session for unknown thread", async () => {
+      const manager = createManager();
+
+      const result = await manager.getOrCreateSession(
+        "1707930000.123456",
+        "C0123456789"
+      );
+
+      expect(result.isNew).toBe(true);
+      expect(result.sessionId).toMatch(/^slack-test-agent-/);
+    });
+
+    it("returns existing session for known thread", async () => {
+      const manager = createManager();
+
+      const first = await manager.getOrCreateSession(
+        "1707930000.123456",
+        "C0123456789"
+      );
+      const second = await manager.getOrCreateSession(
+        "1707930000.123456",
+        "C0123456789"
+      );
+
+      expect(second.isNew).toBe(false);
+      expect(second.sessionId).toBe(first.sessionId);
+    });
+
+    it("creates different sessions for different threads", async () => {
+      const manager = createManager();
+
+      const first = await manager.getOrCreateSession(
+        "1707930000.111111",
+        "C0123456789"
+      );
+      const second = await manager.getOrCreateSession(
+        "1707930000.222222",
+        "C0123456789"
+      );
+
+      expect(first.sessionId).not.toBe(second.sessionId);
+    });
+  });
+
+  describe("getSession", () => {
+    it("returns null for unknown thread", async () => {
+      const manager = createManager();
+
+      const session = await manager.getSession("unknown-thread");
+
+      expect(session).toBeNull();
+    });
+
+    it("returns session for known thread", async () => {
+      const manager = createManager();
+
+      await manager.getOrCreateSession("1707930000.123456", "C0123456789");
+      const session = await manager.getSession("1707930000.123456");
+
+      expect(session).not.toBeNull();
+      expect(session!.channelId).toBe("C0123456789");
+    });
+
+    it("returns null for expired sessions", async () => {
+      // 0 hours expiry = immediately expired
+      const manager = createManager("test-agent", 0);
+
+      await manager.getOrCreateSession("1707930000.123456", "C0123456789");
+
+      // Wait a tick so the session is expired
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const session = await manager.getSession("1707930000.123456");
+      expect(session).toBeNull();
+    });
+  });
+
+  describe("touchSession", () => {
+    it("updates last message timestamp", async () => {
+      const manager = createManager();
+
+      await manager.getOrCreateSession("1707930000.123456", "C0123456789");
+      const before = await manager.getSession("1707930000.123456");
+      const beforeTime = new Date(before!.lastMessageAt).getTime();
+
+      // Wait enough for a distinct timestamp
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await manager.touchSession("1707930000.123456");
+
+      const after = await manager.getSession("1707930000.123456");
+      const afterTime = new Date(after!.lastMessageAt).getTime();
+
+      expect(afterTime).toBeGreaterThanOrEqual(beforeTime);
+    });
+
+    it("does not throw for unknown thread", async () => {
+      const manager = createManager();
+
+      await expect(
+        manager.touchSession("unknown-thread")
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("setSession", () => {
+    it("creates or updates a session", async () => {
+      const manager = createManager();
+
+      await manager.setSession(
+        "1707930000.123456",
+        "custom-session-id",
+        "C0123456789"
+      );
+
+      const session = await manager.getSession("1707930000.123456");
+      expect(session).not.toBeNull();
+      expect(session!.sessionId).toBe("custom-session-id");
+    });
+
+    it("overwrites existing session", async () => {
+      const manager = createManager();
+
+      await manager.getOrCreateSession("1707930000.123456", "C0123456789");
+      await manager.setSession(
+        "1707930000.123456",
+        "new-session-id",
+        "C0123456789"
+      );
+
+      const session = await manager.getSession("1707930000.123456");
+      expect(session!.sessionId).toBe("new-session-id");
+    });
+  });
+
+  describe("clearSession", () => {
+    it("removes a session and returns true", async () => {
+      const manager = createManager();
+
+      await manager.getOrCreateSession("1707930000.123456", "C0123456789");
+      const result = await manager.clearSession("1707930000.123456");
+
+      expect(result).toBe(true);
+
+      const session = await manager.getSession("1707930000.123456");
+      expect(session).toBeNull();
+    });
+
+    it("returns false for unknown thread", async () => {
+      const manager = createManager();
+
+      const result = await manager.clearSession("unknown-thread");
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("cleanupExpiredSessions", () => {
+    it("removes expired sessions", async () => {
+      const manager = createManager("test-agent", 0);
+
+      await manager.getOrCreateSession("thread-1", "C0123456789");
+      await manager.getOrCreateSession("thread-2", "C0123456789");
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const count = await manager.cleanupExpiredSessions();
+
+      expect(count).toBe(2);
+    });
+
+    it("keeps active sessions", async () => {
+      const manager = createManager("test-agent", 24);
+
+      await manager.getOrCreateSession("thread-1", "C0123456789");
+
+      const count = await manager.cleanupExpiredSessions();
+
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("getActiveSessionCount", () => {
+    it("returns 0 when no sessions", async () => {
+      const manager = createManager();
+
+      expect(await manager.getActiveSessionCount()).toBe(0);
+    });
+
+    it("counts active sessions", async () => {
+      const manager = createManager();
+
+      await manager.getOrCreateSession("thread-1", "C0123456789");
+      await manager.getOrCreateSession("thread-2", "C0123456789");
+
+      expect(await manager.getActiveSessionCount()).toBe(2);
+    });
+  });
+
+  describe("persistence", () => {
+    it("persists state to YAML file", async () => {
+      const manager = createManager();
+
+      await manager.getOrCreateSession("1707930000.123456", "C0123456789");
+
+      const filePath = join(
+        tempDir,
+        "slack-sessions",
+        "test-agent.yaml"
+      );
+      const content = await readFile(filePath, "utf-8");
+
+      expect(content).toContain("version: 1");
+      expect(content).toContain("agentName: test-agent");
+      expect(content).toContain("1707930000.123456");
+    });
+
+    it("survives recreation with same state dir", async () => {
+      const manager1 = createManager();
+      const result1 = await manager1.getOrCreateSession(
+        "1707930000.123456",
+        "C0123456789"
+      );
+
+      // Create new manager pointing to same dir
+      const manager2 = createManager();
+      const result2 = await manager2.getOrCreateSession(
+        "1707930000.123456",
+        "C0123456789"
+      );
+
+      expect(result2.isNew).toBe(false);
+      expect(result2.sessionId).toBe(result1.sessionId);
+    });
+  });
+});
+
+describe("Session manager types", () => {
+  describe("createInitialSessionState", () => {
+    it("creates state with empty threads", () => {
+      const state = createInitialSessionState("my-agent");
+
+      expect(state.version).toBe(1);
+      expect(state.agentName).toBe("my-agent");
+      expect(state.threads).toEqual({});
+    });
+  });
+
+  describe("createThreadSession", () => {
+    it("creates thread session", () => {
+      const session = createThreadSession("session-123", "C0123456789");
+
+      expect(session.sessionId).toBe("session-123");
+      expect(session.channelId).toBe("C0123456789");
+      expect(session.lastMessageAt).toBeDefined();
+    });
+  });
+});
+
+describe("Session manager errors", () => {
+  it("SessionManagerError has correct properties", () => {
+    const error = new SessionManagerError(
+      "test error",
+      SessionErrorCode.STATE_READ_FAILED,
+      "test-agent"
+    );
+
+    expect(error.message).toBe("test error");
+    expect(error.code).toBe(SessionErrorCode.STATE_READ_FAILED);
+    expect(error.agentName).toBe("test-agent");
+    expect(error.name).toBe("SessionManagerError");
+  });
+
+  it("SessionStateReadError has formatted message", () => {
+    const error = new SessionStateReadError("test-agent", "/path/to/state");
+
+    expect(error.message).toContain("test-agent");
+    expect(error.message).toContain("/path/to/state");
+    expect(error.code).toBe(SessionErrorCode.STATE_READ_FAILED);
+  });
+
+  it("SessionStateWriteError has formatted message", () => {
+    const error = new SessionStateWriteError("test-agent", "/path/to/state");
+
+    expect(error.message).toContain("test-agent");
+    expect(error.code).toBe(SessionErrorCode.STATE_WRITE_FAILED);
+  });
+
+  it("SessionDirectoryCreateError has formatted message", () => {
+    const error = new SessionDirectoryCreateError("test-agent", "/path/to/dir");
+
+    expect(error.message).toContain("test-agent");
+    expect(error.code).toBe(SessionErrorCode.DIRECTORY_CREATE_FAILED);
+  });
+});

--- a/packages/slack/src/commands/command-handler.ts
+++ b/packages/slack/src/commands/command-handler.ts
@@ -1,0 +1,157 @@
+/**
+ * Command handler for Slack message prefix commands
+ *
+ * Handles !command style messages for MVP simplicity
+ * (vs Slack slash commands which require URL verification).
+ */
+
+import type { SlackConnectorLogger, ISlackSessionManager } from "../types.js";
+import type { SlackConnectorState } from "../types.js";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Context passed to command handlers
+ */
+export interface CommandContext {
+  /** Name of the agent handling this command */
+  agentName: string;
+
+  /** Thread timestamp */
+  threadTs: string;
+
+  /** Channel ID */
+  channelId: string;
+
+  /** User who sent the command */
+  userId: string;
+
+  /** Function to reply in the thread */
+  reply: (content: string) => Promise<void>;
+
+  /** Session manager for the agent */
+  sessionManager: ISlackSessionManager;
+
+  /** Current connector state */
+  connectorState: SlackConnectorState;
+}
+
+/**
+ * A prefix command definition
+ */
+export interface PrefixCommand {
+  /** Command name (without ! prefix) */
+  name: string;
+
+  /** Description of the command */
+  description: string;
+
+  /** Execute the command */
+  execute(context: CommandContext): Promise<void>;
+}
+
+/**
+ * Options for CommandHandler
+ */
+export interface CommandHandlerOptions {
+  /** Logger instance */
+  logger?: SlackConnectorLogger;
+}
+
+// =============================================================================
+// Command Handler
+// =============================================================================
+
+/**
+ * CommandHandler manages message prefix commands for Slack
+ *
+ * Commands are triggered by messages starting with `!` (e.g., `!reset`, `!status`)
+ */
+export class CommandHandler {
+  private commands: Map<string, PrefixCommand> = new Map();
+  private readonly logger: SlackConnectorLogger;
+
+  constructor(options: CommandHandlerOptions = {}) {
+    this.logger = options.logger ?? {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+  }
+
+  /**
+   * Register a command
+   */
+  registerCommand(command: PrefixCommand): void {
+    this.commands.set(command.name.toLowerCase(), command);
+  }
+
+  /**
+   * Check if a message is a command
+   */
+  isCommand(text: string): boolean {
+    const trimmed = text.trim();
+    if (!trimmed.startsWith("!")) {
+      return false;
+    }
+
+    const commandName = trimmed.slice(1).split(/\s+/)[0].toLowerCase();
+    return this.commands.has(commandName);
+  }
+
+  /**
+   * Execute a command from message text
+   *
+   * @returns true if a command was executed, false otherwise
+   */
+  async executeCommand(
+    text: string,
+    context: CommandContext
+  ): Promise<boolean> {
+    const trimmed = text.trim();
+    if (!trimmed.startsWith("!")) {
+      return false;
+    }
+
+    const commandName = trimmed.slice(1).split(/\s+/)[0].toLowerCase();
+    const command = this.commands.get(commandName);
+
+    if (!command) {
+      return false;
+    }
+
+    this.logger.info(`Executing command: !${commandName}`, {
+      agentName: context.agentName,
+      threadTs: context.threadTs,
+    });
+
+    try {
+      await command.execute(context);
+      return true;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      this.logger.error(`Command !${commandName} failed: ${errorMessage}`);
+
+      try {
+        await context.reply(
+          `An error occurred while executing \`!${commandName}\`. Please try again.`
+        );
+      } catch {
+        // Ignore reply error
+      }
+
+      return true; // Command was attempted, even if it failed
+    }
+  }
+
+  /**
+   * Get all registered commands
+   */
+  getCommands(): PrefixCommand[] {
+    return Array.from(this.commands.values());
+  }
+}

--- a/packages/slack/src/commands/help.ts
+++ b/packages/slack/src/commands/help.ts
@@ -1,0 +1,27 @@
+/**
+ * !help command — Show available commands
+ */
+
+import type { PrefixCommand, CommandContext } from "./command-handler.js";
+
+export const helpCommand: PrefixCommand = {
+  name: "help",
+  description: "Show available commands",
+
+  async execute(context: CommandContext): Promise<void> {
+    const { agentName, reply } = context;
+
+    const helpMessage = `*${agentName} Bot Commands*
+
+\`!help\` — Show this help message
+\`!status\` — Show agent status and session info
+\`!reset\` — Clear conversation context (start fresh session)
+
+*Interacting with the bot:*
+\u2022 Mention the bot in a configured channel to start a conversation
+\u2022 Reply in the thread to continue the conversation
+\u2022 Each thread is a separate conversation with its own context`;
+
+    await reply(helpMessage);
+  },
+};

--- a/packages/slack/src/commands/index.ts
+++ b/packages/slack/src/commands/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Commands module for Slack
+ *
+ * Provides message prefix command handling.
+ */
+
+export { CommandHandler } from "./command-handler.js";
+
+export type {
+  CommandContext,
+  PrefixCommand,
+  CommandHandlerOptions,
+} from "./command-handler.js";
+
+export { helpCommand } from "./help.js";
+export { resetCommand } from "./reset.js";
+export { statusCommand } from "./status.js";

--- a/packages/slack/src/commands/reset.ts
+++ b/packages/slack/src/commands/reset.ts
@@ -1,0 +1,24 @@
+/**
+ * !reset command — Clear session for current thread
+ */
+
+import type { PrefixCommand, CommandContext } from "./command-handler.js";
+
+export const resetCommand: PrefixCommand = {
+  name: "reset",
+  description: "Clear conversation context (start fresh session)",
+
+  async execute(context: CommandContext): Promise<void> {
+    const { threadTs, sessionManager, reply } = context;
+
+    const cleared = await sessionManager.clearSession(threadTs);
+
+    if (cleared) {
+      await reply(
+        "Session cleared. The next message will start a fresh conversation."
+      );
+    } else {
+      await reply("No active session in this thread.");
+    }
+  },
+};

--- a/packages/slack/src/commands/status.ts
+++ b/packages/slack/src/commands/status.ts
@@ -1,0 +1,110 @@
+/**
+ * !status command — Show agent status and connection info
+ */
+
+import type { PrefixCommand, CommandContext } from "./command-handler.js";
+
+/**
+ * Format a timestamp for display
+ */
+function formatTimestamp(isoString: string | null): string {
+  if (!isoString) {
+    return "N/A";
+  }
+  const date = new Date(isoString);
+  return date.toLocaleString();
+}
+
+/**
+ * Format duration since a timestamp
+ */
+function formatDuration(isoString: string | null): string {
+  if (!isoString) {
+    return "N/A";
+  }
+  const startTime = new Date(isoString).getTime();
+  const now = Date.now();
+  const durationMs = now - startTime;
+
+  const seconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `${days}d ${hours % 24}h`;
+  }
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  return `${seconds}s`;
+}
+
+/**
+ * Get status emoji based on connection status
+ */
+function getStatusEmoji(status: string): string {
+  switch (status) {
+    case "connected":
+      return "\u{1F7E2}"; // Green circle
+    case "connecting":
+    case "reconnecting":
+      return "\u{1F7E1}"; // Yellow circle
+    case "disconnected":
+    case "disconnecting":
+      return "\u26AA"; // White circle
+    case "error":
+      return "\u{1F534}"; // Red circle
+    default:
+      return "\u2753"; // Question mark
+  }
+}
+
+export const statusCommand: PrefixCommand = {
+  name: "status",
+  description: "Show agent status and connection info",
+
+  async execute(context: CommandContext): Promise<void> {
+    const { agentName, threadTs, connectorState, sessionManager, reply } =
+      context;
+
+    // Get session info for this thread
+    const session = await sessionManager.getSession(threadTs);
+
+    // Build status message using Slack mrkdwn
+    const statusEmoji = getStatusEmoji(connectorState.status);
+    const botUsername = connectorState.botUser?.username ?? "Unknown";
+
+    let statusMessage = `*${agentName} Status*\n\n`;
+    statusMessage += `${statusEmoji} *Connection:* ${connectorState.status}\n`;
+    statusMessage += `*Bot:* ${botUsername}`;
+
+    if (connectorState.connectedAt) {
+      statusMessage += `\n*Connected:* ${formatTimestamp(connectorState.connectedAt)}`;
+      statusMessage += `\n*Uptime:* ${formatDuration(connectorState.connectedAt)}`;
+    }
+
+    if (connectorState.reconnectAttempts > 0) {
+      statusMessage += `\n*Reconnect Attempts:* ${connectorState.reconnectAttempts}`;
+    }
+
+    if (connectorState.lastError) {
+      statusMessage += `\n*Last Error:* ${connectorState.lastError}`;
+    }
+
+    // Session info
+    statusMessage += `\n\n*Session Info*`;
+    if (session) {
+      statusMessage += `\n*Session ID:* \`${session.sessionId.substring(0, 20)}...\``;
+      statusMessage += `\n*Last Activity:* ${formatTimestamp(session.lastMessageAt)}`;
+      statusMessage += `\n*Session Age:* ${formatDuration(session.lastMessageAt)}`;
+    } else {
+      statusMessage += `\nNo active session in this thread.`;
+    }
+
+    await reply(statusMessage);
+  },
+};

--- a/packages/slack/src/error-handler.ts
+++ b/packages/slack/src/error-handler.ts
@@ -1,0 +1,154 @@
+/**
+ * Error handling utilities for the Slack connector
+ *
+ * Provides error classification, user-friendly messages,
+ * and retry logic for Slack API operations.
+ */
+
+import type { SlackConnectorLogger } from "./types.js";
+
+// =============================================================================
+// Error Classification
+// =============================================================================
+
+/**
+ * Error categories for classification
+ */
+export enum ErrorCategory {
+  /** Authentication/authorization errors */
+  AUTH = "auth",
+  /** Rate limiting errors */
+  RATE_LIMIT = "rate_limit",
+  /** Network errors */
+  NETWORK = "network",
+  /** Slack API errors */
+  API = "api",
+  /** Internal errors */
+  INTERNAL = "internal",
+  /** Unknown errors */
+  UNKNOWN = "unknown",
+}
+
+/**
+ * Classified error with category and user-facing message
+ */
+export interface ClassifiedError {
+  category: ErrorCategory;
+  userMessage: string;
+  isRetryable: boolean;
+  originalError: Error;
+}
+
+/**
+ * User-friendly error messages
+ */
+export const USER_ERROR_MESSAGES: Record<string, string> = {
+  auth: "I'm having trouble authenticating with Slack. Please check the bot configuration.",
+  rate_limit: "I'm being rate limited by Slack. Please try again in a moment.",
+  network: "I'm having trouble connecting to Slack. Please try again later.",
+  api: "Something went wrong with the Slack API. Please try again.",
+  internal: "An internal error occurred. Please try again or use `!reset` to start a new session.",
+  unknown: "An unexpected error occurred. Please try again.",
+};
+
+/**
+ * Classify an error for appropriate handling
+ */
+export function classifyError(error: Error): ClassifiedError {
+  const message = error.message.toLowerCase();
+
+  if (message.includes("invalid_auth") || message.includes("token")) {
+    return {
+      category: ErrorCategory.AUTH,
+      userMessage: USER_ERROR_MESSAGES.auth,
+      isRetryable: false,
+      originalError: error,
+    };
+  }
+
+  if (message.includes("rate_limit") || message.includes("ratelimited")) {
+    return {
+      category: ErrorCategory.RATE_LIMIT,
+      userMessage: USER_ERROR_MESSAGES.rate_limit,
+      isRetryable: true,
+      originalError: error,
+    };
+  }
+
+  if (
+    message.includes("econnrefused") ||
+    message.includes("enotfound") ||
+    message.includes("timeout")
+  ) {
+    return {
+      category: ErrorCategory.NETWORK,
+      userMessage: USER_ERROR_MESSAGES.network,
+      isRetryable: true,
+      originalError: error,
+    };
+  }
+
+  if (message.includes("slack") || message.includes("api")) {
+    return {
+      category: ErrorCategory.API,
+      userMessage: USER_ERROR_MESSAGES.api,
+      isRetryable: true,
+      originalError: error,
+    };
+  }
+
+  return {
+    category: ErrorCategory.UNKNOWN,
+    userMessage: USER_ERROR_MESSAGES.unknown,
+    isRetryable: false,
+    originalError: error,
+  };
+}
+
+// =============================================================================
+// Safe Execution
+// =============================================================================
+
+/**
+ * Execute a function safely, catching and logging errors
+ */
+export async function safeExecute<T>(
+  fn: () => Promise<T>,
+  logger: SlackConnectorLogger,
+  context: string
+): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : String(error);
+    logger.error(`Error in ${context}: ${errorMessage}`);
+    return undefined;
+  }
+}
+
+/**
+ * Execute a function safely and reply with error message on failure
+ */
+export async function safeExecuteWithReply(
+  fn: () => Promise<void>,
+  reply: (content: string) => Promise<void>,
+  logger: SlackConnectorLogger,
+  context: string
+): Promise<void> {
+  try {
+    await fn();
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    const classified = classifyError(err);
+    logger.error(`Error in ${context}: ${err.message}`);
+
+    try {
+      await reply(classified.userMessage);
+    } catch (replyError) {
+      logger.error(
+        `Failed to send error reply: ${(replyError as Error).message}`
+      );
+    }
+  }
+}

--- a/packages/slack/src/errors.ts
+++ b/packages/slack/src/errors.ts
@@ -1,0 +1,92 @@
+/**
+ * Error classes for the Slack connector
+ *
+ * Provides typed errors for Slack connection and message handling failures.
+ */
+
+/**
+ * Error codes for Slack connector operations
+ */
+export enum SlackErrorCode {
+  CONNECTION_FAILED = "SLACK_CONNECTION_FAILED",
+  ALREADY_CONNECTED = "SLACK_ALREADY_CONNECTED",
+  MISSING_TOKEN = "SLACK_MISSING_TOKEN",
+  INVALID_TOKEN = "SLACK_INVALID_TOKEN",
+  MESSAGE_SEND_FAILED = "SLACK_MESSAGE_SEND_FAILED",
+  SOCKET_MODE_ERROR = "SLACK_SOCKET_MODE_ERROR",
+}
+
+/**
+ * Base error class for Slack connector operations
+ */
+export class SlackConnectorError extends Error {
+  public readonly code: SlackErrorCode;
+
+  constructor(
+    message: string,
+    code: SlackErrorCode,
+    options?: { cause?: Error }
+  ) {
+    super(message, options);
+    this.name = "SlackConnectorError";
+    this.code = code;
+  }
+}
+
+/**
+ * Error thrown when connection to Slack fails
+ */
+export class SlackConnectionError extends SlackConnectorError {
+  constructor(message: string, options?: { cause?: Error }) {
+    super(message, SlackErrorCode.CONNECTION_FAILED, options);
+    this.name = "SlackConnectionError";
+  }
+}
+
+/**
+ * Error thrown when attempting to connect while already connected
+ */
+export class AlreadyConnectedError extends SlackConnectorError {
+  constructor() {
+    super(
+      "Slack connector is already connected",
+      SlackErrorCode.ALREADY_CONNECTED
+    );
+    this.name = "AlreadyConnectedError";
+  }
+}
+
+/**
+ * Error thrown when bot or app token is missing
+ */
+export class MissingTokenError extends SlackConnectorError {
+  public readonly tokenType: "bot" | "app";
+
+  constructor(tokenType: "bot" | "app", envVar: string) {
+    super(
+      `Slack ${tokenType} token not found in environment variable '${envVar}'`,
+      SlackErrorCode.MISSING_TOKEN
+    );
+    this.name = "MissingTokenError";
+    this.tokenType = tokenType;
+  }
+}
+
+/**
+ * Error thrown when a token is invalid
+ */
+export class InvalidTokenError extends SlackConnectorError {
+  constructor(message: string, options?: { cause?: Error }) {
+    super(message, SlackErrorCode.INVALID_TOKEN, options);
+    this.name = "InvalidTokenError";
+  }
+}
+
+/**
+ * Type guard to check if an error is a SlackConnectorError
+ */
+export function isSlackConnectorError(
+  error: unknown
+): error is SlackConnectorError {
+  return error instanceof SlackConnectorError;
+}

--- a/packages/slack/src/formatting.ts
+++ b/packages/slack/src/formatting.ts
@@ -1,0 +1,262 @@
+/**
+ * Message formatting utilities for Slack
+ *
+ * Provides utilities for:
+ * - Converting standard markdown to Slack's mrkdwn format
+ * - Splitting long messages to fit Slack's practical limit
+ * - Creating context attachments with color coding
+ */
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Slack's practical maximum message length
+ *
+ * Hard limit is ~40K, but messages above ~4K become unwieldy in threads.
+ */
+export const SLACK_MAX_MESSAGE_LENGTH = 4000;
+
+/**
+ * Minimum chunk size when splitting messages
+ */
+export const MIN_CHUNK_SIZE = 100;
+
+/**
+ * Default delay between sending split messages (in milliseconds)
+ */
+export const DEFAULT_MESSAGE_DELAY_MS = 500;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Options for splitting messages
+ */
+export interface MessageSplitOptions {
+  maxLength?: number;
+  preserveBoundaries?: boolean;
+  splitPoints?: string[];
+}
+
+/**
+ * Result from splitting a message
+ */
+export interface SplitResult {
+  chunks: string[];
+  wasSplit: boolean;
+  originalLength: number;
+}
+
+/**
+ * Context attachment for Slack messages
+ */
+export interface ContextAttachment {
+  footer: string;
+  color: string;
+}
+
+// =============================================================================
+// Markdown to mrkdwn Conversion
+// =============================================================================
+
+/**
+ * Convert standard markdown to Slack's mrkdwn format
+ *
+ * Conversions:
+ * - **bold** → *bold*
+ * - [text](url) → <url|text>
+ * - Code blocks: backticks work the same in both formats
+ * - _italic_ stays _italic_ (same in mrkdwn)
+ */
+export function markdownToMrkdwn(text: string): string {
+  let result = text;
+
+  // Convert bold: **text** → *text*
+  // Be careful not to convert content inside code blocks
+  result = convertOutsideCodeBlocks(result, (segment) => {
+    return segment.replace(/\*\*(.+?)\*\*/g, "*$1*");
+  });
+
+  // Convert links: [text](url) → <url|text>
+  result = convertOutsideCodeBlocks(result, (segment) => {
+    return segment.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>");
+  });
+
+  return result;
+}
+
+/**
+ * Apply a transformation function only to text segments outside code blocks
+ */
+function convertOutsideCodeBlocks(
+  text: string,
+  transform: (segment: string) => string
+): string {
+  // Split on code blocks (``` ... ```)
+  const parts = text.split(/(```[\s\S]*?```|`[^`]+`)/);
+
+  return parts
+    .map((part, index) => {
+      // Odd indices are code blocks — don't transform
+      if (index % 2 === 1) {
+        return part;
+      }
+      return transform(part);
+    })
+    .join("");
+}
+
+// =============================================================================
+// Message Splitting
+// =============================================================================
+
+const DEFAULT_SPLIT_POINTS = ["\n\n", "\n", ". ", "! ", "? ", ", ", " "];
+
+/**
+ * Find the best split point within a text chunk
+ */
+export function findSplitPoint(
+  text: string,
+  maxLength: number,
+  splitPoints: string[] = DEFAULT_SPLIT_POINTS
+): number {
+  if (text.length <= maxLength) {
+    return text.length;
+  }
+
+  for (const splitPoint of splitPoints) {
+    const searchText = text.slice(0, maxLength);
+    const lastIndex = searchText.lastIndexOf(splitPoint);
+
+    if (lastIndex > MIN_CHUNK_SIZE) {
+      return lastIndex + splitPoint.length;
+    }
+  }
+
+  const hardSplitIndex = text.lastIndexOf(" ", maxLength);
+  if (hardSplitIndex > MIN_CHUNK_SIZE) {
+    return hardSplitIndex + 1;
+  }
+
+  return maxLength;
+}
+
+/**
+ * Split a message into chunks that fit Slack's message length limit
+ */
+export function splitMessage(
+  content: string,
+  options: MessageSplitOptions = {}
+): SplitResult {
+  const {
+    maxLength = SLACK_MAX_MESSAGE_LENGTH,
+    preserveBoundaries = true,
+    splitPoints = DEFAULT_SPLIT_POINTS,
+  } = options;
+
+  const originalLength = content.length;
+
+  if (content.length <= maxLength) {
+    return {
+      chunks: [content],
+      wasSplit: false,
+      originalLength,
+    };
+  }
+
+  const chunks: string[] = [];
+  let remaining = content;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining.trim());
+      break;
+    }
+
+    let splitIndex: number;
+    if (preserveBoundaries) {
+      splitIndex = findSplitPoint(remaining, maxLength, splitPoints);
+    } else {
+      splitIndex = maxLength;
+    }
+
+    const chunk = remaining.slice(0, splitIndex).trim();
+    if (chunk.length > 0) {
+      chunks.push(chunk);
+    }
+
+    remaining = remaining.slice(splitIndex).trim();
+  }
+
+  return {
+    chunks,
+    wasSplit: chunks.length > 1,
+    originalLength,
+  };
+}
+
+/**
+ * Check if a message needs to be split
+ */
+export function needsSplit(
+  content: string,
+  maxLength: number = SLACK_MAX_MESSAGE_LENGTH
+): boolean {
+  return content.length > maxLength;
+}
+
+// =============================================================================
+// Context Attachments
+// =============================================================================
+
+/**
+ * Create a context attachment for Slack messages
+ *
+ * Used to display context usage information in a color-coded footer.
+ */
+export function createContextAttachment(
+  contextPercent: number
+): ContextAttachment {
+  return {
+    footer: `Context: ${Math.round(contextPercent)}% remaining`,
+    color: contextPercent < 20 ? "#ff0000" : "#36a64f",
+  };
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Truncate a message to fit within the max length, adding an ellipsis
+ */
+export function truncateMessage(
+  content: string,
+  maxLength: number = SLACK_MAX_MESSAGE_LENGTH,
+  ellipsis: string = "..."
+): string {
+  if (content.length <= maxLength) {
+    return content;
+  }
+
+  const truncatedLength = maxLength - ellipsis.length;
+  return content.slice(0, truncatedLength) + ellipsis;
+}
+
+/**
+ * Format code as a Slack code block
+ */
+export function formatCodeBlock(code: string, language?: string): string {
+  const langTag = language ?? "";
+  return `\`\`\`${langTag}\n${code}\n\`\`\``;
+}
+
+/**
+ * Escape Slack mrkdwn characters in text
+ */
+export function escapeMrkdwn(text: string): string {
+  return text.replace(/([*_~`|\\<>])/g, "\\$1");
+}

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -1,0 +1,135 @@
+/**
+ * @herdctl/slack
+ *
+ * Slack connector for herdctl — Autonomous Agent Fleet Management for Claude Code
+ *
+ * This package provides:
+ * - SlackConnector class for connecting agents to Slack via Socket Mode
+ * - Single Bolt App shared across all agents (one bot token per workspace)
+ * - Channel→agent routing for multi-agent support
+ * - Thread-based conversation management
+ * - SessionManager for per-thread conversation context
+ */
+
+export const VERSION = "0.1.0";
+
+// Main connector class
+export { SlackConnector } from "./slack-connector.js";
+
+// Logger
+export {
+  createSlackLogger,
+  createDefaultSlackLogger,
+} from "./logger.js";
+
+export type {
+  SlackLogLevel,
+  SlackLoggerOptions,
+} from "./logger.js";
+
+// Session manager
+export { SessionManager } from "./session-manager/index.js";
+
+// Types
+export type {
+  SlackConnectorOptions,
+  SlackConnectorState,
+  SlackConnectionStatus,
+  SlackConnectorLogger,
+  SlackMessageEvent,
+  SlackErrorEvent,
+  ISlackConnector,
+  ISlackSessionManager,
+  SlackConnectorEventMap,
+  SlackConnectorEventName,
+  SlackConnectorEventPayload,
+} from "./types.js";
+
+// Session manager types
+export type {
+  SessionManagerOptions,
+  SessionManagerLogger,
+  ISessionManager,
+  SessionResult,
+  ThreadSession,
+  SlackSessionState,
+} from "./session-manager/index.js";
+
+export {
+  SlackSessionStateSchema,
+  ThreadSessionSchema,
+  createInitialSessionState,
+  createThreadSession,
+} from "./session-manager/index.js";
+
+// Errors
+export {
+  SlackErrorCode,
+  SlackConnectorError,
+  SlackConnectionError,
+  AlreadyConnectedError,
+  MissingTokenError,
+  InvalidTokenError,
+  isSlackConnectorError,
+} from "./errors.js";
+
+// Error handling utilities
+export {
+  USER_ERROR_MESSAGES,
+  ErrorCategory,
+  classifyError,
+  safeExecute,
+  safeExecuteWithReply,
+} from "./error-handler.js";
+
+export type { ClassifiedError } from "./error-handler.js";
+
+// Session manager errors
+export {
+  SessionErrorCode,
+  SessionManagerError,
+  SessionStateReadError,
+  SessionStateWriteError,
+  SessionDirectoryCreateError,
+  isSessionManagerError,
+} from "./session-manager/index.js";
+
+// Commands
+export { CommandHandler } from "./commands/index.js";
+export { helpCommand, resetCommand, statusCommand } from "./commands/index.js";
+
+export type {
+  CommandContext,
+  PrefixCommand,
+  CommandHandlerOptions,
+} from "./commands/index.js";
+
+// Message handling
+export {
+  isBotMentioned,
+  stripBotMention,
+  stripMentions,
+  shouldProcessMessage,
+  processMessage,
+} from "./message-handler.js";
+
+// Formatting utilities
+export {
+  SLACK_MAX_MESSAGE_LENGTH,
+  DEFAULT_MESSAGE_DELAY_MS,
+  MIN_CHUNK_SIZE,
+  findSplitPoint,
+  splitMessage,
+  needsSplit,
+  truncateMessage,
+  formatCodeBlock,
+  escapeMrkdwn,
+  markdownToMrkdwn,
+  createContextAttachment,
+} from "./formatting.js";
+
+export type {
+  MessageSplitOptions,
+  SplitResult,
+  ContextAttachment,
+} from "./formatting.js";

--- a/packages/slack/src/logger.ts
+++ b/packages/slack/src/logger.ts
@@ -1,0 +1,69 @@
+/**
+ * Logger utilities for the Slack connector
+ *
+ * Provides configurable logging with level-based filtering.
+ */
+
+import type { SlackConnectorLogger } from "./types.js";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Log level for Slack connector operations
+ */
+export type SlackLogLevel = "minimal" | "standard" | "verbose";
+
+/**
+ * Options for creating a Slack logger
+ */
+export interface SlackLoggerOptions {
+  /** Prefix for log messages */
+  prefix: string;
+
+  /** Log level */
+  logLevel?: SlackLogLevel;
+}
+
+// =============================================================================
+// Logger Factory
+// =============================================================================
+
+/**
+ * Create a logger with the specified configuration
+ */
+export function createSlackLogger(
+  options: SlackLoggerOptions
+): SlackConnectorLogger {
+  const { prefix, logLevel = "standard" } = options;
+
+  return {
+    debug: (msg: string, data?: Record<string, unknown>) => {
+      if (logLevel === "verbose") {
+        console.debug(`${prefix} ${msg}`, data ? JSON.stringify(data) : "");
+      }
+    },
+    info: (msg: string, data?: Record<string, unknown>) => {
+      if (logLevel !== "minimal") {
+        console.info(`${prefix} ${msg}`, data ? JSON.stringify(data) : "");
+      }
+    },
+    warn: (msg: string, data?: Record<string, unknown>) => {
+      console.warn(`${prefix} ${msg}`, data ? JSON.stringify(data) : "");
+    },
+    error: (msg: string, data?: Record<string, unknown>) => {
+      console.error(`${prefix} ${msg}`, data ? JSON.stringify(data) : "");
+    },
+  };
+}
+
+/**
+ * Create a default logger for Slack operations
+ */
+export function createDefaultSlackLogger(
+  agentName?: string
+): SlackConnectorLogger {
+  const prefix = agentName ? `[slack:${agentName}]` : "[slack]";
+  return createSlackLogger({ prefix });
+}

--- a/packages/slack/src/message-handler.ts
+++ b/packages/slack/src/message-handler.ts
@@ -1,0 +1,103 @@
+/**
+ * Message handling utilities for Slack
+ *
+ * Provides utilities for:
+ * - Detecting bot mentions in messages
+ * - Stripping bot mention from message text
+ * - Determining if a message should be processed
+ */
+
+// =============================================================================
+// Mention Detection
+// =============================================================================
+
+/**
+ * Check if the bot was mentioned in a message
+ *
+ * Slack format for mentions: <@U1234567890>
+ *
+ * @param text - Message text
+ * @param botUserId - Bot's user ID
+ * @returns true if the bot was mentioned
+ */
+export function isBotMentioned(text: string, botUserId: string): boolean {
+  return text.includes(`<@${botUserId}>`);
+}
+
+/**
+ * Strip the bot mention from message text
+ *
+ * Removes <@BOTID> and trims whitespace.
+ *
+ * @param text - Message text
+ * @param botUserId - Bot's user ID
+ * @returns Cleaned message text
+ */
+export function stripBotMention(text: string, botUserId: string): string {
+  return text.replace(new RegExp(`<@${botUserId}>`, "g"), "").trim();
+}
+
+/**
+ * Strip all user mentions from message text
+ *
+ * @param text - Message text
+ * @returns Text with all mentions removed
+ */
+export function stripMentions(text: string): string {
+  return text.replace(/<@[A-Z0-9]+>/g, "").trim();
+}
+
+// =============================================================================
+// Message Processing
+// =============================================================================
+
+/**
+ * Determine if a message should be processed
+ *
+ * Rules:
+ * - Ignore messages from bots
+ * - Process app_mention events (always a mention)
+ * - Process thread replies in active conversation threads
+ *
+ * @param event - Slack event data
+ * @param botUserId - Bot's user ID
+ * @returns true if the message should be processed
+ */
+export function shouldProcessMessage(
+  event: {
+    bot_id?: string;
+    subtype?: string;
+    user?: string;
+    thread_ts?: string;
+  },
+  botUserId: string
+): boolean {
+  // Ignore bot messages
+  if (event.bot_id || event.subtype === "bot_message") {
+    return false;
+  }
+
+  // Ignore messages from the bot itself
+  if (event.user === botUserId) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Process a message event and extract the prompt
+ *
+ * @param text - Raw message text
+ * @param botUserId - Bot's user ID
+ * @returns Processed prompt text
+ */
+export function processMessage(text: string, botUserId: string): string {
+  // Strip the bot mention if present
+  let prompt = stripBotMention(text, botUserId);
+
+  // Trim whitespace
+  prompt = prompt.trim();
+
+  return prompt;
+}

--- a/packages/slack/src/session-manager/errors.ts
+++ b/packages/slack/src/session-manager/errors.ts
@@ -1,0 +1,112 @@
+/**
+ * Error classes for Slack session management
+ *
+ * Provides typed errors for session persistence and retrieval failures.
+ */
+
+/**
+ * Error codes for session manager operations
+ */
+export enum SessionErrorCode {
+  STATE_READ_FAILED = "SESSION_STATE_READ_FAILED",
+  STATE_WRITE_FAILED = "SESSION_STATE_WRITE_FAILED",
+  DIRECTORY_CREATE_FAILED = "SESSION_DIRECTORY_CREATE_FAILED",
+  SESSION_NOT_FOUND = "SESSION_NOT_FOUND",
+  SESSION_EXPIRED = "SESSION_EXPIRED",
+  INVALID_STATE = "SESSION_INVALID_STATE",
+}
+
+/**
+ * Base error class for session manager operations
+ */
+export class SessionManagerError extends Error {
+  public readonly code: SessionErrorCode;
+  public readonly agentName: string;
+
+  constructor(
+    message: string,
+    code: SessionErrorCode,
+    agentName: string,
+    options?: { cause?: Error }
+  ) {
+    super(message, options);
+    this.name = "SessionManagerError";
+    this.code = code;
+    this.agentName = agentName;
+  }
+}
+
+/**
+ * Error thrown when session state file cannot be read
+ */
+export class SessionStateReadError extends SessionManagerError {
+  public readonly path: string;
+
+  constructor(
+    agentName: string,
+    path: string,
+    options?: { cause?: Error }
+  ) {
+    super(
+      `Failed to read session state for agent '${agentName}' from '${path}'`,
+      SessionErrorCode.STATE_READ_FAILED,
+      agentName,
+      options
+    );
+    this.name = "SessionStateReadError";
+    this.path = path;
+  }
+}
+
+/**
+ * Error thrown when session state file cannot be written
+ */
+export class SessionStateWriteError extends SessionManagerError {
+  public readonly path: string;
+
+  constructor(
+    agentName: string,
+    path: string,
+    options?: { cause?: Error }
+  ) {
+    super(
+      `Failed to write session state for agent '${agentName}' to '${path}'`,
+      SessionErrorCode.STATE_WRITE_FAILED,
+      agentName,
+      options
+    );
+    this.name = "SessionStateWriteError";
+    this.path = path;
+  }
+}
+
+/**
+ * Error thrown when session directory cannot be created
+ */
+export class SessionDirectoryCreateError extends SessionManagerError {
+  public readonly path: string;
+
+  constructor(
+    agentName: string,
+    path: string,
+    options?: { cause?: Error }
+  ) {
+    super(
+      `Failed to create session directory for agent '${agentName}' at '${path}'`,
+      SessionErrorCode.DIRECTORY_CREATE_FAILED,
+      agentName,
+      options
+    );
+    this.name = "SessionDirectoryCreateError";
+    this.path = path;
+  }
+}
+
+/**
+ * Type guard to check if an error is a SessionManagerError
+ */
+export function isSessionManagerError(
+  error: unknown
+): error is SessionManagerError {
+  return error instanceof SessionManagerError;
+}

--- a/packages/slack/src/session-manager/index.ts
+++ b/packages/slack/src/session-manager/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Session manager module for Slack
+ *
+ * Provides per-thread session management for Claude conversations.
+ */
+
+export { SessionManager } from "./session-manager.js";
+
+export {
+  // Schemas
+  ThreadSessionSchema,
+  SlackSessionStateSchema,
+  // Types
+  type ThreadSession,
+  type SlackSessionState,
+  type SessionManagerLogger,
+  type SessionManagerOptions,
+  type SessionResult,
+  type ISessionManager,
+  // Factory functions
+  createInitialSessionState,
+  createThreadSession,
+} from "./types.js";
+
+export {
+  SessionErrorCode,
+  SessionManagerError,
+  SessionStateReadError,
+  SessionStateWriteError,
+  SessionDirectoryCreateError,
+  isSessionManagerError,
+} from "./errors.js";

--- a/packages/slack/src/session-manager/session-manager.ts
+++ b/packages/slack/src/session-manager/session-manager.ts
@@ -1,0 +1,417 @@
+/**
+ * Session manager for Slack thread conversations
+ *
+ * Provides per-thread session management for Claude conversations,
+ * enabling conversation context preservation across Slack threads.
+ *
+ * Sessions are stored at .herdctl/slack-sessions/<agent-name>.yaml
+ */
+
+import { mkdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import { stringify as stringifyYaml, parse as parseYaml } from "yaml";
+import { readFile, writeFile, rename, unlink } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import {
+  type SessionManagerOptions,
+  type SessionManagerLogger,
+  type ISessionManager,
+  type SessionResult,
+  type ThreadSession,
+  type SlackSessionState,
+  SlackSessionStateSchema,
+  createInitialSessionState,
+} from "./types.js";
+import {
+  SessionStateReadError,
+  SessionStateWriteError,
+  SessionDirectoryCreateError,
+} from "./errors.js";
+
+// =============================================================================
+// Default Logger
+// =============================================================================
+
+function createDefaultLogger(agentName: string): SessionManagerLogger {
+  const prefix = `[slack-session:${agentName}]`;
+  return {
+    debug: (msg, data) =>
+      console.debug(prefix, msg, data ? JSON.stringify(data) : ""),
+    info: (msg, data) =>
+      console.info(prefix, msg, data ? JSON.stringify(data) : ""),
+    warn: (msg, data) =>
+      console.warn(prefix, msg, data ? JSON.stringify(data) : ""),
+    error: (msg, data) =>
+      console.error(prefix, msg, data ? JSON.stringify(data) : ""),
+  };
+}
+
+// =============================================================================
+// Session Manager Implementation
+// =============================================================================
+
+/**
+ * SessionManager manages per-thread Claude sessions for a Slack agent.
+ *
+ * Each agent has its own SessionManager instance, storing session mappings
+ * in a YAML file at .herdctl/slack-sessions/<agent-name>.yaml
+ *
+ * Unlike Discord's SessionManager which keys by channelId,
+ * Slack's keys by threadTs (thread timestamp) since each conversation
+ * is a Slack thread.
+ */
+export class SessionManager implements ISessionManager {
+  public readonly agentName: string;
+
+  private readonly stateDir: string;
+  private readonly sessionExpiryHours: number;
+  private readonly logger: SessionManagerLogger;
+  private readonly stateFilePath: string;
+
+  // In-memory cache of session state
+  private state: SlackSessionState | null = null;
+
+  constructor(options: SessionManagerOptions) {
+    this.agentName = options.agentName;
+    this.stateDir = options.stateDir;
+    this.sessionExpiryHours = options.sessionExpiryHours ?? 24;
+    this.logger =
+      options.logger ?? createDefaultLogger(options.agentName);
+
+    // Compute state file path
+    this.stateFilePath = join(
+      this.stateDir,
+      "slack-sessions",
+      `${this.agentName}.yaml`
+    );
+  }
+
+  // ===========================================================================
+  // Public API
+  // ===========================================================================
+
+  /**
+   * Get or create a session for a thread
+   */
+  async getOrCreateSession(
+    threadTs: string,
+    channelId: string
+  ): Promise<SessionResult> {
+    const existingSession = await this.getSession(threadTs);
+
+    if (existingSession) {
+      this.logger.info("Resuming existing session", {
+        threadTs,
+        sessionId: existingSession.sessionId,
+      });
+      return {
+        sessionId: existingSession.sessionId,
+        isNew: false,
+      };
+    }
+
+    // Create new session
+    const sessionId = this.generateSessionId();
+    const state = await this.loadState();
+    const now = new Date().toISOString();
+
+    state.threads[threadTs] = {
+      sessionId,
+      lastMessageAt: now,
+      channelId,
+    };
+
+    await this.saveState(state);
+
+    this.logger.info("Created new session", { threadTs, channelId, sessionId });
+
+    return {
+      sessionId,
+      isNew: true,
+    };
+  }
+
+  /**
+   * Update the last message timestamp for a session
+   */
+  async touchSession(threadTs: string): Promise<void> {
+    const state = await this.loadState();
+    const session = state.threads[threadTs];
+
+    if (!session) {
+      this.logger.warn("Attempted to touch non-existent session", {
+        threadTs,
+      });
+      return;
+    }
+
+    session.lastMessageAt = new Date().toISOString();
+    await this.saveState(state);
+
+    this.logger.debug("Touched session", {
+      threadTs,
+      sessionId: session.sessionId,
+    });
+  }
+
+  /**
+   * Get an existing session without creating one
+   */
+  async getSession(threadTs: string): Promise<ThreadSession | null> {
+    const state = await this.loadState();
+    const session = state.threads[threadTs];
+
+    if (!session) {
+      return null;
+    }
+
+    // Check if session is expired
+    if (this.isSessionExpired(session)) {
+      this.logger.info("Session expired", {
+        threadTs,
+        sessionId: session.sessionId,
+        lastMessageAt: session.lastMessageAt,
+        expiryHours: this.sessionExpiryHours,
+      });
+      return null;
+    }
+
+    return session;
+  }
+
+  /**
+   * Store or update the session ID for a thread
+   */
+  async setSession(
+    threadTs: string,
+    sessionId: string,
+    channelId: string
+  ): Promise<void> {
+    const state = await this.loadState();
+    const now = new Date().toISOString();
+    const existingSession = state.threads[threadTs];
+
+    state.threads[threadTs] = {
+      sessionId,
+      lastMessageAt: now,
+      channelId,
+    };
+
+    await this.saveState(state);
+
+    if (existingSession) {
+      this.logger.info("Updated session", {
+        threadTs,
+        oldSessionId: existingSession.sessionId,
+        newSessionId: sessionId,
+      });
+    } else {
+      this.logger.info("Stored new session", { threadTs, sessionId });
+    }
+  }
+
+  /**
+   * Clear a specific session
+   */
+  async clearSession(threadTs: string): Promise<boolean> {
+    const state = await this.loadState();
+
+    if (!state.threads[threadTs]) {
+      return false;
+    }
+
+    const sessionId = state.threads[threadTs].sessionId;
+    delete state.threads[threadTs];
+    await this.saveState(state);
+
+    this.logger.info("Cleared session", { threadTs, sessionId });
+    return true;
+  }
+
+  /**
+   * Clean up all expired sessions
+   */
+  async cleanupExpiredSessions(): Promise<number> {
+    const state = await this.loadState();
+    const threadTsKeys = Object.keys(state.threads);
+    let cleanedUp = 0;
+
+    for (const threadTs of threadTsKeys) {
+      const session = state.threads[threadTs];
+      if (this.isSessionExpired(session)) {
+        this.logger.debug("Cleaning up expired session", {
+          threadTs,
+          sessionId: session.sessionId,
+          lastMessageAt: session.lastMessageAt,
+        });
+        delete state.threads[threadTs];
+        cleanedUp++;
+      }
+    }
+
+    if (cleanedUp > 0) {
+      await this.saveState(state);
+      this.logger.info("Cleaned up expired sessions", { count: cleanedUp });
+    }
+
+    return cleanedUp;
+  }
+
+  /**
+   * Get the count of active (non-expired) sessions
+   */
+  async getActiveSessionCount(): Promise<number> {
+    const state = await this.loadState();
+    let activeCount = 0;
+
+    for (const threadTs of Object.keys(state.threads)) {
+      const session = state.threads[threadTs];
+      if (!this.isSessionExpired(session)) {
+        activeCount++;
+      }
+    }
+
+    return activeCount;
+  }
+
+  // ===========================================================================
+  // Private Helpers
+  // ===========================================================================
+
+  private generateSessionId(): string {
+    return `slack-${this.agentName}-${randomUUID()}`;
+  }
+
+  private isSessionExpired(session: ThreadSession): boolean {
+    const lastMessageAt = new Date(session.lastMessageAt);
+    const now = new Date();
+    const expiryMs = this.sessionExpiryHours * 60 * 60 * 1000;
+    return now.getTime() - lastMessageAt.getTime() > expiryMs;
+  }
+
+  private async loadState(): Promise<SlackSessionState> {
+    if (this.state) {
+      return this.state;
+    }
+
+    let content: string;
+    try {
+      content = await readFile(this.stateFilePath, "utf-8");
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+
+      if (code === "ENOENT") {
+        this.state = createInitialSessionState(this.agentName);
+        return this.state;
+      }
+
+      throw new SessionStateReadError(this.agentName, this.stateFilePath, {
+        cause: error as Error,
+      });
+    }
+
+    if (content.trim() === "") {
+      this.state = createInitialSessionState(this.agentName);
+      return this.state;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = parseYaml(content);
+    } catch (error) {
+      this.logger.warn("Corrupted session state file, creating fresh state", {
+        error: (error as Error).message,
+      });
+      this.state = createInitialSessionState(this.agentName);
+      return this.state;
+    }
+
+    const validated = SlackSessionStateSchema.safeParse(parsed);
+    if (!validated.success) {
+      this.logger.warn("Corrupted session state file, creating fresh state", {
+        error: validated.error.message,
+      });
+      this.state = createInitialSessionState(this.agentName);
+      return this.state;
+    }
+
+    this.state = validated.data;
+    return this.state;
+  }
+
+  private async saveState(state: SlackSessionState): Promise<void> {
+    await this.ensureDirectoryExists();
+
+    this.state = state;
+
+    const yamlContent = stringifyYaml(state, { indent: 2, lineWidth: 120 });
+    const tempPath = this.generateTempPath(this.stateFilePath);
+
+    try {
+      await writeFile(tempPath, yamlContent, "utf-8");
+      await this.renameWithRetry(tempPath, this.stateFilePath);
+    } catch (error) {
+      try {
+        await unlink(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+
+      throw new SessionStateWriteError(this.agentName, this.stateFilePath, {
+        cause: error as Error,
+      });
+    }
+  }
+
+  private async ensureDirectoryExists(): Promise<void> {
+    const dir = dirname(this.stateFilePath);
+    try {
+      await mkdir(dir, { recursive: true });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") {
+        throw new SessionDirectoryCreateError(this.agentName, dir, {
+          cause: error as Error,
+        });
+      }
+    }
+  }
+
+  private generateTempPath(targetPath: string): string {
+    const dir = dirname(targetPath);
+    const random = randomBytes(8).toString("hex");
+    const filename = `${this.agentName}.yaml`;
+    return join(dir, `.${filename}.tmp.${random}`);
+  }
+
+  private async renameWithRetry(
+    oldPath: string,
+    newPath: string,
+    maxRetries = 3,
+    baseDelayMs = 50
+  ): Promise<void> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        await rename(oldPath, newPath);
+        return;
+      } catch (error) {
+        lastError = error as Error;
+        const code = (error as NodeJS.ErrnoException).code;
+
+        if (code !== "EACCES" && code !== "EPERM") {
+          throw error;
+        }
+
+        if (attempt < maxRetries) {
+          const delay = baseDelayMs * Math.pow(2, attempt);
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+      }
+    }
+
+    throw lastError;
+  }
+}

--- a/packages/slack/src/session-manager/types.ts
+++ b/packages/slack/src/session-manager/types.ts
@@ -1,0 +1,197 @@
+/**
+ * Type definitions for Slack session management
+ *
+ * Provides interfaces for per-thread session state tracking,
+ * enabling conversation context preservation across Slack threads.
+ */
+
+import { z } from "zod";
+
+// =============================================================================
+// Session Schema
+// =============================================================================
+
+/**
+ * Schema for individual thread session mapping
+ */
+export const ThreadSessionSchema = z.object({
+  /** Claude session ID for resuming conversations */
+  sessionId: z.string().min(1, "Session ID cannot be empty"),
+
+  /** ISO timestamp when last message was sent/received */
+  lastMessageAt: z.string().datetime({
+    message: "lastMessageAt must be a valid ISO datetime string",
+  }),
+
+  /** Channel ID where the thread exists */
+  channelId: z.string().min(1, "Channel ID cannot be empty"),
+});
+
+/**
+ * Schema for the entire agent's Slack session state file
+ *
+ * Stored at .herdctl/slack-sessions/<agent-name>.yaml
+ */
+export const SlackSessionStateSchema = z.object({
+  /** Version for future schema migrations */
+  version: z.literal(1),
+
+  /** Agent name this session state belongs to */
+  agentName: z.string().min(1, "Agent name cannot be empty"),
+
+  /** Map of thread timestamp to session info */
+  threads: z.record(z.string(), ThreadSessionSchema),
+});
+
+// =============================================================================
+// Type Exports
+// =============================================================================
+
+export type ThreadSession = z.infer<typeof ThreadSessionSchema>;
+export type SlackSessionState = z.infer<typeof SlackSessionStateSchema>;
+
+// =============================================================================
+// Session Manager Options
+// =============================================================================
+
+/**
+ * Logger interface for session manager operations
+ */
+export interface SessionManagerLogger {
+  debug(message: string, data?: Record<string, unknown>): void;
+  info(message: string, data?: Record<string, unknown>): void;
+  warn(message: string, data?: Record<string, unknown>): void;
+  error(message: string, data?: Record<string, unknown>): void;
+}
+
+/**
+ * Options for configuring the SessionManager
+ */
+export interface SessionManagerOptions {
+  /** Name of the agent this session manager is for */
+  agentName: string;
+
+  /** Root path for state storage (e.g., .herdctl) */
+  stateDir: string;
+
+  /** Session expiry timeout in hours (default: 24) */
+  sessionExpiryHours?: number;
+
+  /** Logger for session manager operations */
+  logger?: SessionManagerLogger;
+}
+
+// =============================================================================
+// Session Manager Interface
+// =============================================================================
+
+/**
+ * Result of getting or creating a session
+ */
+export interface SessionResult {
+  /** Claude session ID */
+  sessionId: string;
+
+  /** Whether this is a newly created session */
+  isNew: boolean;
+}
+
+/**
+ * Interface that all Slack session managers must implement
+ *
+ * Keyed by threadTs (unlike Discord which keys by channelId)
+ */
+export interface ISessionManager {
+  /**
+   * Get or create a session for a thread
+   *
+   * @param threadTs - Slack thread timestamp (conversation key)
+   * @param channelId - Channel where the thread exists
+   */
+  getOrCreateSession(
+    threadTs: string,
+    channelId: string
+  ): Promise<SessionResult>;
+
+  /**
+   * Update the last message timestamp for a session
+   *
+   * @param threadTs - Slack thread timestamp
+   */
+  touchSession(threadTs: string): Promise<void>;
+
+  /**
+   * Get an existing session without creating one
+   *
+   * @param threadTs - Slack thread timestamp
+   * @returns Session if it exists and is not expired, null otherwise
+   */
+  getSession(threadTs: string): Promise<ThreadSession | null>;
+
+  /**
+   * Store or update the session ID for a thread
+   *
+   * @param threadTs - Slack thread timestamp
+   * @param sessionId - The Claude Agent SDK session ID
+   * @param channelId - Channel where the thread exists
+   */
+  setSession(
+    threadTs: string,
+    sessionId: string,
+    channelId: string
+  ): Promise<void>;
+
+  /**
+   * Clear a specific session
+   *
+   * @param threadTs - Slack thread timestamp
+   * @returns true if cleared, false if it didn't exist
+   */
+  clearSession(threadTs: string): Promise<boolean>;
+
+  /**
+   * Clean up all expired sessions
+   *
+   * @returns Number of sessions cleaned up
+   */
+  cleanupExpiredSessions(): Promise<number>;
+
+  /**
+   * Get the count of active (non-expired) sessions
+   */
+  getActiveSessionCount(): Promise<number>;
+
+  /** Name of the agent this session manager is for */
+  readonly agentName: string;
+}
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+/**
+ * Create initial session state for a new agent
+ */
+export function createInitialSessionState(
+  agentName: string
+): SlackSessionState {
+  return {
+    version: 1,
+    agentName,
+    threads: {},
+  };
+}
+
+/**
+ * Create a new thread session
+ */
+export function createThreadSession(
+  sessionId: string,
+  channelId: string
+): ThreadSession {
+  return {
+    sessionId,
+    lastMessageAt: new Date().toISOString(),
+    channelId,
+  };
+}

--- a/packages/slack/src/slack-connector.ts
+++ b/packages/slack/src/slack-connector.ts
@@ -1,0 +1,422 @@
+/**
+ * Slack Connector
+ *
+ * Single Bolt App instance with channel→agent routing.
+ * Uses Socket Mode for connection (no public URL needed).
+ *
+ * Key design differences from Discord:
+ * - ONE connector shared across all agents (not N connectors)
+ * - Channel→agent routing via channelAgentMap
+ * - Thread-based conversations (threadTs as session key)
+ * - Hourglass emoji reaction as typing indicator
+ */
+
+import { EventEmitter } from "node:events";
+import type {
+  SlackConnectorOptions,
+  SlackConnectorState,
+  SlackConnectionStatus,
+  SlackConnectorLogger,
+  SlackMessageEvent,
+  ISlackConnector,
+  ISlackSessionManager,
+} from "./types.js";
+import {
+  shouldProcessMessage,
+  processMessage,
+  isBotMentioned,
+} from "./message-handler.js";
+import { AlreadyConnectedError, SlackConnectionError } from "./errors.js";
+import { createDefaultSlackLogger } from "./logger.js";
+
+// =============================================================================
+// Slack Connector Implementation
+// =============================================================================
+
+export class SlackConnector extends EventEmitter implements ISlackConnector {
+  private readonly botToken: string;
+  private readonly appToken: string;
+  private readonly channelAgentMap: Map<string, string>;
+  private readonly sessionManagers: Map<string, ISlackSessionManager>;
+  private readonly logger: SlackConnectorLogger;
+
+  // Bolt App instance (dynamically imported)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private app: any = null;
+
+  // Connection state
+  private status: SlackConnectionStatus = "disconnected";
+  private connectedAt: string | null = null;
+  private disconnectedAt: string | null = null;
+  private reconnectAttempts: number = 0;
+  private lastError: string | null = null;
+  private botUserId: string | null = null;
+  private botUsername: string | null = null;
+
+  // Message stats
+  private messagesReceived: number = 0;
+  private messagesSent: number = 0;
+  private messagesIgnored: number = 0;
+
+  // Track active threads (threadTs → agentName) for reply routing
+  private activeThreads: Map<string, string> = new Map();
+
+  constructor(options: SlackConnectorOptions) {
+    super();
+
+    this.botToken = options.botToken;
+    this.appToken = options.appToken;
+    this.channelAgentMap = options.channelAgentMap;
+    this.sessionManagers = options.sessionManagers;
+    this.logger = options.logger ?? createDefaultSlackLogger();
+  }
+
+  // ===========================================================================
+  // ISlackConnector Implementation
+  // ===========================================================================
+
+  async connect(): Promise<void> {
+    if (this.status === "connected" || this.status === "connecting") {
+      throw new AlreadyConnectedError();
+    }
+
+    this.status = "connecting";
+    this.logger.info("Connecting to Slack via Socket Mode...");
+
+    try {
+      // Dynamically import @slack/bolt
+      const { App } = await import("@slack/bolt");
+
+      this.app = new App({
+        token: this.botToken,
+        appToken: this.appToken,
+        socketMode: true,
+      });
+
+      // Register event handlers
+      this.registerEventHandlers();
+
+      // Start the app
+      await this.app.start();
+
+      // Get bot info
+      const authResult = await this.app.client.auth.test();
+      this.botUserId = authResult.user_id as string;
+      this.botUsername = authResult.user as string;
+
+      this.status = "connected";
+      this.connectedAt = new Date().toISOString();
+      this.disconnectedAt = null;
+      this.reconnectAttempts = 0;
+      this.lastError = null;
+
+      this.logger.info("Connected to Slack", {
+        botUserId: this.botUserId,
+        botUsername: this.botUsername,
+        channelCount: this.channelAgentMap.size,
+      });
+
+      this.emit("connected");
+    } catch (error) {
+      this.status = "error";
+      this.lastError =
+        error instanceof Error ? error.message : String(error);
+
+      this.logger.error("Failed to connect to Slack", {
+        error: this.lastError,
+      });
+
+      throw new SlackConnectionError(
+        `Failed to connect to Slack: ${this.lastError}`,
+        { cause: error instanceof Error ? error : undefined }
+      );
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (
+      this.status === "disconnected" ||
+      this.status === "disconnecting"
+    ) {
+      return;
+    }
+
+    this.status = "disconnecting";
+    this.logger.info("Disconnecting from Slack...");
+
+    try {
+      if (this.app) {
+        await this.app.stop();
+        this.app = null;
+      }
+
+      this.status = "disconnected";
+      this.disconnectedAt = new Date().toISOString();
+
+      this.logger.info("Disconnected from Slack");
+      this.emit("disconnected");
+    } catch (error) {
+      this.status = "error";
+      this.lastError =
+        error instanceof Error ? error.message : String(error);
+
+      this.logger.error("Error disconnecting from Slack", {
+        error: this.lastError,
+      });
+    }
+  }
+
+  isConnected(): boolean {
+    return this.status === "connected";
+  }
+
+  getState(): SlackConnectorState {
+    return {
+      status: this.status,
+      connectedAt: this.connectedAt,
+      disconnectedAt: this.disconnectedAt,
+      reconnectAttempts: this.reconnectAttempts,
+      lastError: this.lastError,
+      botUser: this.botUserId
+        ? {
+            id: this.botUserId,
+            username: this.botUsername ?? "unknown",
+          }
+        : null,
+      messageStats: {
+        received: this.messagesReceived,
+        sent: this.messagesSent,
+        ignored: this.messagesIgnored,
+      },
+    };
+  }
+
+  // ===========================================================================
+  // Event Handlers
+  // ===========================================================================
+
+  private registerEventHandlers(): void {
+    if (!this.app) return;
+
+    // Handle @mentions — starts new thread conversations
+    this.app.event("app_mention", async ({ event, say }: { event: AppMentionEvent; say: SayFn }) => {
+      this.messagesReceived++;
+
+      if (!this.botUserId) return;
+
+      // Find which agent handles this channel
+      const agentName = this.channelAgentMap.get(event.channel);
+      if (!agentName) {
+        this.messagesIgnored++;
+        this.logger.debug("Ignoring mention in unconfigured channel", {
+          channel: event.channel,
+        });
+        return;
+      }
+
+      const prompt = processMessage(event.text, this.botUserId);
+      if (!prompt) {
+        this.messagesIgnored++;
+        return;
+      }
+
+      // Thread timestamp: use existing thread or create from this message
+      const threadTs = event.thread_ts ?? event.ts;
+
+      // Track this thread for future reply routing
+      this.activeThreads.set(threadTs, agentName);
+
+      const messageEvent = this.buildMessageEvent(
+        agentName,
+        prompt,
+        event.channel,
+        threadTs,
+        event.ts,
+        event.user,
+        true,
+        say
+      );
+
+      this.emit("message", messageEvent);
+    });
+
+    // Handle thread replies — continues existing conversations
+    this.app.event("message", async ({ event, say }: { event: MessageEvent; say: SayFn }) => {
+      // Only process thread replies
+      if (!event.thread_ts) return;
+
+      this.messagesReceived++;
+
+      if (!this.botUserId) return;
+
+      // Ignore bot messages
+      if (!shouldProcessMessage(event, this.botUserId)) {
+        this.messagesIgnored++;
+        return;
+      }
+
+      // Check if this thread is an active conversation
+      const agentName = this.activeThreads.get(event.thread_ts);
+      if (!agentName) {
+        // Could also be in a channel we know about — check channel routing
+        const channelAgent = this.channelAgentMap.get(event.channel);
+        if (!channelAgent) {
+          this.messagesIgnored++;
+          return;
+        }
+
+        // Check if the bot was mentioned (to start tracking this thread)
+        if (
+          typeof event.text === "string" &&
+          isBotMentioned(event.text, this.botUserId)
+        ) {
+          this.activeThreads.set(event.thread_ts, channelAgent);
+        } else {
+          // Thread reply in a known channel but bot wasn't mentioned
+          // and we're not tracking this thread — check if we have a session
+          const sessionManager = this.sessionManagers.get(channelAgent);
+          if (sessionManager) {
+            const session = await sessionManager.getSession(event.thread_ts);
+            if (session) {
+              // We have a session — track and process
+              this.activeThreads.set(event.thread_ts, channelAgent);
+            } else {
+              this.messagesIgnored++;
+              return;
+            }
+          } else {
+            this.messagesIgnored++;
+            return;
+          }
+        }
+      }
+
+      const resolvedAgent =
+        this.activeThreads.get(event.thread_ts) ??
+        this.channelAgentMap.get(event.channel);
+
+      if (!resolvedAgent) {
+        this.messagesIgnored++;
+        return;
+      }
+
+      const prompt = processMessage(
+        event.text ?? "",
+        this.botUserId
+      );
+
+      if (!prompt) {
+        this.messagesIgnored++;
+        return;
+      }
+
+      const messageEvent = this.buildMessageEvent(
+        resolvedAgent,
+        prompt,
+        event.channel,
+        event.thread_ts,
+        event.ts,
+        event.user ?? "",
+        isBotMentioned(event.text ?? "", this.botUserId),
+        say
+      );
+
+      this.emit("message", messageEvent);
+    });
+  }
+
+  // ===========================================================================
+  // Message Building
+  // ===========================================================================
+
+  private buildMessageEvent(
+    agentName: string,
+    prompt: string,
+    channelId: string,
+    threadTs: string,
+    messageTs: string,
+    userId: string,
+    wasMentioned: boolean,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    say: any
+  ): SlackMessageEvent {
+    const reply = async (content: string): Promise<void> => {
+      await say({
+        text: content,
+        thread_ts: threadTs,
+      });
+      this.messagesSent++;
+    };
+
+    const startProcessingIndicator = (): (() => void) => {
+      // Add hourglass reaction while processing
+      if (this.app?.client) {
+        this.app.client.reactions
+          .add({
+            channel: channelId,
+            name: "hourglass_flowing_sand",
+            timestamp: messageTs,
+          })
+          .catch(() => {
+            // Ignore reaction errors — not critical
+          });
+      }
+
+      return () => {
+        // Remove hourglass reaction when done
+        if (this.app?.client) {
+          this.app.client.reactions
+            .remove({
+              channel: channelId,
+              name: "hourglass_flowing_sand",
+              timestamp: messageTs,
+            })
+            .catch(() => {
+              // Ignore reaction errors — not critical
+            });
+        }
+      };
+    };
+
+    return {
+      agentName,
+      prompt,
+      metadata: {
+        channelId,
+        threadTs,
+        messageTs,
+        userId,
+        wasMentioned,
+      },
+      reply,
+      startProcessingIndicator,
+    };
+  }
+}
+
+// =============================================================================
+// Internal Slack Event Types (subset of Bolt types)
+// =============================================================================
+
+interface AppMentionEvent {
+  type: "app_mention";
+  user: string;
+  text: string;
+  ts: string;
+  channel: string;
+  thread_ts?: string;
+}
+
+interface MessageEvent {
+  type: "message";
+  subtype?: string;
+  bot_id?: string;
+  user?: string;
+  text?: string;
+  ts: string;
+  channel: string;
+  thread_ts?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SayFn = (message: any) => Promise<any>;

--- a/packages/slack/src/types.ts
+++ b/packages/slack/src/types.ts
@@ -1,0 +1,229 @@
+/**
+ * Type definitions for the Slack connector
+ *
+ * Provides interfaces for connector configuration, state tracking,
+ * and event definitions.
+ */
+
+import type { EventEmitter } from "node:events";
+
+// =============================================================================
+// Connection Status
+// =============================================================================
+
+/**
+ * Slack connector connection status
+ */
+export type SlackConnectionStatus =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnecting"
+  | "error";
+
+// =============================================================================
+// Connector State
+// =============================================================================
+
+/**
+ * Current state of the Slack connector
+ */
+export interface SlackConnectorState {
+  /** Current connection status */
+  status: SlackConnectionStatus;
+
+  /** ISO timestamp when the connector connected */
+  connectedAt: string | null;
+
+  /** ISO timestamp when the connector disconnected */
+  disconnectedAt: string | null;
+
+  /** Number of reconnect attempts */
+  reconnectAttempts: number;
+
+  /** Last error message */
+  lastError: string | null;
+
+  /** Bot user info (only present when connected) */
+  botUser: {
+    id: string;
+    username: string;
+  } | null;
+
+  /** Message statistics */
+  messageStats: {
+    received: number;
+    sent: number;
+    ignored: number;
+  };
+}
+
+// =============================================================================
+// Connector Options
+// =============================================================================
+
+/**
+ * Options for creating a SlackConnector
+ */
+export interface SlackConnectorOptions {
+  /** Slack Bot Token (xoxb-...) */
+  botToken: string;
+
+  /** Slack App Token for Socket Mode (xapp-...) */
+  appToken: string;
+
+  /** Map of channel ID to agent name for routing */
+  channelAgentMap: Map<string, string>;
+
+  /** Session managers keyed by agent name */
+  sessionManagers: Map<string, ISlackSessionManager>;
+
+  /** Logger for connector operations */
+  logger?: SlackConnectorLogger;
+
+  /** State directory for persistence */
+  stateDir?: string;
+}
+
+// =============================================================================
+// Logger
+// =============================================================================
+
+/**
+ * Logger interface for Slack connector operations
+ */
+export interface SlackConnectorLogger {
+  debug(message: string, data?: Record<string, unknown>): void;
+  info(message: string, data?: Record<string, unknown>): void;
+  warn(message: string, data?: Record<string, unknown>): void;
+  error(message: string, data?: Record<string, unknown>): void;
+}
+
+// =============================================================================
+// Message Event
+// =============================================================================
+
+/**
+ * Message event payload from SlackConnector
+ */
+export interface SlackMessageEvent {
+  /** Name of the agent handling this message */
+  agentName: string;
+
+  /** The processed prompt text */
+  prompt: string;
+
+  /** Slack-specific metadata */
+  metadata: {
+    /** Channel ID where the message was sent */
+    channelId: string;
+
+    /** Thread timestamp (conversation key) */
+    threadTs: string;
+
+    /** Message timestamp */
+    messageTs: string;
+
+    /** User ID who sent the message */
+    userId: string;
+
+    /** Whether this was triggered by a mention */
+    wasMentioned: boolean;
+  };
+
+  /** Function to send a reply in the same thread */
+  reply: (content: string) => Promise<void>;
+
+  /** Add hourglass reaction while processing, returns remove function */
+  startProcessingIndicator: () => () => void;
+}
+
+/**
+ * Error event payload from SlackConnector
+ */
+export interface SlackErrorEvent {
+  agentName: string;
+  error: Error;
+}
+
+// =============================================================================
+// Connector Interface
+// =============================================================================
+
+/**
+ * Interface for the Slack connector
+ */
+export interface ISlackConnector extends EventEmitter {
+  /** Connect to Slack via Socket Mode */
+  connect(): Promise<void>;
+
+  /** Disconnect from Slack */
+  disconnect(): Promise<void>;
+
+  /** Check if connected */
+  isConnected(): boolean;
+
+  /** Get current state */
+  getState(): SlackConnectorState;
+
+  /** Event subscription */
+  on(event: "message", listener: (payload: SlackMessageEvent) => void): this;
+  on(event: "error", listener: (payload: SlackErrorEvent) => void): this;
+  on(event: string, listener: (...args: unknown[]) => void): this;
+  off(event: string, listener: (...args: unknown[]) => void): this;
+}
+
+// =============================================================================
+// Session Manager Interface (minimal for connector use)
+// =============================================================================
+
+/**
+ * Session manager interface for Slack
+ *
+ * Keyed by threadTs instead of channelId (unlike Discord).
+ */
+export interface ISlackSessionManager {
+  readonly agentName: string;
+
+  getOrCreateSession(
+    threadTs: string,
+    channelId: string
+  ): Promise<{ sessionId: string; isNew: boolean }>;
+
+  getSession(
+    threadTs: string
+  ): Promise<{ sessionId: string; lastMessageAt: string; channelId: string } | null>;
+
+  setSession(
+    threadTs: string,
+    sessionId: string,
+    channelId: string
+  ): Promise<void>;
+
+  touchSession(threadTs: string): Promise<void>;
+
+  clearSession(threadTs: string): Promise<boolean>;
+
+  cleanupExpiredSessions(): Promise<number>;
+
+  getActiveSessionCount(): Promise<number>;
+}
+
+// =============================================================================
+// Connector Event Map
+// =============================================================================
+
+/**
+ * Strongly-typed event map for SlackConnector
+ */
+export interface SlackConnectorEventMap {
+  message: [payload: SlackMessageEvent];
+  error: [payload: SlackErrorEvent];
+  connected: [];
+  disconnected: [];
+}
+
+export type SlackConnectorEventName = keyof SlackConnectorEventMap;
+export type SlackConnectorEventPayload<E extends SlackConnectorEventName> =
+  SlackConnectorEventMap[E] extends [infer P] ? P : void;

--- a/packages/slack/tsconfig.json
+++ b/packages/slack/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,34 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17(@types/node@20.19.30)(yaml@2.8.2)
 
+  packages/slack:
+    dependencies:
+      '@herdctl/core':
+        specifier: workspace:*
+        version: link:../core
+      '@slack/bolt':
+        specifier: ^4.1.0
+        version: 4.6.0(@types/express@5.0.6)
+      '@slack/web-api':
+        specifier: ^7.8.0
+        version: 7.14.1
+      yaml:
+        specifier: ^2.3.0
+        version: 2.8.2
+      zod:
+        specifier: ^3.22.0
+        version: 3.25.76
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.0.17
+        version: 4.0.17(vitest@4.0.17(@types/node@20.19.30)(yaml@2.8.2))
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.17
+        version: 4.0.17(@types/node@20.19.30)(yaml@2.8.2)
+
 packages:
 
   '@anthropic-ai/claude-agent-sdk@0.1.77':
@@ -1274,11 +1302,43 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@slack/bolt@4.6.0':
+    resolution: {integrity: sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+    peerDependencies:
+      '@types/express': ^5.0.0
+
+  '@slack/logger@4.0.0':
+    resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/oauth@3.0.4':
+    resolution: {integrity: sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+
+  '@slack/socket-mode@2.0.5':
+    resolution: {integrity: sha512-VaapvmrAifeFLAFaDPfGhEwwunTKsI6bQhYzxRXw7BSujZUae5sANO76WqlVsLXuhVtCVrBWPiS2snAQR2RHJQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/types@2.20.0':
+    resolution: {integrity: sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.14.1':
+    resolution: {integrity: sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -1298,11 +1358,23 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -1328,8 +1400,23 @@ packages:
   '@types/node@20.19.30':
     resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
 
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
@@ -1387,6 +1474,10 @@ packages:
   '@vladfrangu/async_event_emitter@2.4.7':
     resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1469,6 +1560,12 @@ packages:
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1498,6 +1595,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1509,12 +1610,27 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buildcheck@0.0.7:
     resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
     engines: {node: '>=10.0.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
@@ -1587,6 +1703,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -1601,8 +1721,24 @@ packages:
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -1667,6 +1803,14 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1748,11 +1892,25 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1769,8 +1927,24 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -1791,6 +1965,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -1825,6 +2002,13 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -1835,6 +2019,10 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   expressive-code@0.41.6:
     resolution: {integrity: sha512-W/5+IQbrpCIM5KGLjO35wlp1NCwDOOVQb+PAvzEoGkW1xjGM807ZGfBKptNWH6UECvt6qgmLyWolCMYKh7eQmA==}
@@ -1872,6 +2060,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -1880,12 +2072,33 @@ packages:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   fontace@0.4.0:
     resolution: {integrity: sha512-moThBCItUe2bjZip5PF/iZClpKHGLwMvR79Kp8XpGRBrvoRSnySN4VcILdv3/MJzbhvUA5WeiUXF5o538m5fvg==}
 
   fontkitten@1.0.2:
     resolution: {integrity: sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q==}
     engines: {node: '>=20'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1903,6 +2116,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1910,6 +2126,14 @@ packages:
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
@@ -1926,6 +2150,10 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1935,6 +2163,18 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   hast-util-embedded@3.0.0:
     resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
@@ -2011,6 +2251,10 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
@@ -2042,6 +2286,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -2058,6 +2306,9 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
+
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2086,6 +2337,13 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
@@ -2136,6 +2394,16 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -2150,6 +2418,27 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
@@ -2193,6 +2482,10 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -2253,6 +2546,14 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2370,6 +2671,22 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -2395,6 +2712,10 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
@@ -2429,6 +2750,10 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -2437,6 +2762,10 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2454,6 +2783,10 @@ packages:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -2470,9 +2803,21 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
   p-queue@8.1.1:
     resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
     engines: {node: '>=18'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
 
   p-timeout@6.1.4:
     resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
@@ -2505,6 +2850,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2516,6 +2865,9 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2580,8 +2932,19 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -2591,6 +2954,14 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -2690,6 +3061,10 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2698,6 +3073,10 @@ packages:
     resolution: {integrity: sha512-PggGy4dhwx5qaW+CKBilA/98Ql9keyfnb7lh4SR6shQ91QQQi1ORJ1v4UinkdP2i87OBs9AQFooQylcrrRfIcg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2717,6 +3096,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2731,6 +3121,22 @@ packages:
 
   shiki@3.21.0:
     resolution: {integrity: sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2781,6 +3187,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2866,6 +3276,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -2890,6 +3304,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsscmp@1.0.6:
+    resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
+    engines: {node: '>=0.6.x'}
 
   turbo-darwin-64@2.7.5:
     resolution: {integrity: sha512-nN3wfLLj4OES/7awYyyM7fkU8U8sAFxsXau2bYJwAWi6T09jd87DgHD8N31zXaJ7LcpyppHWPRI2Ov9MuZEwnQ==}
@@ -2931,6 +3349,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3000,6 +3422,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unstorage@1.17.4:
     resolution: {integrity: sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==}
     peerDependencies:
@@ -3068,6 +3494,10 @@ packages:
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -4381,12 +4811,86 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@slack/bolt@4.6.0(@types/express@5.0.6)':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/oauth': 3.0.4
+      '@slack/socket-mode': 2.0.5
+      '@slack/types': 2.20.0
+      '@slack/web-api': 7.14.1
+      '@types/express': 5.0.6
+      axios: 1.13.5
+      express: 5.2.1
+      path-to-regexp: 8.3.0
+      raw-body: 3.0.2
+      tsscmp: 1.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@slack/logger@4.0.0':
+    dependencies:
+      '@types/node': 20.19.30
+
+  '@slack/oauth@3.0.4':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/web-api': 7.14.1
+      '@types/jsonwebtoken': 9.0.10
+      '@types/node': 20.19.30
+      jsonwebtoken: 9.0.3
+    transitivePeerDependencies:
+      - debug
+
+  '@slack/socket-mode@2.0.5':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/web-api': 7.14.1
+      '@types/node': 20.19.30
+      '@types/ws': 8.18.1
+      eventemitter3: 5.0.4
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@slack/types@2.20.0': {}
+
+  '@slack/web-api@7.14.1':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/types': 2.20.0
+      '@types/node': 20.19.30
+      '@types/retry': 0.12.0
+      axios: 1.13.5
+      eventemitter3: 5.0.4
+      form-data: 4.0.5
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+
   '@standard-schema/spec@1.1.0': {}
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.30
 
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.30
 
   '@types/debug@4.1.12':
     dependencies:
@@ -4411,11 +4915,31 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 20.19.30
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/http-errors@2.0.5': {}
+
   '@types/js-yaml@4.0.9': {}
+
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 20.19.30
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -4441,8 +4965,23 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/retry@0.12.0': {}
+
   '@types/sax@1.2.7':
     dependencies:
+      '@types/node': 20.19.30
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.30
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
       '@types/node': 20.19.30
 
   '@types/ssh2@1.15.5':
@@ -4513,6 +5052,11 @@ snapshots:
       tinyrainbow: 3.0.3
 
   '@vladfrangu/async_event_emitter@2.4.7': {}
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -4676,6 +5220,16 @@ snapshots:
       - uploadthing
       - yaml
 
+  asynckit@0.4.0: {}
+
+  axios@1.13.5:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
@@ -4706,6 +5260,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   boxen@8.0.1:
@@ -4723,6 +5291,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -4730,6 +5300,18 @@ snapshots:
 
   buildcheck@0.0.7:
     optional: true
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   camelcase@8.0.0: {}
 
@@ -4779,6 +5361,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
@@ -4787,7 +5373,15 @@ snapshots:
 
   common-ancestor-path@1.0.1: {}
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   cookie-es@1.2.2: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
@@ -4850,6 +5444,10 @@ snapshots:
       character-entities: 2.0.2
 
   defu@6.1.4: {}
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -4945,9 +5543,23 @@ snapshots:
 
   dset@3.1.4: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  ee-first@1.1.1: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -4962,7 +5574,22 @@ snapshots:
 
   entities@6.0.1: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -5038,6 +5665,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@5.0.0: {}
 
   esprima@4.0.1: {}
@@ -5077,6 +5706,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.4: {}
 
   execa@9.6.1:
@@ -5095,6 +5728,39 @@ snapshots:
       yoctocolors: 2.1.2
 
   expect-type@1.3.0: {}
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   expressive-code@0.41.6:
     dependencies:
@@ -5133,12 +5799,25 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
   flattie@1.1.1: {}
+
+  follow-redirects@1.15.11: {}
 
   fontace@0.4.0:
     dependencies:
@@ -5147,6 +5826,18 @@ snapshots:
   fontkitten@1.0.2:
     dependencies:
       tiny-inflate: 1.0.3
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -5165,9 +5856,29 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@9.0.1:
     dependencies:
@@ -5189,6 +5900,8 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   h3@1.15.5:
@@ -5204,6 +5917,16 @@ snapshots:
       uncrypto: 0.1.3
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-embedded@3.0.0:
     dependencies:
@@ -5404,6 +6127,14 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   human-id@4.1.3: {}
 
   human-signals@8.0.1: {}
@@ -5426,6 +6157,8 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  ipaddr.js@1.9.1: {}
+
   iron-webcrypto@1.2.1: {}
 
   is-alphabetical@2.0.1: {}
@@ -5438,6 +6171,8 @@ snapshots:
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
+
+  is-electron@2.2.2: {}
 
   is-extglob@2.1.1: {}
 
@@ -5456,6 +6191,10 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
+
+  is-stream@2.0.1: {}
 
   is-stream@4.0.1: {}
 
@@ -5501,6 +6240,30 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.3
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   kleur@3.0.3: {}
 
   klona@2.0.6: {}
@@ -5510,6 +6273,20 @@ snapshots:
       p-locate: 4.1.0
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.once@4.1.1: {}
 
   lodash.snakecase@4.1.1: {}
 
@@ -5544,6 +6321,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -5731,6 +6510,10 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.12.2: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -6013,6 +6796,18 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mkdirp-classic@0.5.3: {}
 
   mri@1.2.0: {}
@@ -6027,6 +6822,8 @@ snapshots:
     optional: true
 
   nanoid@3.3.11: {}
+
+  negotiator@1.0.0: {}
 
   neotraverse@0.6.18: {}
 
@@ -6053,6 +6850,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
 
   ofetch@1.5.1:
@@ -6062,6 +6861,10 @@ snapshots:
       ufo: 1.6.3
 
   ohash@2.0.11: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -6081,6 +6884,8 @@ snapshots:
     dependencies:
       p-map: 2.1.0
 
+  p-finally@1.0.0: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -6095,10 +6900,24 @@ snapshots:
 
   p-map@2.1.0: {}
 
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
   p-queue@8.1.1:
     dependencies:
       eventemitter3: 5.0.4
       p-timeout: 6.1.4
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   p-timeout@6.1.4: {}
 
@@ -6144,11 +6963,15 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
 
@@ -6210,16 +7033,36 @@ snapshots:
       '@types/node': 20.19.30
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
 
   radix3@1.1.2: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -6403,6 +7246,8 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   rollup@4.55.2:
@@ -6436,6 +7281,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.55.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6447,6 +7302,33 @@ snapshots:
   sax@1.4.4: {}
 
   semver@7.7.3: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -6496,6 +7378,34 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -6537,6 +7447,8 @@ snapshots:
       nan: 2.25.0
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -6631,6 +7543,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tr46@0.0.3: {}
 
   trim-lines@3.0.1: {}
@@ -6644,6 +7558,8 @@ snapshots:
       typescript: 5.9.3
 
   tslib@2.8.1: {}
+
+  tsscmp@1.0.6: {}
 
   turbo-darwin-64@2.7.5:
     optional: true
@@ -6675,6 +7591,12 @@ snapshots:
   tweetnacl@0.14.5: {}
 
   type-fest@4.41.0: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@5.9.3: {}
 
@@ -6756,6 +7678,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unpipe@1.0.0: {}
+
   unstorage@1.17.4:
     dependencies:
       anymatch: 3.1.3
@@ -6770,6 +7694,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  vary@1.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `@herdctl/slack` package with SlackConnector (Bolt/Socket Mode), SessionManager, CommandHandler (`!reset`, `!status`, `!help`), error handling, mrkdwn formatting, and message splitting
- Integrates into `@herdctl/core`: config schema (`AgentChatSlackSchema`, `SlackHookConfigSchema`), `SlackManager` for single-connector lifecycle with channel-to-agent routing, `SlackHookRunner` for schedule notifications, FleetManager wiring, status queries, and event types
- 200+ tests across both packages with full coverage thresholds passing
- Example config at `examples/slack-chat-bot/`

Key architectural difference from Discord: Slack uses **one** Bolt App instance shared across all agents (single bot token per workspace) with channel-to-agent routing, while Discord uses N connectors (one per agent with separate bot tokens).

## Test plan

- [x] `pnpm build` — all 5 packages compile
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm test` — all tests pass with coverage thresholds (2500+ tests total)
- [ ] Manual test with a Slack workspace: create Slack App with Socket Mode, set env vars, run `herdctl start`, verify thread creation and response