### PR TITLE
fix: log OAuth refresh response body on failure

### DIFF
--- a/.changeset/oauth-refresh-error-logging.md
+++ b/.changeset/oauth-refresh-error-logging.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/core": patch
+---
+
+Log OAuth token refresh response body on failure for easier diagnosis

--- a/packages/core/src/runner/runtime/container-manager.ts
+++ b/packages/core/src/runner/runtime/container-manager.ts
@@ -360,7 +360,13 @@ async function refreshClaudeOAuthToken(
     });
 
     if (!response.ok) {
-      logger.error(`Token refresh failed: HTTP ${response.status}`);
+      let body = "";
+      try {
+        body = await response.text();
+      } catch {
+        // ignore body read failure
+      }
+      logger.error(`Token refresh failed: HTTP ${response.status}${body ? ` — ${body}` : ""}`);
       return null;
     }
 


### PR DESCRIPTION
## Summary

- When `refreshClaudeOAuthToken()` fails, now logs the response body alongside the HTTP status code
- Previously only logged `Token refresh failed: HTTP 400`, now logs `Token refresh failed: HTTP 400 — {"error":"invalid_grant","error_description":"Refresh token not found or invalid"}`
- Makes it possible to diagnose refresh failures from herdctl logs without manual curl

## Context

Investigated a 401 "OAuth token has expired" failure. The refresh mechanism fired correctly but failed with HTTP 400. The logs only showed the status code, not the `invalid_grant` error in the response body. Root cause turned out to be an expired login on the host (`claude login` fixed it), but the missing response body made diagnosis harder than it needed to be.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- Logging-only change, no behavioral difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)