### PR TITLE
feat(web): remove duplicate chat sidebar, move title to header bar

### DIFF
--- a/.changeset/chat-ui-cleanup.md
+++ b/.changeset/chat-ui-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/web": patch
+---
+
+Remove duplicate inner sidebar from chat page, move chat title and session ID to top-level header bar, and make the global sidebar new-chat button blue

--- a/packages/web/src/client/src/components/chat/ChatView.tsx
+++ b/packages/web/src/client/src/components/chat/ChatView.tsx
@@ -7,10 +7,8 @@
 
 import { useEffect } from "react";
 import { useParams, useNavigate } from "react-router";
-import { MessageCircle, ArrowLeft } from "lucide-react";
-import { Link } from "react-router";
+import { MessageCircle } from "lucide-react";
 import { useChatMessages, useChatActions, useChatSessions } from "../../store";
-import { SessionList } from "./SessionList";
 import { MessageFeed } from "./MessageFeed";
 import { Composer } from "./Composer";
 
@@ -58,79 +56,54 @@ export function ChatView() {
   };
 
   return (
-    <div className="flex h-full">
-      {/* Session list sidebar */}
-      <SessionList agentName={agentName} activeSessionId={sessionId ?? null} />
-
-      {/* Main chat area */}
-      <div className="flex-1 flex flex-col min-w-0">
-        {/* Header */}
-        <div className="h-12 border-b border-herd-border bg-herd-card flex items-center px-4 gap-3">
-          <Link
-            to={`/agents/${encodeURIComponent(agentName)}`}
-            className="text-herd-muted hover:text-herd-fg transition-colors"
-            title="Back to agent"
-          >
-            <ArrowLeft className="w-4 h-4" />
-          </Link>
-          <h1 className="text-sm font-medium text-herd-fg">
-            Chat with {agentName}
-          </h1>
-          {sessionId && (
-            <span className="text-[11px] text-herd-muted font-mono">
-              {sessionId.slice(0, 8)}
-            </span>
-          )}
-        </div>
-
-        {/* Chat content */}
-        {sessionId ? (
-          <>
-            {/* Error banner */}
-            {chatError && (
-              <div className="px-4 pt-4">
-                <div className="max-w-2xl mx-auto">
-                  <div className="bg-herd-status-error/10 border border-herd-status-error/20 text-herd-status-error rounded-lg px-3 py-2 text-xs">
-                    {chatError}
-                  </div>
+    <div className="flex-1 flex flex-col min-w-0 h-full">
+      {/* Chat content */}
+      {sessionId ? (
+        <>
+          {/* Error banner */}
+          {chatError && (
+            <div className="px-4 pt-4">
+              <div className="max-w-2xl mx-auto">
+                <div className="bg-herd-status-error/10 border border-herd-status-error/20 text-herd-status-error rounded-lg px-3 py-2 text-xs">
+                  {chatError}
                 </div>
               </div>
-            )}
-
-            {/* Message feed */}
-            <MessageFeed agentName={agentName} />
-
-            {/* Composer */}
-            <Composer agentName={agentName} sessionId={sessionId} />
-          </>
-        ) : (
-          /* Welcome state when no session is selected */
-          <div className="flex-1 flex items-center justify-center">
-            <div className="flex flex-col items-center gap-4 text-center px-4">
-              <div className="w-16 h-16 rounded-full bg-herd-primary-muted flex items-center justify-center">
-                <MessageCircle className="w-8 h-8 text-herd-primary" />
-              </div>
-              <div>
-                <h2 className="text-lg font-semibold text-herd-fg mb-1">
-                  Chat with {agentName}
-                </h2>
-                <p className="text-sm text-herd-muted max-w-sm">
-                  {chatSessions.length > 0
-                    ? "Select a conversation from the sidebar or start a new one."
-                    : "Start a new conversation to chat with this agent."}
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={handleStartNewChat}
-                className="bg-herd-primary hover:bg-herd-primary-hover text-white rounded-lg px-4 py-2 text-sm font-medium transition-colors"
-              >
-                New Chat
-              </button>
             </div>
+          )}
+
+          {/* Message feed */}
+          <MessageFeed agentName={agentName} />
+
+          {/* Composer */}
+          <Composer agentName={agentName} sessionId={sessionId} />
+        </>
+      ) : (
+        /* Welcome state when no session is selected */
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-4 text-center px-4">
+            <div className="w-16 h-16 rounded-full bg-herd-primary-muted flex items-center justify-center">
+              <MessageCircle className="w-8 h-8 text-herd-primary" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-herd-fg mb-1">
+                Chat with {agentName}
+              </h2>
+              <p className="text-sm text-herd-muted max-w-sm">
+                {chatSessions.length > 0
+                  ? "Select a conversation from the sidebar or start a new one."
+                  : "Start a new conversation to chat with this agent."}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleStartNewChat}
+              className="bg-herd-primary hover:bg-herd-primary-hover text-white rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+            >
+              New Chat
+            </button>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/client/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/client/src/components/layout/Sidebar.tsx
@@ -132,7 +132,7 @@ function AgentSection({
             e.stopPropagation();
             onNewChat(agent.name);
           }}
-          className="flex-shrink-0 p-1.5 mr-1 rounded text-herd-sidebar-muted/50 hover:text-herd-sidebar-fg hover:bg-herd-sidebar-hover transition-colors"
+          className="flex-shrink-0 p-1.5 mr-1 rounded bg-herd-primary/80 text-white hover:bg-herd-primary transition-colors"
           title="New chat"
         >
           <Plus className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary

- **Remove the inner session-list sidebar** from the chat page — the global sidebar already provides chat session navigation, so the duplicate was unnecessary
- **Move chat title to the top-level header bar** — "Chat with {agent}" plus the truncated session ID and a back arrow now appear in the app header, consistent with how other pages display their titles
- **Make the global sidebar new-chat "+" button blue** (`bg-herd-primary`) so it visually stands out

## Test plan

- [ ] Navigate to a chat page and verify the inner sidebar (with "New Chat" button and session list) is gone
- [ ] Verify the top-level header shows "Chat with {agent}" with the session ID and a back arrow on chat routes
- [ ] Verify clicking the back arrow navigates to the agent detail page
- [ ] Verify the "+" button next to each agent in the global sidebar is now blue
- [ ] Verify non-chat pages (Dashboard, Jobs, Schedules, Agent detail) still show correct titles without a back arrow
- [ ] Verify the welcome state (no session selected) still renders correctly with the "New Chat" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)