### PR TITLE
Fix dashboard showing empty Recent Jobs section

### DIFF
--- a/.changeset/fix-dashboard-recent-jobs.md
+++ b/.changeset/fix-dashboard-recent-jobs.md
@@ -1,0 +1,7 @@
+---
+"@herdctl/web": patch
+---
+
+Fix dashboard showing empty "Recent Jobs" section
+
+Removed the 24-hour client-side filter that was discarding all jobs when none had run recently. The section already limits to the 50 most recent jobs via the store, so the time-based cutoff was unnecessary and caused the dashboard to appear broken.

--- a/packages/web/src/client/src/components/dashboard/FleetDashboard.tsx
+++ b/packages/web/src/client/src/components/dashboard/FleetDashboard.tsx
@@ -161,9 +161,6 @@ function RecentJobsEmptyState() {
 // Main Component
 // =============================================================================
 
-/** Cutoff for "recent" jobs: 24 hours */
-const RECENT_HOURS = 24;
-
 export function FleetDashboard() {
   const { fleetStatus, agents, recentJobs, lastUpdated } = useFleet();
   const { setRecentJobs } = useFleetActions();
@@ -179,12 +176,6 @@ export function FleetDashboard() {
         // Non-critical — dashboard still works from WebSocket events
       });
   }, [setRecentJobs]);
-
-  // Filter to last 24 hours
-  const cutoff = Date.now() - RECENT_HOURS * 60 * 60 * 1000;
-  const recentJobsFiltered = recentJobs.filter(
-    (job) => new Date(job.createdAt).getTime() >= cutoff,
-  );
 
   const counts = fleetStatus?.counts ?? {
     totalAgents: 0,
@@ -277,13 +268,13 @@ export function FleetDashboard() {
       {/* Recent Jobs Section */}
       <section>
         <Card className="p-4">
-          {recentJobsFiltered.length === 0 ? (
+          {recentJobs.length === 0 ? (
             <>
               <h2 className="text-sm font-semibold text-herd-fg mb-3">Recent Jobs</h2>
               <RecentJobsEmptyState />
             </>
           ) : (
-            <RecentJobs jobs={recentJobsFiltered} pageSize={10} />
+            <RecentJobs jobs={recentJobs} pageSize={10} />
           )}
         </Card>
       </section>


### PR DESCRIPTION
## Summary

- The dashboard's "Recent Jobs" section was always empty because a client-side 24-hour cutoff filtered out all jobs when none had run in the last day
- Removed the `RECENT_HOURS = 24` filter — the store already caps at the 50 most recent jobs, so the time-based cutoff was redundant and counterproductive

## Root cause

`FleetDashboard.tsx` fetched 100 jobs from the API, then filtered client-side to only show jobs from the last 24 hours. When no jobs had run recently (e.g., 2 days since last job), the filtered list was empty — showing "No jobs yet" despite 249 total jobs existing.

## Test plan

- [x] Verified API returns jobs correctly (249 total, 100 returned)
- [x] Confirmed 0 jobs fell within the 24h window (newest was 2 days old)
- [x] After fix: dashboard shows "Recent Jobs (50)" with paginated table
- [x] "Completed" stat chip now shows correct count (49)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)