### PR TITLE
docs: update What's New page (2026-03-25)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
+last_checked_commit: 993f597
+last_run: "2026-03-16T04:00:55Z"
+entries_added: 0
 branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
 status: completed
 ---
 
 # Changelog Update State
 
-**Last Updated:** 2026-02-25T04:05:06Z
+**Last Updated:** 2026-03-16T04:00:55Z
 
 This document tracks the state of the changelog updater agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 993f597 | docs: update What's New page (2026-03-13) |
+| Last run | 2026-03-16T04:00:55Z | No new user-facing changes |
+| Entries added (last run) | 0 | Only doc automation commits found |
+| Branches created | None | No changes to document |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-03-16 | 2 | 0 | No changes | None (doc automation only) |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,8 +1,8 @@
 ---
-last_checked_commit: 993f597
-last_run: "2026-03-16T04:00:55Z"
-entries_added: 0
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 3662d18
+last_run: "2026-03-25T04:01:23Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-03-25"]
 status: completed
 ---
 
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 993f597 | docs: update What's New page (2026-03-13) |
-| Last run | 2026-03-16T04:00:55Z | No new user-facing changes |
-| Entries added (last run) | 0 | Only doc automation commits found |
-| Branches created | None | No changes to document |
+| Last checked commit | 3662d18 | chore: version packages (#211) |
+| Last run | 2026-03-25T04:01:23Z | Added Windows path fix entry |
+| Entries added (last run) | 1 | @herdctl/core@5.10.1 release |
+| Branches created | changelog/auto-update-2026-03-25 | Ready for PR |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-03-25 | 2 | 1 | Ready for PR | changelog/auto-update-2026-03-25 |
 | 2026-03-16 | 2 | 0 | No changes | None (doc automation only) |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |

--- a/agents/docs/state.md
+++ b/agents/docs/state.md
@@ -1,7 +1,7 @@
 ---
-last_checked_commit: 1114870f5bcf4d2b7ce74e0df7e1f7d5e3f3b6b9
-last_run: "2026-03-13T07:08:30Z"
-docs_gaps_found: 5
+last_checked_commit: 8a9c5fb682fd34d9dcd094fb6ddb44b39e5eb1bf
+last_run: "2026-03-15T03:00:43Z"
+docs_gaps_found: 0
 branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13"]
 status: completed
 ---
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 1114870 | docs: auto-update documentation (2026-03-07) |
-| Last run | 2026-03-13T07:08:30Z | Manual invocation |
-| Gaps found (last run) | 5 | Discord improvements features |
-| Branches created | docs/auto-update-2026-03-13 | Added Discord voice, attachments, output, guild, skills docs |
+| Last checked commit | 8a9c5fb | chore(engineer): daily housekeeping |
+| Last run | 2026-03-15T03:00:43Z | Scheduled run |
+| Gaps found (last run) | 0 | No code changes since last audit |
+| Branches created | - | No action needed |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Gaps Found | Action | Branch |
 |------|-----------------|------------|--------|--------|
+| 2026-03-15 | 3 | 0 | no-action | - |
 | 2026-03-13 | 3 | 5 | created-branch | docs/auto-update-2026-03-13 |
 | 2026-03-07 | 4 | 1 | created-branch | docs/auto-update-2026-03-07 |
 | 2026-03-05 | 10 | 1 | created-branch | docs/auto-update-2026-03-05 |

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -84,3 +84,8 @@ Performed daily housekeeping tasks: confirmed on main branch (already up-to-date
 **Date:** 2026-03-17 | **Type:** chat
 Performed daily housekeeping tasks: confirmed on main branch (already up-to-date), checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (no recent jobs found), confirmed state.md has no stale entries, updated state.md with current date (2026-03-17). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-18 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-18) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from 2026-02-26, over 20 days old), confirmed state.md has no stale entries, updated state.md with current date (2026-03-18). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -69,3 +69,8 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 **Date:** 2026-03-14 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-14) to main branch, reset to origin/main to resolve divergence (local had accumulated housekeeping commits), checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from 2026-02-26), confirmed state.md has no stale entries, updated state.md with current date (2026-03-14). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-15 | **Type:** chat
