### PR TITLE
fix: align all CLAUDE.md files with gold standard

### DIFF
--- a/.claude/rules/diagrams.md
+++ b/.claude/rules/diagrams.md
@@ -36,41 +36,4 @@ See `docs/d2-spike/fleet-composition-subteams.d2` for the canonical example usin
 
 ## Diagram Color Palette
 
-Colors are derived from the herdctl logo blue (`#326CE5`). All diagrams use these colors consistently.
-
-### Primary colors — for containers and structural hierarchy
-
-| Role | Fill | Stroke | Text | Usage |
-|------|------|--------|------|-------|
-| Top-level container | `#1e3a5f` | `#142842` | `#ffffff` | Super fleets, outermost containers |
-| Major components | `#326CE5` | `#2857b8` | `#ffffff` | Sub-fleets, core modules (logo blue) |
-| Secondary groupings | `#2a9d8f` | `#21867a` | `#ffffff` | Team groups, processing components |
-
-### Secondary colors — for leaf nodes, agents, and individual elements
-
-Each agent should get its own distinct color to aid visual identification. For non-agent diagrams, pick from this set for variety.
-
-| Name | Fill | Stroke | Text |
-|------|------|--------|------|
-| White | `#f8fafc` | `#cbd5e1` | `#1e293b` |
-| Slate | `#94a3b8` | `#64748b` | `#0f172a` |
-| Light blue | `#93c5fd` | `#60a5fa` | `#1e293b` |
-| Sky | `#38bdf8` | `#0ea5e9` | `#0c4a6e` |
-| Peach | `#fdba74` | `#f59e0b` | `#451a03` |
-| Amber | `#fbbf24` | `#d97706` | `#451a03` |
-| Coral | `#f87171` | `#ef4444` | `#ffffff` |
-| Rose | `#fda4af` | `#fb7185` | `#4c0519` |
-| Lavender | `#c4b5fd` | `#a78bfa` | `#2e1065` |
-| Mint | `#6ee7b7` | `#34d399` | `#064e3b` |
-| Sand | `#d6d3d1` | `#a8a29e` | `#1c1917` |
-| Warm gray | `#78716c` | `#57534e` | `#ffffff` |
-| Cyan | `#22d3ee` | `#06b6d4` | `#083344` |
-| Lime | `#a3e635` | `#84cc16` | `#1a2e05` |
-| Orange | `#fb923c` | `#f97316` | `#431407` |
-| Steel | `#475569` | `#334155` | `#ffffff` |
-
-### Guidelines
-
-- In agent diagrams, give each agent a unique secondary color so they're visually distinct.
-- In non-agent diagrams (architecture, flows, state machines), pick secondary colors for variety and contrast rather than using a single color for all leaf nodes.
-- Text color varies per secondary color (some are light-on-dark, some dark-on-light) — always use the text color from the table above.
+See `docs/diagram-color-palette.md` for the full color palette. Use herdctl brand colors consistently in all diagrams.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance for Claude Code when working in this repository.
 
 ## LIVE PROJECT - Follow Semver
 
-We are a live project. Breaking changes require a major version bump.
+Follow Semver. Breaking changes require a major version bump.
 
 ## Project Overview
 
@@ -58,7 +58,7 @@ pnpm dev                # Development mode (watch)
 ### Testing
 - Tests live in `__tests__/` directories adjacent to source
 - Use Vitest for unit tests
-- Coverage thresholds: 85% lines/functions/statements, 65% branches
+- Coverage thresholds vary per package — see each package's `vitest.config.ts`
 - Mock external dependencies (SDK, file system, GitHub API)
 
 ### Logging
@@ -79,7 +79,7 @@ pnpm dev                # Development mode (watch)
 
 | File | Purpose |
 |------|---------|
-| `docs/src/content/docs/architecture/` | Architecture documentation (14 pages) |
+| `docs/src/content/docs/architecture/` | Architecture documentation |
 | `packages/core/src/fleet-manager/` | FleetManager orchestration layer |
 | `packages/core/src/config/` | Configuration parsing and validation |
 | `packages/core/src/scheduler/` | Job scheduling |
@@ -96,7 +96,7 @@ Before merging:
 
 ## Documentation
 
-Documentation lives in `docs/` and deploys to herdctl.dev. When adding features:
+Keep documentation in `docs/`. It deploys to herdctl.dev automatically. When adding features:
 1. Update relevant docs in `docs/src/content/docs/`
 2. Run `pnpm build` in docs/ to verify
 3. Docs deploy automatically on merge to main

