### PR TITLE
fix(core): escape $ and backtick in Docker CLI runtime prompts

### DIFF
--- a/.changeset/fix-docker-shell-escaping.md
+++ b/.changeset/fix-docker-shell-escaping.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/core": patch
+---
+
+Fix shell escaping in Docker CLI runtime to prevent `$` and backtick characters in prompts from being interpreted by the shell. Previously, prompts containing dollar signs (e.g., "$1234") would have `$1` consumed by shell variable expansion, silently corrupting the prompt sent to the agent.

--- a/packages/core/src/runner/runtime/container-runner.ts
+++ b/packages/core/src/runner/runtime/container-runner.ts
@@ -150,7 +150,11 @@ export class ContainerRunner implements RuntimeInterface {
         // Build docker exec command with prompt piped to stdin
         // Uses printf to avoid issues with newlines and special chars in prompt
         // Command: docker exec <container> sh -c 'cd /workspace && printf %s "prompt" | claude <args>'
-        const escapedPrompt = prompt.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+        const escapedPrompt = prompt
+          .replace(/\\/g, "\\\\")
+          .replace(/\$/g, "\\$")
+          .replace(/`/g, "\\`")
+          .replace(/"/g, '\\"');
         const claudeArgs = args
           .map((arg) => {
             // Escape single quotes in arguments


### PR DESCRIPTION
## Summary

- Fix shell variable expansion bug in Docker CLI runtime where `$` and backtick characters in prompts were not escaped before being passed to `sh -c` inside double quotes
- Prompts like `$1234` were silently corrupted to `234` because `$1` was interpreted as an empty shell positional parameter
- Backticks were also vulnerable to command substitution interpretation

## Details

The Docker CLI runtime constructs a shell command like:

```
sh -c 'cd /workspace && printf %s "PROMPT" | claude ...'
```

The prompt escaping only handled `\` and `"`, but `$` and `` ` `` are also special inside double-quoted POSIX shell strings. This adds the two missing escape rules, in the correct order (backslash first to avoid double-escaping).

## Test plan

- [x] `pnpm test` — all 6 suites pass
- [x] `pnpm typecheck` — all 11 packages pass
- [x] `pnpm biome check` on changed file — clean
- [ ] Manual: send a Docker CLI agent a prompt containing `$1234` and verify it receives the full string

🤖 Generated with [Claude Code](https://claude.com/claude-code)