+Performed daily housekeeping tasks: confirmed on main branch (already up-to-date), checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory has no recent jobs), confirmed state.md has no stale entries, updated state.md with current date (2026-03-15). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -89,3 +89,8 @@ Performed daily housekeeping tasks: confirmed on main branch (already up-to-date
 **Date:** 2026-03-18 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-18) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from 2026-02-26, over 20 days old), confirmed state.md has no stale entries, updated state.md with current date (2026-03-18). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-20 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-20) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (no recent jobs found), confirmed state.md has no stale entries, updated state.md with current date (2026-03-20). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -79,3 +79,8 @@ Performed daily housekeeping tasks: confirmed on main branch (already up-to-date
 **Date:** 2026-03-16 | **Type:** chat
 Performed daily housekeeping tasks: confirmed on main branch (already up-to-date), checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent job from 2026-02-26), confirmed state.md has no stale entries, updated state.md with current date (2026-03-16). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-17 | **Type:** chat
+Performed daily housekeeping tasks: confirmed on main branch (already up-to-date), checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (no recent jobs found), confirmed state.md has no stale entries, updated state.md with current date (2026-03-17). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -74,3 +74,8 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 **Date:** 2026-03-15 | **Type:** chat
 Performed daily housekeeping tasks: confirmed on main branch (already up-to-date), checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory has no recent jobs), confirmed state.md has no stale entries, updated state.md with current date (2026-03-15). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-16 | **Type:** chat
+Performed daily housekeeping tasks: confirmed on main branch (already up-to-date), checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent job from 2026-02-26), confirmed state.md has no stale entries, updated state.md with current date (2026-03-16). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -64,3 +64,8 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 **Date:** 2026-03-12 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-12) to main branch, checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory is empty), confirmed state.md has no stale entries, updated state.md with current date (2026-03-12). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-14 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-14) to main branch, reset to origin/main to resolve divergence (local had accumulated housekeeping commits), checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from 2026-02-26), confirmed state.md has no stale entries, updated state.md with current date (2026-03-14). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -94,3 +94,8 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 **Date:** 2026-03-20 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-20) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (no recent jobs found), confirmed state.md has no stale entries, updated state.md with current date (2026-03-20). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-03-21 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-21) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (no recent jobs found), confirmed state.md has no stale entries, updated state.md with current date (2026-03-21). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-17"
+last_active: "2026-03-18"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-17
+**Last Updated:** 2026-03-18
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-12"
+last_active: "2026-03-14"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-03-14
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-14"
+last_active: "2026-03-15"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-14
+**Last Updated:** 2026-03-15
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-15"
+last_active: "2026-03-16"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-15
+**Last Updated:** 2026-03-16
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-20"
+last_active: "2026-03-21"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-20
+**Last Updated:** 2026-03-21
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-16"
+last_active: "2026-03-17"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-16
+**Last Updated:** 2026-03-17
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-18"
+last_active: "2026-03-20"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-18
+**Last Updated:** 2026-03-20
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Path Separator Fix
+**March 17, 2026** · `@herdctl/core@5.10.1`
+
+Fixed path traversal validation failing on Windows systems. The `buildSafeFilePath` security check was using a hardcoded "/" separator when checking if resolved paths stay within allowed directories. On Windows, `path.resolve` returns paths with "\", causing the validation to always fail and throw false positive `PathTraversalError` on every state file operation. The check now uses `path.sep` to work correctly on both Windows and Unix systems, and handles root directory base paths that already end with a separator. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
## Summary
- Added entry for Windows path separator fix (@herdctl/core@5.10.1)

## Details
This automated changelog update documents the fix for path traversal validation failing on Windows systems. The security check was using a hardcoded "/" separator, causing false positive errors on Windows where paths use "\".

## Commits analyzed
- 31c675c - fix: use path.sep in path traversal check for Windows compatibility (#210)
- 3662d18 - chore: version packages (#211)

🤖 Generated by changelog-updater agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path validation errors on Windows systems during state file operations. Path separators are now handled correctly across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->