### PR TITLE
fix: invalidate attribution cache after chat message send

### DIFF
--- a/.changeset/fix-chat-attribution-cache.md
+++ b/.changeset/fix-chat-attribution-cache.md
@@ -1,0 +1,16 @@
+---
+"@herdctl/core": patch
+"@herdctl/web": patch
+---
+
+fix: invalidate attribution cache after chat message send
+
+New web chat sessions were not appearing in the sidebar because the
+SessionDiscoveryService's attribution index (30-second cache TTL) didn't
+include the newly written session attribution. The next getAgentSessions()
+call would filter out the new session since it wasn't yet in the index.
+
+Added `invalidateAttributionCache()` to SessionDiscoveryService and call
+it from WebChatManager.sendMessage() after writing session attribution.
+This also clears the directory file listing cache for the agent's working
+directory so new JSONL files are picked up immediately.

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -861,6 +861,101 @@ describe("SessionDiscoveryService", () => {
   });
 
   // ===========================================================================
+  // invalidateAttributionCache
+  // ===========================================================================
+
+  describe("invalidateAttributionCache", () => {
+    it("forces attribution index rebuild on next call", async () => {
+      mockBuildAttributionIndex.mockClear();
+
+      const workingDir = "/Users/ed/Code/myproject";
+      const encodedPath = "-Users-ed-Code-myproject";
+      const projectDir = join(tempClaudeHome, "projects", encodedPath);
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "session-abc");
+
+      mockBuildAttributionIndex.mockResolvedValue(
+        createMockAttributionIndex({ defaultAgentName: "my-agent" }),
+      );
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+        cacheTtlMs: 60000, // Long TTL so cache wouldn't expire naturally
+      });
+
+      // First call builds the index
+      await service.getAgentSessions("my-agent", workingDir, false);
+      expect(mockBuildAttributionIndex).toHaveBeenCalledTimes(1);
+
+      // Invalidate attribution cache
+      service.invalidateAttributionCache();
+
+      // Next call should rebuild the index despite long TTL
+      await service.getAgentSessions("my-agent", workingDir, false);
+      expect(mockBuildAttributionIndex).toHaveBeenCalledTimes(2);
+    });
+
+    it("also invalidates directory cache when workingDirectory is provided", async () => {
+      const workingDir = "/Users/ed/Code/myproject";
+      const encodedPath = "-Users-ed-Code-myproject";
+      const projectDir = join(tempClaudeHome, "projects", encodedPath);
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "session-abc");
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+        cacheTtlMs: 60000, // Long TTL
+      });
+
+      // Populate both caches
+      await service.getAgentSessions("my-agent", workingDir, false);
+
+      // Add a new session file (won't be seen due to cache)
+      await createSessionFile(projectDir, "session-def");
+
+      // Verify cache returns old data
+      const beforeInvalidate = await service.getAgentSessions("my-agent", workingDir, false);
+      expect(beforeInvalidate).toHaveLength(1);
+
+      // Invalidate attribution + directory cache for this path
+      service.invalidateAttributionCache(workingDir);
+
+      // Should now see both sessions
+      const afterInvalidate = await service.getAgentSessions("my-agent", workingDir, false);
+      expect(afterInvalidate).toHaveLength(2);
+    });
+
+    it("does not invalidate directory cache when no workingDirectory is provided", async () => {
+      const workingDir = "/Users/ed/Code/myproject";
+      const encodedPath = "-Users-ed-Code-myproject";
+      const projectDir = join(tempClaudeHome, "projects", encodedPath);
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "session-abc");
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+        cacheTtlMs: 60000, // Long TTL
+      });
+
+      // Populate caches
+      await service.getAgentSessions("my-agent", workingDir, false);
+
+      // Add a new session file
+      await createSessionFile(projectDir, "session-def");
+
+      // Invalidate only attribution (no workingDirectory arg)
+      service.invalidateAttributionCache();
+
+      // Directory cache is still active, so only 1 session
+      const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+      expect(sessions).toHaveLength(1);
+    });
+  });
+
+  // ===========================================================================
   // Edge cases
   // ===========================================================================
 

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -762,4 +762,29 @@ export class SessionDiscoveryService {
       logger.debug("Invalidated all caches");
     }
   }
