### PR TITLE
fix(core): skip Discord hooks for Discord-triggered jobs

### DIFF
--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -509,9 +509,24 @@ export class JobControl {
     });
 
     // Execute after_run hooks (run for all events)
-    if (agent.hooks.after_run && agent.hooks.after_run.length > 0) {
-      logger.debug(`Executing ${agent.hooks.after_run.length} after_run hook(s)`);
-      const afterRunResult = await hookExecutor.executeHooks(agent.hooks, context, "after_run");
+    // Skip Discord hooks when the job was triggered from Discord, since the
+    // Discord manager already streams output to the channel in real-time.
+    const filteredAfterRun =
+      context.triggerType === "discord"
+        ? (agent.hooks.after_run ?? []).filter((h) => h.type !== "discord")
+        : agent.hooks.after_run;
+    if (filteredAfterRun && filteredAfterRun.length > 0) {
+      if (filteredAfterRun.length !== (agent.hooks.after_run ?? []).length) {
+        logger.debug(
+          "Skipping Discord after_run hook(s) for Discord-triggered job to prevent duplicates",
+        );
+      }
+      logger.debug(`Executing ${filteredAfterRun.length} after_run hook(s)`);
+      const afterRunResult = await hookExecutor.executeHooks(
+        { ...agent.hooks, after_run: filteredAfterRun },
+        context,
+        "after_run",
+      );
 
       if (afterRunResult.shouldFailJob) {
         logger.warn(`Hook failure with continue_on_error=false detected for job ${jobMetadata.id}`);
@@ -519,9 +534,23 @@ export class JobControl {
     }
 
     // Execute on_error hooks (only for failed events)
-    if (event === "failed" && agent.hooks.on_error && agent.hooks.on_error.length > 0) {
-      logger.debug(`Executing ${agent.hooks.on_error.length} on_error hook(s)`);
-      const onErrorResult = await hookExecutor.executeHooks(agent.hooks, context, "on_error");
+    // Also skip Discord hooks for Discord-triggered jobs here
+    const filteredOnError =
+      context.triggerType === "discord"
+        ? (agent.hooks.on_error ?? []).filter((h) => h.type !== "discord")
+        : agent.hooks.on_error;
+    if (event === "failed" && filteredOnError && filteredOnError.length > 0) {
+      if (filteredOnError.length !== (agent.hooks.on_error ?? []).length) {
+        logger.debug(
+          "Skipping Discord on_error hook(s) for Discord-triggered job to prevent duplicates",
+        );
+      }
+      logger.debug(`Executing ${filteredOnError.length} on_error hook(s)`);
+      const onErrorResult = await hookExecutor.executeHooks(
+        { ...agent.hooks, on_error: filteredOnError },
+        context,
+        "on_error",
+      );
 
       if (onErrorResult.shouldFailJob) {
         logger.warn(
@@ -556,6 +585,7 @@ export class JobControl {
 
     return {
       event,
+      triggerType: jobMetadata.trigger_type,
       job: {
         id: jobMetadata.id,
         agentId: agent.qualifiedName,

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -9,6 +9,8 @@
  * This file contains only runtime types not derived from Zod schemas.
  */
 
+import type { TriggerType } from "../state/schemas/job-metadata.js";
+
 // Import config types that are validated by Zod
 // We import both output types (after defaults) and input types (for construction)
 import type {
@@ -156,7 +158,7 @@ export interface HookContext {
    * skipped when triggerType is "discord" because the Discord manager already
    * streams output to the channel in real-time.
    */
-  triggerType?: string;
+  triggerType?: TriggerType;
 
   /**
    * Agent-provided metadata (from metadata.json or configured metadata_file)

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -150,6 +150,15 @@ export interface HookContext {
   };
 
   /**
+   * How the job was triggered (e.g. "manual", "schedule", "discord", "slack")
+   *
+   * Used to prevent duplicate notifications - for example, Discord hooks are
+   * skipped when triggerType is "discord" because the Discord manager already
+   * streams output to the channel in real-time.
+   */
+  triggerType?: string;
+
+  /**
    * Agent-provided metadata (from metadata.json or configured metadata_file)
    *
    * This is arbitrary structured data that the agent can write during execution.

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -9,8 +9,6 @@
  * This file contains only runtime types not derived from Zod schemas.
  */
 
-import type { TriggerType } from "../state/schemas/job-metadata.js";
-
 // Import config types that are validated by Zod
 // We import both output types (after defaults) and input types (for construction)
 import type {
@@ -28,6 +26,7 @@ import type {
   WebhookHookConfig,
   WebhookHookConfigInput,
 } from "../config/schema.js";
+import type { TriggerType } from "../state/schemas/job-metadata.js";
 
 // Re-export for convenience within the hooks module
 // Export input types (used by tests and runners)


### PR DESCRIPTION
## Summary

- When a job is triggered from Discord, the Discord manager already streams output to the channel in real-time via `onMessage`. After the job completes, `executeHooks` also fires any configured `discord`-type hooks (`after_run` and `on_error`), resulting in **duplicate messages** in the Discord channel.
- This fix filters out Discord-type hooks when the job's `triggerType` is `"discord"`, preventing the duplication while leaving all other hook types (shell, webhook, slack) unaffected.
- Adds `triggerType` to `HookContext` so hook execution can be trigger-aware.

## Changes

- `packages/core/src/fleet-manager/job-control.ts`: Filter Discord hooks from `after_run` and `on_error` arrays when `context.triggerType === "discord"`. Plumb `triggerType` from `jobMetadata.trigger_type` into `buildHookContext()`.
- `packages/core/src/hooks/types.ts`: Add optional `triggerType` field to `HookContext` interface with documentation.

## Test plan

- [ ] Configure an agent with a Discord `after_run` hook and trigger a job from Discord — verify only one response appears (not duplicated)
- [ ] Trigger the same agent via CLI/schedule — verify the Discord hook still fires normally
- [ ] Verify non-Discord hooks (shell, webhook) still execute for Discord-triggered jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate notifications when jobs are triggered from Discord by skipping redundant Discord-specific hooks during execution (including success and failure cases).

* **Improvements**
  * Job execution context now recognizes trigger sources (Discord, manual, scheduled, Slack) so notifications and hooks are handled more accurately and consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->