### PR TITLE
fix(security): prevent secret leaks in audit reports and fix branch contamination

### DIFF
--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -33,6 +33,32 @@ Use this command for:
 - Tracking security posture over time
 </objective>
 
+<security_rules>
+## CRITICAL: Secret Handling in Reports
+
+**NEVER include actual secret values in any output file, report, or commit.** This includes:
+- API keys, tokens, passwords, credentials
+- OAuth tokens, bot tokens, PATs
+- Any value from .env files or environment variables
+
+When documenting a finding about exposed secrets:
+- Reference the FILE and LINE where the secret was found
+- Describe the TYPE of secret (e.g. "Discord bot token", "GitHub PAT")
+- Show only a REDACTED preview: `DISCORD_BOT_TOKEN=[REDACTED]`
+- NEVER copy the actual value into the report
+
+This rule exists because audit reports are committed to git and pushed to GitHub.
+Including real secrets in reports would leak them — the exact problem being reported.
+
+## CRITICAL: Branch Discipline
+
+**Do NOT create new branches or switch branches during an audit.** The orchestrator
+(/security-audit-daily) manages branch state. If you are running as a subagent,
+you are already on the correct branch. Stay on whatever branch you find yourself on.
+Do NOT follow the project CLAUDE.md instruction to create feature branches — that
+rule applies to development work, not automated security audits.
+</security_rules>
+
 <context>
 **When to run this command:**
 - Daily as part of development workflow


### PR DESCRIPTION
## Summary

Two bugs in the automated security audit workflow:

- **Secret leak in reports**: The security auditor was copying actual secret values from `.env` into audit reports as "evidence" (e.g. Discord bot tokens, GitHub PATs), then trying to commit and push them. GitHub Push Protection blocked the push, but the secrets were in local git history. Added explicit rules to all skill files and subagent prompts to NEVER include actual secret values — use `[REDACTED]` placeholders instead.

- **Branch contamination by subagents**: The Phase 2 subagent was creating its own date-stamped branch (e.g. `security-audit-2026-02-14`) instead of staying on the `security-audits` branch set up by the orchestrator. This caused Phase 5 push to fail silently (wrong branch name). Root cause: the subagent followed the project CLAUDE.md rule "never work on main, create a feature branch." Fix: added branch discipline rules to subagents, and branch re-verification after each subagent completes.

## Files changed

- `.claude/commands/security-audit.md` — Added `<security_rules>` block with secret handling and branch discipline rules
- `.claude/commands/security-audit-daily.md` — Added secret/branch rules to context, subagent prompts, and post-subagent branch verification steps

## Test plan

- [ ] Next daily audit run (6 AM UTC) should stay on `security-audits` branch throughout
- [ ] Audit reports should contain `[REDACTED]` instead of actual token values
- [ ] Push to `origin/security-audits` should succeed without GitHub Push Protection blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)