### PR TITLE
docs: changelog update for v5.10.0 release

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,8 +1,8 @@
 ---
-last_checked_commit: 72ab438
-last_run: "2026-03-11T00:00:00Z"
-entries_added: 0
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06"]
+last_checked_commit: 8b8a3e1
+last_run: "2026-03-14T00:00:00Z"
+entries_added: 3
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-14"]
 status: completed
 ---
 
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 72ab438 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-11T00:00:00Z | No user-facing changes to document |
-| Entries added (last run) | 0 | All commits were agent housekeeping |
-| Branches created | (none) | No branch needed |
+| Last checked commit | 8b8a3e1 | chore: version packages (#201) |
+| Last run | 2026-03-14T00:00:00Z | Added 3 entries for v5.10.0 release |
+| Entries added (last run) | 3 | Discord attachments, CLI MCP, Slack dedup |
+| Branches created | changelog/auto-update-2026-03-14 | Ready for PR |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-03-14 | 2 | 3 | Created branch | changelog/auto-update-2026-03-14 |
 | 2026-03-11 | 10 | 0 | No update needed | - |
 | 2026-03-09 | 2 | 0 | No update needed | - |
 | 2026-03-08 | 3 | 0 | No update needed | - |

--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,6 +1,6 @@
 ---
-last_checked_commit: 62098bb
-last_run: "2026-03-07T05:15:00Z"
+last_checked_commit: 9a6b58d
+last_run: "2026-03-08T12:00:00Z"
 entries_added: 0
 branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06"]
 status: completed
@@ -19,9 +19,9 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 62098bb | security: audit 2026-03-06 - 71 commits analyzed (YELLOW) |
-| Last run | 2026-03-07T05:15:00Z | No user-facing changes to document |
-| Entries added (last run) | 0 | All commits were internal/docs updates |
+| Last checked commit | 9a6b58d | chore(docs-auditor): update audit state (2026-03-08) |
+| Last run | 2026-03-08T12:00:00Z | No user-facing changes to document |
+| Entries added (last run) | 0 | All commits were agent housekeeping |
 | Branches created | (none) | No branch needed |
 
 ---
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-03-08 | 3 | 0 | No update needed | - |
 | 2026-03-07 | 4 | 0 | No update needed | - |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,7 +1,7 @@
 ---
-last_checked_commit: b7fed00
-last_run: "2026-03-06T04:01:56Z"
-entries_added: 3
+last_checked_commit: 62098bb
+last_run: "2026-03-07T05:15:00Z"
+entries_added: 0
 branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06"]
 status: completed
 ---
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | b7fed00 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-06T04:01:56Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Tool restriction, Discord typing indicator, Docker session/security fixes |
-| Branches created | changelog/auto-update-2026-03-06 | Current update branch |
+| Last checked commit | 62098bb | security: audit 2026-03-06 - 71 commits analyzed (YELLOW) |
+| Last run | 2026-03-07T05:15:00Z | No user-facing changes to document |
+| Entries added (last run) | 0 | All commits were internal/docs updates |
+| Branches created | (none) | No branch needed |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-03-07 | 4 | 0 | No update needed | - |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |
 | 2026-02-26 | 11 | 3 | Created PR | changelog/auto-update-2026-02-26 |

--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,6 +1,6 @@
 ---
-last_checked_commit: 9a6b58d
-last_run: "2026-03-08T12:00:00Z"
+last_checked_commit: 72ab438
+last_run: "2026-03-11T00:00:00Z"
 entries_added: 0
 branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06"]
 status: completed
@@ -19,8 +19,8 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 9a6b58d | chore(docs-auditor): update audit state (2026-03-08) |
-| Last run | 2026-03-08T12:00:00Z | No user-facing changes to document |
+| Last checked commit | 72ab438 | chore(engineer): daily housekeeping |
+| Last run | 2026-03-11T00:00:00Z | No user-facing changes to document |
 | Entries added (last run) | 0 | All commits were agent housekeeping |
 | Branches created | (none) | No branch needed |
 
@@ -30,6 +30,8 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-03-11 | 10 | 0 | No update needed | - |
+| 2026-03-09 | 2 | 0 | No update needed | - |
 | 2026-03-08 | 3 | 0 | No update needed | - |
 | 2026-03-07 | 4 | 0 | No update needed | - |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -59,3 +59,8 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 **Date:** 2026-03-07 | **Type:** chat
 Performed daily housekeeping tasks: confirmed already on main branch (up-to-date), checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-07). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-08 | **Type:** chat
