### PR TITLE
chore: add missing changeset for web sidebar improvements

### DIFF
--- a/.changeset/sidebar-fleet-hierarchy.md
+++ b/.changeset/sidebar-fleet-hierarchy.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/web": patch
+---
+
+Improve sidebar fleet hierarchy visual clarity with divider lines between fleet groups, left border accent on expanded content, and removal of status indicator dots from fleet headers and agent rows


### PR DESCRIPTION
## Summary

- Adds a missing changeset for PR #92 which modified the `@herdctl/web` sidebar component but was merged without a changeset
- Patch bump for `@herdctl/web` covering the fleet hierarchy visual improvements (divider lines, left border accent, status dot removal)

## Context

PR #92 (`fix: docs styling and web sidebar fleet hierarchy improvements`) changed `packages/web/src/client/src/components/layout/Sidebar.tsx` but didn't include a changeset, so the changes wouldn't have been picked up by the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)