--- a/canon/claude-md-gold-standard.md
+++ b/canon/claude-md-gold-standard.md
@@ -188,9 +188,11 @@ This table is the authoritative list of CLAUDE.md files that should exist in the
 | `CLAUDE.md` (root) | ~102 | Project overview, shared conventions, quality gates |
 | `packages/core/CLAUDE.md` | ~44 | Unique module structure, relative imports, specific coverage thresholds |
 | `packages/cli/CLAUDE.md` | ~41 | Thin-client boundary enforcement — prevents business logic in CLI handlers |
-| `packages/web/CLAUDE.md` | ~61 | Different tech stack (React/Vite/Tailwind), design system, Zustand/Router |
+| `packages/web/CLAUDE.md` | ~60 | Different tech stack (React/Vite/Tailwind), design system, Zustand/Router |
 | `packages/chat/CLAUDE.md` | ~46 | Dependency-injected logger, session management, typed ChatErrorCode |
-| `packages/discord/CLAUDE.md` | ~40 | Custom DiscordLogger, discord.js mocking, DiscordErrorCode hierarchy |
+| `packages/discord/CLAUDE.md` | ~31 | Custom DiscordLogger, discord.js mocking, DiscordErrorCode hierarchy |
 | `packages/slack/CLAUDE.md` | ~39 | Socket Mode, mrkdwn formatting, SlackErrorCode hierarchy |
+| `agents/engineer/CLAUDE.md` | ~60 | Agent persona and behavior configuration, distinct from package conventions |
+| `docs/CLAUDE.md` | ~25 | Different tech stack (Astro/Starlight), distinct build/preview workflow, sidebar management, landing page conventions |
 
 Additional CLAUDE.md files may be added at the module level (e.g., `packages/core/src/scheduler/CLAUDE.md`) following the three-question test and reactive principle described above.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,33 @@
+# docs/CLAUDE.md
+
+Astro + Starlight documentation site. Deploys to herdctl.dev via Cloudflare Pages.
+
+## Build & Preview
+
+Run `pnpm build && pnpm preview` to see the site with Mermaid diagrams rendered.
+Never rely on `pnpm dev` (`astro dev`) for visual verification — Mermaid diagrams do not render in dev mode.
+
+## Content
+
+Write all documentation pages as `.md` or `.mdx` files in `src/content/docs/`.
+Use Mermaid code blocks for inline diagrams. Mermaid is configured via `rehype-mermaid` with client-side rendering.
+
+## Sidebar
+
+Manage the sidebar manually in `astro.config.mjs` under the `sidebar` array. Add new pages there explicitly — Starlight does not auto-discover content.
+
+## Landing Page
+
+Custom landing page components live in `src/components/landing/`. These use raw Tailwind and Inter font — they do NOT use `herd-*` design tokens from the web dashboard. Do not confuse these with `packages/web/` conventions.
+
+## D2 Diagrams
+
+D2 source files live in `docs/d2/`. Read `.claude/rules/diagrams.md` for the full D2 workflow, render commands, and the project color palette. Always use `--pad=20` when rendering.
+
+## Redirects
+
+Define URL redirects in `astro.config.mjs` under `redirects`. Update these when moving or renaming pages.
+
+## Analytics
+
+PostHog analytics are proxied through Cloudflare. Configuration is inline in `astro.config.mjs` head scripts.

