### PR TITLE
docs: update What's New page (2026-03-29)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 3662d18
+last_run: "2026-03-29T04:03:33Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-03-29"]
 status: completed
 ---
 
 # Changelog Update State
 
-**Last Updated:** 2026-02-25T04:05:06Z
+**Last Updated:** 2026-03-29T04:03:33Z
 
 This document tracks the state of the changelog updater agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 3662d18 | chore: version packages (#211) |
+| Last run | 2026-03-29T04:03:33Z | Latest update completed successfully |
+| Entries added (last run) | 1 | Windows path separator compatibility fix |
+| Branches created | changelog/auto-update-2026-03-29 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-03-29 | 2 | 1 | Created PR #223 | changelog/auto-update-2026-03-29 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Compatibility Fix
+**March 17, 2026** · `@herdctl/core@5.10.1` · `herdctl@1.5.8`
+
+Fixed a critical Windows compatibility issue where herdctl would fail on all state file operations due to incorrect path separator handling. The path traversal security check now uses platform-specific separators (`\` on Windows, `/` on Unix), allowing Windows users to run fleets without encountering false-positive PathTraversalError exceptions. This patch also handles edge cases with root directory paths that could trigger the same error on any platform. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
Automated changelog update added 1 new entry.

## Entries Added

### Windows Compatibility Fix
- **Date:** March 17, 2026
- **Versions:** @herdctl/core@5.10.1, herdctl@1.5.8
- **Description:** Fixed critical Windows compatibility issue where path traversal security checks used Unix-style separators, causing false-positive PathTraversalError exceptions and preventing Windows users from running fleets

## Commits Analyzed
2 commits from 993f597 to 3662d18

Generated by changelog-update-daily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows compatibility fix documentation describing improved path-separator handling in security checks to prevent false positives on edge cases, including special handling for root directory scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->