### PR TITLE
fix(core): remove optional peer deps to prevent major version cascade

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,18 +26,6 @@
     "yaml": "^2.3.0",
     "zod": "^3.22.0"
   },
-  "peerDependencies": {
-    "@herdctl/discord": "workspace:*",
-    "@herdctl/slack": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@herdctl/discord": {
-      "optional": true
-    },
-    "@herdctl/slack": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/dockerode": "^4.0.1",
     "@vitest/coverage-v8": "^4.0.17",

--- a/packages/core/src/fleet-manager/__tests__/slack-manager.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/slack-manager.test.ts
@@ -177,7 +177,7 @@ describe("SlackManager (no @herdctl/slack)", () => {
       );
     });
 
-    it("skips when no agents have Slack configured", async () => {
+    it("skips when @herdctl/slack is not installed (no slack agents)", async () => {
       const SlackManager = await getSlackManager();
       const config = createConfigWithAgents(
         createNonSlackAgent("agent1"),
@@ -189,11 +189,11 @@ describe("SlackManager (no @herdctl/slack)", () => {
       await manager.initialize();
 
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        "No agents with Slack configured"
+        "@herdctl/slack not installed, skipping Slack connector"
       );
     });
 
-    it("skips when Slack token env vars are not set", async () => {
+    it("skips when @herdctl/slack is not installed (with slack agents)", async () => {
       const SlackManager = await getSlackManager();
       const config = createConfigWithAgents(
         createSlackAgent("agent1", defaultSlackConfig)
@@ -203,8 +203,8 @@ describe("SlackManager (no @herdctl/slack)", () => {
 
       await manager.initialize();
 
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        "Slack bot token not found in environment variable 'SLACK_BOT_TOKEN'"
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "@herdctl/slack not installed, skipping Slack connector"
       );
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,12 +69,6 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.1.0
         version: 0.1.77(zod@3.25.76)
-      '@herdctl/discord':
-        specifier: workspace:*
-        version: link:../discord
-      '@herdctl/slack':
-        specifier: workspace:*
-        version: link:../slack
       chokidar:
         specifier: ^5
         version: 5.0.0


### PR DESCRIPTION
## Summary

- Remove `peerDependencies` and `peerDependenciesMeta` for `@herdctl/slack` and `@herdctl/discord` from `@herdctl/core`
- Update slack-manager tests to match the genuine "not installed" behavior

## Why

Changesets treats any peer dependency version change as a breaking change, auto-escalating `@herdctl/core` to a new major version every time `@herdctl/slack` or `@herdctl/discord` are updated. PR #50 currently wants to bump core from 4.0.0 → 5.0.0 because of this.

Since core only uses these packages via dynamic `import()` with local type interfaces (zero compile-time dependency), the peer dependencies serve no technical purpose. Removing them drops core from 5.0.0 back to 4.1.0 in the next release.

Verified locally with `npx @changesets/cli status`:

| Package | Before | After |
|---|---|---|
| `@herdctl/core` | **major** (5.0.0) | **minor** (4.1.0) |
| `@herdctl/slack` | minor | minor |
| `@herdctl/discord` | patch | patch |
| `herdctl` | patch | patch |

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (2417 tests, 56 files)
- [x] `pnpm typecheck` passes
- [x] `npx @changesets/cli status` shows no major bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)