### PR TITLE
fix: prevent sidebar chats from vanishing on navigation

### DIFF
--- a/.changeset/fix-sidebar-chat-clearing.md
+++ b/.changeset/fix-sidebar-chat-clearing.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/web": patch
+---
+
+fix: sidebar chats no longer vanish when navigating to agent details page

--- a/packages/web/src/client/src/components/chat/ChatView.tsx
+++ b/packages/web/src/client/src/components/chat/ChatView.tsx
@@ -22,15 +22,16 @@ export function ChatView() {
   const navigate = useNavigate();
   const { activeChatSessionId, chatError } = useChatMessages();
   const { chatSessions } = useChatSessions();
-  const { fetchChatMessages, setActiveChatSession, clearChatState, createChatSession } =
+  const { fetchChatMessages, setActiveChatSession, clearActiveChatState, createChatSession } =
     useChatActions();
 
-  // Clear chat state when leaving the page or changing agents
+  // Clear active chat session state when leaving the page or changing agents
+  // (preserves sidebar sessions so they don't vanish on navigation)
   useEffect(() => {
     return () => {
-      clearChatState();
+      clearActiveChatState();
     };
-  }, [qualifiedName, clearChatState]);
+  }, [qualifiedName, clearActiveChatState]);
 
   // Fetch messages when session ID changes
   useEffect(() => {

--- a/packages/web/src/client/src/store/chat-slice.ts
+++ b/packages/web/src/client/src/store/chat-slice.ts
@@ -66,6 +66,8 @@ export interface ChatActions {
   setChatError: (error: string | null) => void;
   /** Fetch recent sessions for all agents (sidebar display) */
   fetchSidebarSessions: (agentNames: string[]) => Promise<void>;
+  /** Clear active chat session state (preserves sidebar sessions) */
+  clearActiveChatState: () => void;
   /** Clear all chat state */
   clearChatState: () => void;
 }
@@ -325,6 +327,20 @@ export const createChatSlice: StateCreator<ChatSlice, [], [], ChatSlice> = (
     } catch {
       set({ sidebarSessionsLoading: false });
     }
+  },
+
+  clearActiveChatState: () => {
+    set({
+      chatSessions: [],
+      chatSessionsLoading: false,
+      chatMessages: [],
+      chatMessagesLoading: false,
+      activeChatSessionId: null,
+      chatStreaming: false,
+      chatStreamingContent: "",
+      chatError: null,
+      // sidebarSessions intentionally preserved
+    });
   },
 
   clearChatState: () => {

--- a/packages/web/src/client/src/store/index.ts
+++ b/packages/web/src/client/src/store/index.ts
@@ -277,6 +277,7 @@ export function useChatActions() {
       addUserMessage: state.addUserMessage,
       setChatError: state.setChatError,
       fetchSidebarSessions: state.fetchSidebarSessions,
+      clearActiveChatState: state.clearActiveChatState,
       clearChatState: state.clearChatState,
     }))
   );


### PR DESCRIPTION
## Summary

- **Bug:** Navigating from a chat page to an agent details page caused all sidebar chats to show "No chats yet" — a page refresh restored them
- **Root cause:** `ChatView`'s cleanup `useEffect` called `clearChatState()` on unmount, which reset the entire chat slice including `sidebarSessions` (shared global state used by the sidebar)
- **Fix:** Added a targeted `clearActiveChatState()` action that resets only the active session state (messages, streaming, errors) while preserving `sidebarSessions`

## Test plan

- [ ] Navigate to a chat page for an agent (sidebar shows chats for all agents)
- [ ] Click on a different agent's details page
- [ ] Verify sidebar chats remain visible (no "No chats yet")
- [ ] Verify switching between chat sessions still works correctly
- [ ] Verify creating and deleting chat sessions still updates the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)