+Performed daily housekeeping tasks: confirmed already on main branch (up-to-date), checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-08). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -79,3 +79,8 @@ Performed daily housekeeping tasks: confirmed on main branch, rebased with remot
 **Date:** 2026-03-12 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-12) to main branch, stashed uncommitted security agent changes, checked conversations.md token count (~1300 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-12). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-13 | **Type:** chat
+Performed daily housekeeping tasks: confirmed already on main branch (up-to-date), checked conversations.md token count (~1300 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-13). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 1900
+token_estimate: 2000
 last_archived: null
 ---
 
@@ -68,4 +68,9 @@ Performed daily housekeeping tasks: confirmed already on main branch (up-to-date
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-03-09 | **Type:** chat
 Performed daily housekeeping tasks: confirmed already on main branch (up-to-date), checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-09). All state files remain clean and current.
+**Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-10 | **Type:** chat
+Performed daily housekeeping tasks: confirmed already on main branch, rebased with remote to sync changes (stashed other agents' uncommitted changes), checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from Feb 26), confirmed state.md has no stale entries, updated state.md with current date (2026-03-10). All state files remain clean and current.
 **Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -64,3 +64,8 @@ Performed daily housekeeping tasks: confirmed already on main branch (up-to-date
 **Date:** 2026-03-08 | **Type:** chat
 Performed daily housekeeping tasks: confirmed already on main branch (up-to-date), checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-08). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-09 | **Type:** chat
+Performed daily housekeeping tasks: confirmed already on main branch (up-to-date), checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-09). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2000
+token_estimate: 1300
 last_archived: null
 ---
 
@@ -9,11 +9,6 @@ Rolling summary of recent conversations across all chat sessions.
 Older entries are archived to `conversations-archive.md` when this file approaches ~20,000 tokens.
 
 ---
-
-### Daily housekeeping - state file maintenance
-**Date:** 2026-02-23 | **Type:** chat
-Performed daily housekeeping tasks: checked conversations.md token count (~1000 tokens, well below 20k threshold), removed duplicate entries from previous runs, verified no recent jobs in last 24h (most recent jobs from 2026-02-19 were for other agents), updated state.md with current date (2026-02-23). All state files are clean and up-to-date.
-**Outcome:** State files cleaned and updated
 
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-02-24 | **Type:** chat
@@ -73,4 +68,9 @@ Performed daily housekeeping tasks: confirmed already on main branch (up-to-date
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-03-10 | **Type:** chat
 Performed daily housekeeping tasks: confirmed already on main branch, rebased with remote to sync changes (stashed other agents' uncommitted changes), checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from Feb 26), confirmed state.md has no stale entries, updated state.md with current date (2026-03-10). All state files remain clean and current.
+**Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-11 | **Type:** chat
+Performed daily housekeeping tasks: confirmed on main branch, rebased with remote to sync changes (resolved merge conflict in agents/docs/state.md, stashed security agent changes), removed oldest entry (2026-02-23) to keep log manageable, checked conversations.md token count (~1300 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs still from Feb 26), confirmed state.md has no stale entries, updated state.md with current date (2026-03-11). All state files remain clean and current.
 **Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -74,3 +74,8 @@ Performed daily housekeeping tasks: confirmed already on main branch, rebased wi
 **Date:** 2026-03-11 | **Type:** chat
 Performed daily housekeeping tasks: confirmed on main branch, rebased with remote to sync changes (resolved merge conflict in agents/docs/state.md, stashed security agent changes), removed oldest entry (2026-02-23) to keep log manageable, checked conversations.md token count (~1300 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs still from Feb 26), confirmed state.md has no stale entries, updated state.md with current date (2026-03-11). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-12 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-12) to main branch, stashed uncommitted security agent changes, checked conversations.md token count (~1300 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-12). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -54,3 +54,8 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 **Date:** 2026-03-06 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-06) to main branch with rebase, checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-06). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-07 | **Type:** chat
