### PR TITLE
fix: Show All button in DirectoryGroup now properly expands sessions

### DIFF
--- a/.changeset/fix-show-all-button.md
+++ b/.changeset/fix-show-all-button.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/web": patch
+---
+
+Fix "Show All" button in DirectoryGroup to properly expand beyond initial 10 sessions. Button now reveals all locally-loaded sessions and fetches additional sessions from server when needed.

--- a/packages/web/src/client/src/components/all-chats/DirectoryGroup.tsx
+++ b/packages/web/src/client/src/components/all-chats/DirectoryGroup.tsx
@@ -6,7 +6,7 @@
  */
 
 import { ChevronRight, Info } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { agentPath } from "../../lib/paths";
 import type { DirectoryGroup as DirectoryGroupType, DiscoveredSession } from "../../lib/types";
@@ -62,6 +62,7 @@ function sessionMatchesQuery(session: DiscoveredSession, query: string): boolean
 
 export function DirectoryGroup({ group, expanded, onToggle, searchQuery }: DirectoryGroupProps) {
   const { loadMoreGroupSessions } = useAllChatsActions();
+  const [showAll, setShowAll] = useState(false);
 
   // Filter sessions client-side when searching
   const filteredSessions = useMemo(() => {
@@ -70,13 +71,18 @@ export function DirectoryGroup({ group, expanded, onToggle, searchQuery }: Direc
   }, [group.sessions, searchQuery]);
 
   // Determine how many sessions to show
-  const sessionsToShow = filteredSessions.slice(0, INITIAL_SESSIONS_SHOWN);
+  const sessionsToShow = showAll ? filteredSessions : filteredSessions.slice(0, INITIAL_SESSIONS_SHOWN);
   const hasMoreLoaded = filteredSessions.length > INITIAL_SESSIONS_SHOWN;
   const hasMoreOnServer = group.sessionCount > group.sessions.length;
 
   // Handle "Show all" click
   const handleShowAll = () => {
-    loadMoreGroupSessions(group.encodedPath);
+    // First, show all locally-loaded sessions
+    setShowAll(true);
+    // Then fetch more from server if there are any
+    if (hasMoreOnServer) {
+      loadMoreGroupSessions(group.encodedPath);
+    }
   };
 
   return (
@@ -145,7 +151,7 @@ export function DirectoryGroup({ group, expanded, onToggle, searchQuery }: Direc
               ))}
 
               {/* Show more button */}
-              {(hasMoreLoaded || hasMoreOnServer) && (
+              {!showAll && (hasMoreLoaded || hasMoreOnServer) && (
                 <div className="px-4 py-2">
                   <button
                     type="button"


### PR DESCRIPTION
## Summary

Fixes #150

- Added `showAll` state to track whether user clicked "Show all" button
- When `showAll` is true, component renders all `filteredSessions` instead of slicing to `INITIAL_SESSIONS_SHOWN`
- Button now shows all locally-loaded sessions first, then fetches more from server if `hasMoreOnServer` is true
- Button is hidden after being clicked (when `showAll` is true)

## Changes

1. Import `useState` from React
2. Add `showAll` state (defaults to `false`)
3. Conditionally slice `filteredSessions` based on `showAll` state
4. Update `handleShowAll` to set state and conditionally fetch from server
5. Hide button when `showAll` is true

## Test plan

- [ ] Verify "Show All" button appears for directory groups with >10 sessions
- [ ] Click "Show All" and verify all locally-loaded sessions are displayed
- [ ] Verify button disappears after clicking
- [ ] Verify additional sessions are fetched from server when needed
- [ ] Verify no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the "Show All" button in the directory to properly expand beyond the initial view and display all available sessions
  * Now correctly reveals all locally-loaded sessions and automatically fetches additional sessions from the server when needed
  * The button is hidden once all sessions have been displayed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->