### PR TITLE
fix: return 500 for server errors in chat session routes

### DIFF
--- a/packages/web/src/server/routes/chat.ts
+++ b/packages/web/src/server/routes/chat.ts
@@ -234,8 +234,16 @@ export function registerChatRoutes(
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      const errCode = (error as NodeJS.ErrnoException).code;
       logger.error("Failed to get session by path", { error: message, encodedPath, sessionId });
-      return reply.status(404).send({ error: `Session not found: ${sessionId}` });
+
+      // Return 404 only for genuine "not found" cases
+      if (errCode === "ENOENT") {
+        return reply.status(404).send({ error: `Session not found: ${sessionId}` });
+      }
+
+      // Return 500 for all other errors (permission denied, disk failures, parse errors)
+      return reply.status(500).send({ error: `Failed to get session: ${message}` });
     }
   });
 
@@ -338,8 +346,16 @@ export function registerChatRoutes(
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      const errCode = (error as NodeJS.ErrnoException).code;
       logger.error("Failed to get session messages", { error: message, agentName, sessionId });
-      return reply.status(404).send({ error: `Session not found: ${sessionId}` });
+
+      // Return 404 only for genuine "not found" cases
+      if (errCode === "ENOENT") {
+        return reply.status(404).send({ error: `Session not found: ${sessionId}` });
+      }
+
+      // Return 500 for all other errors (permission denied, disk failures, parse errors)
+      return reply.status(500).send({ error: `Failed to get session: ${message}` });
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes #149 - Catch-all 404 in `/by-path` route masks server errors

### Problem

The `/api/chat/sessions/by-path/:encodedPath/:sessionId` and `/api/chat/:agentName/sessions/:sessionId` routes were returning 404 for **all** exceptions, including:
- Permission errors (EACCES)
- Disk failures (EIO)
- Parse errors
- Any other server-side errors

This made it impossible for monitoring/alerting to distinguish "session doesn't exist" from "server can't read the filesystem."

### Solution

Both routes now return:
- **404** only for `ENOENT` (genuine "not found" cases when the session file doesn't exist)
- **500** for all other errors (permission denied, disk failures, parse errors, etc.)

This matches the error handling pattern already used in other routes (`/usage`, `/agent/sessions`) that correctly return 500 for server errors.

### Changes

- Modified catch blocks in two endpoints to check error code before determining HTTP status
- Added explicit `ENOENT` check for 404 responses
- All other errors now correctly return 500

## Test plan

- [ ] Verify existing tests pass (CI will run full test suite)
- [ ] Manually test: request a non-existent session → receives 404
- [ ] Manually test: simulate permission error → receives 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses in chat API endpoints—session not found errors now correctly return 404 status code, while other errors return 500 status code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->