### PR TITLE
feat: start web UI without fleet config for zero-config session browsing

### DIFF
--- a/.changeset/web-only-start.md
+++ b/.changeset/web-only-start.md
@@ -1,0 +1,6 @@
+---
+"@herdctl/core": minor
+"herdctl": minor
+---
+
+Start web UI without fleet config for zero-config session browsing. When no herdctl.yaml is found, `herdctl start` now boots the web dashboard in web-only mode instead of exiting with an error, letting users browse Claude Code sessions from ~/.claude/ without any fleet configuration.

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -12,6 +12,7 @@ import * as path from "node:path";
 import {
   type AgentInfo,
   ConfigNotFoundError,
+  ConfigurationError,
   type FleetConfigOverrides,
   FleetManager,
   type FleetStatus,
@@ -256,7 +257,31 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   try {
     // Initialize the fleet manager
-    await manager.initialize();
+    let webOnlyMode = false;
+    try {
+      await manager.initialize();
+    } catch (initError) {
+      // If no config file found, fall back to web-only mode
+      const isConfigNotFound =
+        initError instanceof ConfigNotFoundError ||
+        (initError instanceof ConfigurationError && initError.cause instanceof ConfigNotFoundError);
+
+      if (isConfigNotFound) {
+        console.log("No fleet configuration found — starting web UI only.");
+        console.log(
+          "Browse your Claude Code sessions at http://localhost:%s",
+          options.webPort ?? 3232,
+        );
+        console.log("");
+
+        await manager.initializeWebOnly({
+          port: options.webPort,
+        });
+        webOnlyMode = true;
+      } else {
+        throw initError;
+      }
+    }
 
     // Start the fleet
     await manager.start();
@@ -265,10 +290,16 @@ export async function startCommand(options: StartOptions): Promise<void> {
     const pidFile = await writePidFile(stateDir);
     console.log(`PID file written: ${pidFile}`);
 
-    // Get and display startup status
-    const status = await manager.getFleetStatus();
-    const agents = await manager.getAgentInfo();
-    console.log(formatStartupStatus(status, agents));
+    if (!webOnlyMode) {
+      // Get and display startup status
+      const status = await manager.getFleetStatus();
+      const agents = await manager.getAgentInfo();
+      console.log(formatStartupStatus(status, agents));
+    } else {
+      console.log("");
+      console.log("Press Ctrl+C to stop the server");
+      console.log("");
+    }
 
     // Stream logs to stdout
     // This keeps the process running since it's an async iterator

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -194,6 +194,94 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   // Lifecycle Methods
   // ===========================================================================
 
+  /**
+   * Initialize FleetManager in web-only mode without a configuration file
+   *
+   * Creates a minimal config with zero agents and web enabled, allowing
+   * the web dashboard to serve session data from ~/.claude/ without
+   * requiring a herdctl.yaml fleet configuration.
+   *
+   * @param options - Optional overrides for the minimal web config
+   */
+  async initializeWebOnly(options?: { port?: number; host?: string }): Promise<void> {
+    if (this.status !== "uninitialized" && this.status !== "stopped" && this.status !== "error") {
+      throw new InvalidStateError("initializeWebOnly", this.status, [
+        "uninitialized",
+        "stopped",
+        "error",
+      ]);
+    }
+
+    this.logger.debug("Initializing fleet manager in web-only mode...");
+
+    try {
+      // Build a minimal ResolvedConfig with web enabled and zero agents
+      this.config = {
+        fleet: {
+          version: 1,
+          fleet: { name: "herdctl" },
+          agents: [],
+          fleets: [],
+          web: {
+            enabled: true,
+            port: options?.port ?? 3232,
+            host: options?.host ?? "localhost",
+            session_expiry_hours: 24,
+            open_browser: false,
+            tool_results: true,
+            message_grouping: "separate",
+          },
+        },
+        agents: [],
+        configPath: "",
+        configDir: process.cwd(),
+      };
+
+      // Apply any CLI config overrides (e.g., --web-port)
+      if (this.configOverrides) {
+        this.config = this.applyConfigOverrides(this.config);
+      }
+
+      this.stateDirInfo = await this.initializeStateDir();
+      this.logger.debug("State directory initialized");
+
+      this.scheduler = new Scheduler({
+        stateDir: this.stateDir,
+        checkInterval: this.checkInterval,
+        logger: this.logger,
+        onTrigger: (info) => this.handleScheduleTrigger(info),
+      });
+
+      // Initialize chat managers (web will be picked up since config.fleet.web.enabled = true)
+      await this.initializeChatManagers();
+
+      await Promise.allSettled(
+        Array.from(this.chatManagers.entries()).map(async ([platform, manager]) => {
+          this.logger.debug(`Initializing ${platform} chat manager...`);
+          try {
+            await manager.initialize();
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.error(`Failed to initialize ${platform} chat manager: ${errorMessage}`);
+            this.chatManagers.delete(platform);
+          }
+        }),
+      );
+
+      this.status = "initialized";
+      this.initializedAt = new Date().toISOString();
+      this.lastError = null;
+
+      this.logger.info("Fleet manager initialized in web-only mode");
+      this.emit("initialized");
+    } catch (error) {
+      this.status = "error";
+      this.lastError = error instanceof Error ? error.message : String(error);
+      this.emit("error", error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }
+  }
+
   async initialize(): Promise<void> {
     if (this.status !== "uninitialized" && this.status !== "stopped") {
       throw new InvalidStateError("initialize", this.status, ["uninitialized", "stopped"]);


### PR DESCRIPTION
## Summary

- When no `herdctl.yaml` is found, `herdctl start` now boots the web dashboard in **web-only mode** instead of exiting with an error
- Users can browse all their Claude Code sessions from `~/.claude/` without any fleet configuration — enabling `npx herdctl start` to just work
- Adds `FleetManager.initializeWebOnly()` which creates a minimal config with zero agents and web enabled

## Changes

- **`packages/core/src/fleet-manager/fleet-manager.ts`** — New `initializeWebOnly()` method that builds a minimal `ResolvedConfig` (zero agents, `web.enabled = true`, port 3232). Accepts optional port/host overrides and handles the `error` state from a failed `initialize()` call.
- **`packages/cli/src/commands/start.ts`** — Catches `ConfigNotFoundError` (direct or wrapped in `ConfigurationError`) and falls back to web-only mode instead of `process.exit(1)`. Shows a friendly message with the URL.
- **`.changeset/web-only-start.md`** — Minor bumps for `@herdctl/core` and `herdctl`.

## Test plan

- [ ] Run `herdctl start` in a directory with no `herdctl.yaml` — should boot web server and show sessions
- [ ] Run `herdctl start` in a directory with a valid `herdctl.yaml` — should work exactly as before
- [ ] Run `herdctl start --web-port 4000` with no config — should use port 4000
- [ ] Verify `pnpm typecheck` passes
- [ ] Verify `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web-only mode: When herdctl starts without a configuration file, it now automatically launches the web dashboard in web-only mode, allowing you to browse and manage sessions from your local environment without requiring fleet configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->