### PR TITLE
fix(web): prevent session cross-contamination when SDK session mapping is missing

### DIFF
--- a/.changeset/fix-web-chat-session-fallback.md
+++ b/.changeset/fix-web-chat-session-fallback.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/web": patch
+---
+
+Fix web chat session cross-contamination when SDK session mapping is missing. Previously, if a web chat session had no stored SDK session ID (e.g. after migration or expiry), the system would fall back to the agent's global session, causing the agent to resume a different conversation's context. Now explicitly starts a fresh session instead of using the fallback.

--- a/packages/web/src/server/chat/web-chat-manager.ts
+++ b/packages/web/src/server/chat/web-chat-manager.ts
@@ -431,7 +431,10 @@ export class WebChatManager {
       const result = await this.fleetManager.trigger(agentName, undefined, {
         triggerType: "web",
         prompt: message,
-        resume: existingSdkSessionId,
+        // Use null (not undefined) when no SDK session exists for this web chat.
+        // undefined means "use agent-level fallback session" which would cross-contaminate
+        // conversations by resuming a different chat's session context.
+        resume: existingSdkSessionId ?? null,
         onMessage: async (sdkMessage) => {
           // Extract text content from assistant messages
           if (sdkMessage.type === "assistant") {


### PR DESCRIPTION
## Summary

- When a web chat session has no stored SDK session ID (e.g. after the qualifiedName migration or session expiry), the `resume` parameter was passed as `undefined`, causing `job-control` to fall back to the agent's global session file. This could resume a completely different conversation's context in the wrong chat (e.g. asking about mulch but getting hard drive pricing context).
- Fix: pass `null` instead of `undefined` when no SDK session mapping exists, which tells `job-control` to start a fresh session rather than using the agent-level fallback.

## Root cause

The `trigger()` API distinguishes three states for `resume`:
- `"session-id"` — resume this specific session
- `null` — explicitly start fresh
- `undefined` — use agent-level fallback session lookup

Web chats each represent independent conversations, so falling back to the agent's global session is never correct. The one-line fix ensures unmapped web sessions always start fresh.

## Test plan

- [x] `pnpm typecheck` passes (all 11 packages)
- [x] `pnpm test` passes
- [x] Lint clean
- [ ] Manual: restart herdctl, open an old web chat that lost its SDK session mapping, send a message — agent should start fresh instead of resuming another conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)