+Performed daily housekeeping tasks: confirmed already on main branch (up-to-date), checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-03-07). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-12"
+last_active: "2026-03-13"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-13
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-07"
+last_active: "2026-03-08"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-07
+**Last Updated:** 2026-03-08
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-10"
+last_active: "2026-03-11"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-10
+**Last Updated:** 2026-03-11
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-11"
+last_active: "2026-03-12"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-11
+**Last Updated:** 2026-03-12
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-08"
+last_active: "2026-03-09"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-08
+**Last Updated:** 2026-03-09
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-09"
+last_active: "2026-03-10"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-09
+**Last Updated:** 2026-03-10
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-06"
+last_active: "2026-03-07"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-06
+**Last Updated:** 2026-03-07
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,27 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Discord File Attachments
+**March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0` · `herdctl@1.5.7`
+
+Discord agents can now receive and process file attachments (images, PDFs, text files, code files) uploaded alongside messages. Text and code files are automatically downloaded and inlined into the agent's prompt for immediate context. Images and PDFs are saved to the agent's working directory with a file path reference, allowing the agent to use its Read tool to view them. Configure via the `chat.discord.attachments` field with options for file size limits, allowed file types, and automatic cleanup. This enables workflows like "here's a screenshot of the bug" or "review this PDF spec" directly in Discord without manual file transfers.
+
+---
+
+### CLI Runtime MCP Server Support
+**March 10, 2026** · `@herdctl/core@5.10.0` · `herdctl@1.5.7`
+
+The CLI runtime now supports injected MCP servers (Model Context Protocol servers), enabling features like file sending for Discord and Slack file uploads. Previously only SDK and Docker runtimes handled injected MCP servers — CLI runtime agents silently ignored them, breaking file attachment features for CLI-based chat agents. The fix reuses existing HTTP bridge infrastructure: herdctl starts HTTP bridges on localhost for each injected server and passes them to the CLI via `--mcp-config` as HTTP-type MCP servers. This brings feature parity across all three runtime modes.
+
+---
+
+### Slack Message Deduplication Fix
+**March 10, 2026** · `@herdctl/slack@1.2.13` · `herdctl@1.5.7`
+
+Fixed duplicate assistant messages appearing in Slack channels. Claude Code can emit intermediate JSONL snapshots (with `stop_reason: null`) before the final assistant message, and the Slack manager was treating each snapshot as a separate message. The connector now skips intermediate snapshots and deduplicates by `message.id`, ensuring only the final, complete assistant response appears in the channel. This eliminates confusing duplicate messages during long-running agent operations.
+
+---
+
 ### Tool Availability Restriction
 **March 5, 2026** · `@herdctl/core@5.9.0` · `herdctl@1.5.6`
 


### PR DESCRIPTION
## Summary
- Added 3 changelog entries for v5.10.0 release (March 10, 2026)
- Updated state tracking (commits 72ab438..8b8a3e1 analyzed)

## New Entries
1. **Discord File Attachments** - Upload images, PDFs, and code files directly in Discord messages
2. **CLI Runtime MCP Support** - Fixes injected MCP servers for CLI agents (file sending, etc.)
3. **Slack Message Deduplication** - Eliminates duplicate assistant messages from intermediate snapshots

## Metadata
- Commits analyzed: 2
- Entries added: 3
- Release version: @herdctl/core@5.10.0, @herdctl/discord@1.2.0, @herdctl/slack@1.2.13, herdctl@1.5.7
- Branch: changelog/auto-update-2026-03-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord agents can now receive and process file attachments (images, PDFs, text, code) with configurable limits and types.
  * CLI runtime now supports injected MCP servers via HTTP bridges, enabling feature parity across runtimes.

* **Bug Fixes**
  * Fixed Slack message duplication by deduplicating responses based on message ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->