### PR TITLE
fix(web): scope chat WebSocket handlers to the active session

### DIFF
--- a/.changeset/fix-chat-session-scoped-websocket.md
+++ b/.changeset/fix-chat-session-scoped-websocket.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/web": patch
+---
+
+Fix chat messages leaking between sessions and vanishing on navigation. WebSocket chat handlers now validate the incoming sessionId against the active session before updating state, preventing streaming chunks from one chat appearing in another and ensuring messages aren't lost when navigating away mid-response.

--- a/packages/web/src/client/src/hooks/useWebSocket.ts
+++ b/packages/web/src/client/src/hooks/useWebSocket.ts
@@ -119,29 +119,40 @@ export function useWebSocket() {
           break;
 
         case "chat:response": {
-          const { chunk } = message.payload;
-          appendStreamingChunk(chunk);
+          const { sessionId, chunk } = message.payload;
+          if (sessionId === useStore.getState().activeChatSessionId) {
+            appendStreamingChunk(chunk);
+          }
           break;
         }
 
         case "chat:complete": {
-          completeStreaming();
+          const { sessionId } = message.payload;
+          if (sessionId === useStore.getState().activeChatSessionId) {
+            completeStreaming();
+          }
           break;
         }
 
         case "chat:tool_call": {
-          addToolCallMessage({
-            toolName: message.payload.toolName,
-            inputSummary: message.payload.inputSummary,
-            output: message.payload.output,
-            isError: message.payload.isError,
-            durationMs: message.payload.durationMs,
-          });
+          const { sessionId } = message.payload;
+          if (sessionId === useStore.getState().activeChatSessionId) {
+            addToolCallMessage({
+              toolName: message.payload.toolName,
+              inputSummary: message.payload.inputSummary,
+              output: message.payload.output,
+              isError: message.payload.isError,
+              durationMs: message.payload.durationMs,
+            });
+          }
           break;
         }
 
         case "chat:error": {
-          setChatError(message.payload.error);
+          const { sessionId } = message.payload;
+          if (sessionId === useStore.getState().activeChatSessionId) {
+            setChatError(message.payload.error);
+          }
           break;
         }
       }


### PR DESCRIPTION
## Summary

- Fixes chat messages from one session leaking into another session's UI when switching between chats while a response is streaming
- Fixes messages vanishing when navigating away from a chat mid-response and returning — the REST fetch on return now loads the complete persisted history without interference from stale WebSocket events
- All four chat WebSocket handlers (`chat:response`, `chat:complete`, `chat:tool_call`, `chat:error`) now validate `message.payload.sessionId` against `activeChatSessionId` before updating store state

## What changed

**`packages/web/src/client/src/hooks/useWebSocket.ts`**

Every server-sent chat message already includes a `sessionId` in its payload, but the client handlers were ignoring it. Now each handler reads `useStore.getState().activeChatSessionId` at message-arrival time and silently drops messages that don't match. This is safe because the server persists all messages to disk regardless — so when the user navigates back to a session, the REST `fetchChatMessages` call returns the full history.

Using `useStore.getState()` instead of a reactive selector avoids adding `activeChatSessionId` to the effect dependency array, which would cause the WebSocket to disconnect and reconnect on every session change.

## Test plan

- [ ] In Chat A, send a message. While the agent is responding, switch to Chat B. Verify Chat A's streaming text does **not** appear in Chat B
- [ ] In Chat A, send a message. Navigate away entirely (e.g. to agents list). Navigate back to Chat A. Verify all messages (including tool calls) are present
- [ ] Normal single-session chat still works: send a message, see streaming response, tool calls render correctly
- [ ] Verify `pnpm typecheck` and `pnpm test` pass (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)