### PR TITLE
fix(core): fix flaky integration test race condition

### DIFF
--- a/packages/core/src/fleet-manager/__tests__/integration.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/integration.test.ts
@@ -636,6 +636,7 @@ describe("FleetManager Integration Tests (US-13)", () => {
           check: {
             type: "interval",
             interval: "1h",
+            enabled: false,
           },
         },
       });


### PR DESCRIPTION
## Summary
- Fix race condition in "persists fleet state across restart" integration test
- The `check` schedule on `persistent-agent` was enabled by default, so the scheduler auto-triggered it immediately on `start()` (interval schedules with no `last_run_at` fire immediately)
- This raced with the manual `trigger()` call, hitting the default concurrency limit of 1
- Fix: add `enabled: false` to the schedule config, matching the pattern used by other tests that manually trigger

## Test plan
- [x] `pnpm test` passes locally (all 6 packages, ~3400 tests)
- [x] The specific "persists fleet state across restart" test passes reliably
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)