--- a/docs/diagram-color-palette.md
+++ b/docs/diagram-color-palette.md
@@ -1,0 +1,40 @@
+# Diagram Color Palette
+
+Colors are derived from the herdctl logo blue (`#326CE5`). All diagrams use these colors consistently.
+
+## Primary colors — for containers and structural hierarchy
+
+| Role | Fill | Stroke | Text | Usage |
+|------|------|--------|------|-------|
+| Top-level container | `#1e3a5f` | `#142842` | `#ffffff` | Super fleets, outermost containers |
+| Major components | `#326CE5` | `#2857b8` | `#ffffff` | Sub-fleets, core modules (logo blue) |
+| Secondary groupings | `#2a9d8f` | `#21867a` | `#ffffff` | Team groups, processing components |
+
+## Secondary colors — for leaf nodes, agents, and individual elements
+
+Each agent should get its own distinct color to aid visual identification. For non-agent diagrams, pick from this set for variety.
+
+| Name | Fill | Stroke | Text |
+|------|------|--------|------|
+| White | `#f8fafc` | `#cbd5e1` | `#1e293b` |
+| Slate | `#94a3b8` | `#64748b` | `#0f172a` |
+| Light blue | `#93c5fd` | `#60a5fa` | `#1e293b` |
+| Sky | `#38bdf8` | `#0ea5e9` | `#0c4a6e` |
+| Peach | `#fdba74` | `#f59e0b` | `#451a03` |
+| Amber | `#fbbf24` | `#d97706` | `#451a03` |
+| Coral | `#f87171` | `#ef4444` | `#ffffff` |
+| Rose | `#fda4af` | `#fb7185` | `#4c0519` |
+| Lavender | `#c4b5fd` | `#a78bfa` | `#2e1065` |
+| Mint | `#6ee7b7` | `#34d399` | `#064e3b` |
+| Sand | `#d6d3d1` | `#a8a29e` | `#1c1917` |
+| Warm gray | `#78716c` | `#57534e` | `#ffffff` |
+| Cyan | `#22d3ee` | `#06b6d4` | `#083344` |
+| Lime | `#a3e635` | `#84cc16` | `#1a2e05` |
+| Orange | `#fb923c` | `#f97316` | `#431407` |
+| Steel | `#475569` | `#334155` | `#ffffff` |
+
+## Guidelines
+
+- In agent diagrams, give each agent a unique secondary color so they're visually distinct.
+- In non-agent diagrams (architecture, flows, state machines), pick secondary colors for variety and contrast rather than using a single color for all leaf nodes.
+- Text color varies per secondary color (some are light-on-dark, some dark-on-light) — always use the text color from the table above.

--- a/packages/chat/CLAUDE.md
+++ b/packages/chat/CLAUDE.md
@@ -32,7 +32,7 @@ src/
 
 ## Key Conventions
 
-- **Dependency-injected logger** -- components accept a `SessionManagerLogger` / `ChatConnectorLogger` interface rather than importing a logger directly. Never use raw `console.log`.
+- **Dependency-injected logger** -- Pass a `SessionManagerLogger` / `ChatConnectorLogger` interface to components. Never import a logger directly. Never use raw `console.log`.
 - **Typed errors with type guards** -- use `ChatErrorCode` enum and `isChatConnectorError()` / `isAlreadyConnectedError()` etc. for error discrimination.
 - **Zod schemas** -- session state is validated at read/write boundaries with `ChatSessionStateSchema`.
 

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -17,13 +17,13 @@ bin/
 
 ## Key Convention
 
-**This is a thin client.** All orchestration, config parsing, scheduling, and state management belong in `@herdctl/core`. Command files here should only:
+**Treat this as a thin client.** Delegate all orchestration, config parsing, scheduling, and state management to `@herdctl/core`. Command files must only:
 1. Parse CLI options
 2. Create a `FleetManager` instance
 3. Call FleetManager methods
 4. Format and print output
 
-If you find yourself writing business logic, it belongs in `@herdctl/core` instead.
+Move any business logic to `@herdctl/core`.
 
 ## Development
 
@@ -38,4 +38,4 @@ pnpm lint              # Biome linter
 
 ## Testing
 
-Tests live in `src/commands/__tests__/` adjacent to the command files. A top-level smoke test (`src/__tests__/smoke.test.ts`) validates the built binary. Tests use Vitest and mock `@herdctl/core` dependencies.
+Place tests in `src/commands/__tests__/` adjacent to command files. Use the smoke test at `src/__tests__/smoke.test.ts` to validate the built binary. Mock `@herdctl/core` dependencies in tests.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -18,12 +18,12 @@ The core library. **ALL business logic lives here.** CLI, web, discord, and slac
 
 ## Key Conventions
 
-- **Logging**: Use `createLogger("Prefix")` — never raw `console.*`. Within core, use relative imports: `import { createLogger } from "../utils/logger.js"`.
+- **Logging**: Within core, use relative imports for the logger: `import { createLogger } from "../utils/logger.js"`.
 - **Errors**: Extend `FleetManagerError` from `fleet-manager/errors.ts`. Always include actionable messages.
 - **Validation**: Use Zod schemas for all external input (config files, CLI args, API payloads).
 - **Imports**: Always use relative imports with `.js` extensions within this package.
 - **Tests**: Place in `__tests__/` directories adjacent to source files. Run with `pnpm test`.
-- **Exports**: All public API surfaces are re-exported through `src/index.ts`.
+- **Exports**: Re-export all public API surfaces through `src/index.ts`.
 
 ## Coverage Thresholds (vitest.config.ts)
 

