### PR TITLE
ci: add multi-arch Docker image build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,47 @@
+name: Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "packages/core/src/runner/runtime/docker-sdk-wrapper.js"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    name: Build & Push Multi-Arch Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: herdctl/runtime:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`.github/workflows/docker.yml`) that builds and pushes multi-arch Docker images (`linux/amd64` + `linux/arm64`) to Docker Hub
- Fixes the issue where `herdctl/runtime:latest` was arm64-only, causing all Docker-enabled agents to fail on amd64 hosts
- **The multi-arch image has already been manually built and pushed** — amd64 users are unblocked now

## Trigger conditions

- **On push to `main`**: when `Dockerfile`, `.dockerignore`, or `docker-sdk-wrapper.js` change
- **Manual**: via `workflow_dispatch` for on-demand rebuilds

## Setup required

Add these repository secrets:
- `DOCKERHUB_USERNAME` — Docker Hub username
- `DOCKERHUB_TOKEN` — Docker Hub access token ([create here](https://hub.docker.com/settings/security))

## Test plan

- [ ] Verify workflow syntax is valid (CI will check this)
- [ ] Add Docker Hub secrets to repository settings
- [ ] Trigger a manual workflow run and confirm both platforms are built and pushed
- [ ] Verify `docker manifest inspect herdctl/runtime:latest` shows both `linux/amd64` and `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)