### PR TITLE
feat(web): improve sidebar chat session item readability

### DIFF
--- a/.changeset/sidebar-chat-styling.md
+++ b/.changeset/sidebar-chat-styling.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/web": patch
+---
+
+Increase font size, padding, and spacing of chat session items in the global sidebar so they are easier to read and click

--- a/packages/web/src/client/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/client/src/components/layout/Sidebar.tsx
@@ -143,7 +143,7 @@ function AgentSection({
       {sessions.length === 0 ? (
         <p className="text-[11px] text-herd-sidebar-muted/50 text-center py-3">No chats yet</p>
       ) : (
-        <div className="mr-1 mt-0.5 space-y-0.5">
+        <div className="mr-1 mt-0.5 space-y-1">
           {sessions.map((session) => {
             const isSessionActive = session.sessionId === activeSessionId;
             return (
@@ -151,7 +151,7 @@ function AgentSection({
                 key={session.sessionId}
                 to={`/agents/${encodeURIComponent(agent.name)}/chat/${session.sessionId}`}
                 onClick={onNavigate}
-                className={`flex items-center justify-between gap-2 px-3 py-1 rounded text-xs transition-colors ${
+                className={`flex items-center justify-between gap-2 px-3 py-2 rounded text-sm transition-colors ${
                   isSessionActive
                     ? "text-herd-sidebar-fg bg-herd-sidebar-active"
                     : "text-herd-sidebar-muted hover:bg-herd-sidebar-hover hover:text-herd-sidebar-fg"


### PR DESCRIPTION
## Summary

- Bump chat session font size from `text-xs` to `text-sm`
- Increase vertical padding from `py-1` to `py-2`
- Widen gap between items from `space-y-0.5` to `space-y-1`

The chat sessions in the global sidebar were visually cramped and easy to overlook. These small tweaks make them more legible and easier to click.

## Test plan

- [ ] Verify sidebar chat session items have visibly larger text and more breathing room
- [ ] Verify active session highlight still works correctly
- [ ] Verify truncation of long preview text still works
- [ ] Verify relative timestamps still display correctly on the right side

🤖 Generated with [Claude Code](https://claude.com/claude-code)