+
+  /**
+   * Invalidate the attribution index cache.
+   *
+   * Call this after writing new session attribution (e.g., after a web chat
+   * message creates or updates a session) so the next session list request
+   * rebuilds the index and includes the newly attributed session.
+   *
+   * Optionally also invalidates a specific directory's file listing cache,
+   * which is needed when a new session creates a new JSONL file.
+   *
+   * @param workingDirectory - Optional working directory whose file listing cache should also be cleared
+   */
+  invalidateAttributionCache(workingDirectory?: string): void {
+    this.attributionIndex = null;
+    this.attributionFetchedAt = 0;
+    logger.debug("Invalidated attribution cache");
+
+    if (workingDirectory !== undefined) {
+      const encodedPath = encodePathForCli(workingDirectory);
+      const sessionDir = path.join(this.claudeHomePath, "projects", encodedPath);
+      this.directoryCache.delete(sessionDir);
+      logger.debug(`Also invalidated directory cache for: ${sessionDir}`);
+    }
+  }
 }

--- a/packages/web/src/server/__tests__/web-chat-manager.test.ts
+++ b/packages/web/src/server/__tests__/web-chat-manager.test.ts
@@ -148,6 +148,7 @@ function createMockDiscoveryService() {
       turnCount: 5,
       hasData: true,
     })),
+    invalidateAttributionCache: vi.fn(),
   } as any;
 }
 
@@ -733,6 +734,30 @@ describe("WebChatManager", () => {
         "sdk-session-abc",
         "sdk-session-abc",
       );
+    });
+
+    it("invalidates attribution cache after storing session attribution", async () => {
+      const onChunk = vi.fn();
+
+      await manager.sendMessage("test-agent", null, "Hello", onChunk);
+
+      expect(mockDiscoveryService.invalidateAttributionCache).toHaveBeenCalledWith(
+        "/home/user/project",
+      );
+    });
+
+    it("does not invalidate attribution cache on failed job", async () => {
+      mockFleetManager.trigger.mockResolvedValue({
+        jobId: "job-456",
+        success: false,
+        error: { message: "Agent busy" },
+      });
+
+      const onChunk = vi.fn();
+
+      await manager.sendMessage("test-agent", null, "Hello", onChunk);
+
+      expect(mockDiscoveryService.invalidateAttributionCache).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/web/src/server/chat/web-chat-manager.ts
+++ b/packages/web/src/server/chat/web-chat-manager.ts
@@ -384,6 +384,13 @@ export class WebChatManager {
           agentName,
           sdkSessionId: result.sessionId,
         });
+
+        // Invalidate the attribution cache so the next session list request
+        // picks up this newly attributed session immediately instead of
+        // waiting for the 30-second cache TTL to expire.
+        const agent = this.getAgentConfig(agentName);
+        const workDir = this.getWorkingDirectory(agent);
+        this.discoveryService!.invalidateAttributionCache(workDir);
       }
 
       return {


### PR DESCRIPTION
## Summary

- Fixes #164 — new web chat sessions not appearing in sidebar after sending a message
- Added `invalidateAttributionCache(workingDirectory?)` to `SessionDiscoveryService` that clears the attribution index and optionally a specific directory's file listing cache
- Called from `WebChatManager.sendMessage()` after writing session attribution, so the next `/api/chat/recent` poll picks up the new session immediately instead of waiting for the 30-second cache TTL

## Test plan

- [x] 3 new unit tests for `invalidateAttributionCache()` in session-discovery.test.ts (45/45 pass)
- [x] 2 new unit tests for cache invalidation in web-chat-manager.test.ts (40/40 pass)
- [x] TypeScript typecheck passes across all packages
- [ ] Manual: start web UI, send a chat message, verify new session appears in sidebar without refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness of session attribution updates—they now reflect immediately in session listings after sending a message instead of waiting for cache refresh intervals.

* **Tests**
  * Added comprehensive test coverage for cache invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->