--- a/packages/discord/CLAUDE.md
+++ b/packages/discord/CLAUDE.md
@@ -25,16 +25,7 @@ Discord bot connector for herdctl fleets. Lets agents join Discord servers, resp
 ## Conventions
 
 - **Errors**: All errors extend `DiscordConnectorError` with a `DiscordErrorCode` enum and `agentName`. Use `isDiscordConnectorError()` type guard for discrimination.
-- **Logging**: Use `DiscordLogger` (not `createLogger` from core). It supports three levels (`minimal`, `standard`, `verbose`) and auto-redacts sensitive fields in verbose mode.
+- **Logging**: Use `DiscordLogger` (not `createLogger` from core). Supports three levels (`minimal`, `standard`, `verbose`). Auto-redacts sensitive fields in verbose mode.
 - **Exports**: Everything public goes through `src/index.ts`. Keep types and implementations co-exported.
 
-## Commands
-
-```
-pnpm test              # run tests with coverage
-pnpm build             # compile TypeScript
-pnpm typecheck         # type-check without emitting
-pnpm lint              # biome check
-```
-
-Tests live in `__tests__/` directories adjacent to source files. Mock discord.js clients and channels in tests.
+Mock discord.js clients and channels in tests.

--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -11,7 +11,7 @@ Web dashboard for herdctl fleet management. Vite + React 19 + Tailwind v4, with 
 - **Colors**: Always use `herd-*` tokens (`bg-herd-bg`, `text-herd-fg`, `border-herd-border`, etc.). Never use raw Tailwind colors (`bg-gray-800`) or hex values.
 - **Fonts**: IBM Plex Sans (`font-sans`), IBM Plex Mono (`font-mono`), Lora (`font-serif` for chat agent responses). Never use Inter, Roboto, or Arial.
 - **Icons**: Lucide React (`lucide-react`), sized `w-4 h-4` (standard) or `w-3.5 h-3.5` (compact).
-- **Dark mode**: Handled entirely via CSS custom properties on `:root` / `.dark`. Never use Tailwind's `dark:` prefix in component classes.
+- **Dark mode**: Use CSS custom properties on `:root` / `.dark` for dark mode. Never use Tailwind's `dark:` prefix in component classes.
 - **Border radius**: `rounded-[10px]` for cards/panels, `rounded-lg` for buttons/inputs, `rounded-full` only for circles.
 - **State management**: Zustand slices in `src/client/src/store/`.
 - **Routing**: React Router v7.
@@ -45,7 +45,6 @@ src/
 
 - **Framework**: Vitest with `jsdom` environment for client tests, `node` environment for server tests.
 - **Libraries**: `@testing-library/react`, `@testing-library/jest-dom`.
-- **Test location**: `__tests__/` directories adjacent to source (currently under `src/server/__tests__/`).
 - **Path alias**: `@` maps to `./src/client/src` in tests and source.
 
 ## Development Commands


### PR DESCRIPTION
## Summary

- Fix all 19 issues identified by the CLAUDE.md audit report (`.reports/claude/2026-02-26-audit.md`)
- Establishes known-good baseline for automated daily audits (step 3 of 4-step plan)

### Changes by priority

**Stale references (P1):** Updated root CLAUDE.md coverage thresholds from incorrect "85%" to "vary per package", removed architecture docs page count to prevent future staleness

**Content duplication (P2):** Removed duplicated content from `packages/core/CLAUDE.md` (logging convention), `packages/web/CLAUDE.md` (test location), and `packages/discord/CLAUDE.md` (dev commands section)

**Style (P3):** Rewrote 10 descriptive lines to imperative language across 6 files (root, core, cli, web, chat, discord)

**Size violations (P4):** Extracted color palette table from `.claude/rules/diagrams.md` (76→39 lines) to `docs/diagram-color-palette.md`

**Coverage gaps (P5):** Created `docs/CLAUDE.md` (33 lines) for Astro/Starlight conventions

**Inventory (P6):** Added `docs/CLAUDE.md` and `agents/engineer/CLAUDE.md` entries to gold standard inventory

## Test plan

- [x] Verification audit passed 18/18 checks
- [x] Confirm no package behavior changes (docs-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established comprehensive diagram color palette and branding guidelines to maintain visual consistency across project documentation.
  * Clarified development conventions covering logging practices, testing approaches, code exports, and inter-package responsibilities.
  * Enhanced documentation site configuration guide with detailed guidance on building, content management, diagram workflows, and analytics setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->