### PR TITLE
docs: auto-update documentation (2026-03-25)

### DIFF
--- a/agents/docs/state.md
+++ b/agents/docs/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 1114870f5bcf4d2b7ce74e0df7e1f7d5e3f3b6b9
-last_run: "2026-03-13T07:08:30Z"
-docs_gaps_found: 5
-branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13"]
+last_checked_commit: 3516a3c85a91ee5c44b7cf92a9c4f43f52feb4ae
+last_run: "2026-03-25T03:05:37Z"
+docs_gaps_found: 1
+branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13", "docs/auto-update-2026-03-25"]
 status: completed
 ---
 
 # Documentation Audit State
 
-**Last Updated:** 2026-03-13
+**Last Updated:** 2026-03-25
 
 This document tracks the state of the documentation audit agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 1114870 | docs: auto-update documentation (2026-03-07) |
-| Last run | 2026-03-13T07:08:30Z | Manual invocation |
-| Gaps found (last run) | 5 | Discord improvements features |
-| Branches created | docs/auto-update-2026-03-13 | Added Discord voice, attachments, output, guild, skills docs |
+| Last checked commit | 3516a3c | chore: version packages (#211) |
+| Last run | 2026-03-25T03:05:37Z | Scheduled run |
+| Gaps found (last run) | 1 | Windows path separator fix |
+| Branches created | docs/auto-update-2026-03-25 | Added What's New entry for Windows fix |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Gaps Found | Action | Branch |
 |------|-----------------|------------|--------|--------|
+| 2026-03-25 | 2 | 1 | created-branch | docs/auto-update-2026-03-25 |
 | 2026-03-13 | 3 | 5 | created-branch | docs/auto-update-2026-03-13 |
 | 2026-03-07 | 4 | 1 | created-branch | docs/auto-update-2026-03-07 |
 | 2026-03-05 | 10 | 1 | created-branch | docs/auto-update-2026-03-05 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Path Separator Compatibility Fix
+**March 17, 2026** · `@herdctl/core@5.10.1`
+
+Fixed a critical bug that prevented herdctl from functioning on Windows systems. The path traversal security check in state file operations used a hardcoded forward slash (`/`) separator, but Windows `path.resolve()` returns paths with backslashes (`\`). This caused every state file operation to fail with false positive `PathTraversalError` exceptions, making herdctl completely non-functional on Windows. The fix uses `path.sep` to correctly handle platform-specific path separators on both Windows and Unix systems. Also handles edge cases where base paths already end with a separator to prevent double-separator bugs. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
Automated documentation audit found 1 gap across 2 commits.

## Gaps Addressed

### Gap 1: Windows Path Separator Fix Not Mentioned in What's New
- **Commit:** 31c675c "fix: use path.sep in path traversal check for Windows compatibility (#210)"
- **What changed:** Fixed critical bug where path traversal check used hardcoded "/" separator, causing false positive errors on Windows
- **Documentation added:** Entry in What's New page for March 17, 2026 release
- **Priority:** Medium

## Summary

Added documentation to `/opt/herdctl/docs/src/content/docs/whats-new.md` explaining the Windows path separator compatibility fix released in `@herdctl/core@5.10.1`. This was a critical fix that made herdctl functional on Windows, where previously all state file operations would fail with false positive `PathTraversalError` exceptions.

Generated by docs-audit-daily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows path separator compatibility issue in version 5.10.1 that incorrectly triggered traversal errors. Platform-specific separator handling has been implemented to prevent this error on Windows systems.

* **Documentation**
  * Updated changelog with new release information and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->