### PR TITLE
Fix iOS Safari auto-zoom on chat input focus

### DIFF
--- a/.changeset/fix-ios-safari-zoom.md
+++ b/.changeset/fix-ios-safari-zoom.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/web": patch
+---
+
+Fix iOS Safari auto-zoom on chat input focus by increasing font-size to 16px

--- a/packages/web/src/client/src/components/chat/Composer.tsx
+++ b/packages/web/src/client/src/components/chat/Composer.tsx
@@ -100,7 +100,7 @@ export function Composer({ agentName, sessionId }: ComposerProps) {
             onKeyDown={handleKeyDown}
             placeholder={`Send a message to ${agentName}...`}
             rows={1}
-            className="flex-1 bg-herd-input-bg border border-herd-border rounded-lg px-3 py-2.5 text-sm text-herd-fg placeholder:text-herd-muted focus:outline-none focus:border-herd-primary/60 transition-colors resize-none"
+            className="flex-1 bg-herd-input-bg border border-herd-border rounded-lg px-3 py-2.5 text-base text-herd-fg placeholder:text-herd-muted focus:outline-none focus:border-herd-primary/60 transition-colors resize-none"
             style={{ minHeight: "42px", maxHeight: "200px" }}
           />
           <button


### PR DESCRIPTION
## Problem

On iOS Safari, tapping the chat input causes the page to auto-zoom, making the send button hard to click. This is a known iOS Safari behavior - it automatically zooms in when focusing on input fields with `font-size < 16px`.

## Solution

Changed the chat textarea font-size from `text-sm` (14px) to `text-base` (16px).

## Testing

On iOS Safari:
- Tap into the chat input
- Page should no longer zoom
- Send button should remain easily clickable

## Changes

- `packages/web/src/client/src/components/chat/Composer.tsx`: Changed `text-sm` to `text-base` on textarea
- Added changeset for patch release

Fixes the mobile UX issue described in https://github.com/edspencer/herdctl/issues/108 (related)