### PR TITLE
docs: auto-update documentation (2026-03-30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ In which we try to cover all of the main parts of herdctl in 20 minutes:
   <p><em>Watch the demo</em></p>
 </div>
 
+## Prerequisites
+
+- **Node.js 20+** — herdctl requires Node.js 20 or later
+- **Claude Code CLI** — Agents use Claude Code under the hood ([install instructions](https://docs.anthropic.com/en/docs/claude-code))
+- **Git** — For workspace management and repo cloning
+- **Platform Support** — macOS, Linux, and Windows
+
 ## Quick Start
 
 ```bash

--- a/agents/docs/state.md
+++ b/agents/docs/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 1114870f5bcf4d2b7ce74e0df7e1f7d5e3f3b6b9
-last_run: "2026-03-13T07:08:30Z"
-docs_gaps_found: 5
-branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13"]
+last_checked_commit: 3662d18
+last_run: "2026-03-30T03:05:40Z"
+docs_gaps_found: 1
+branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13", "docs/auto-update-2026-03-30"]
 status: completed
 ---
 
 # Documentation Audit State
 
-**Last Updated:** 2026-03-13
+**Last Updated:** 2026-03-30
 
 This document tracks the state of the documentation audit agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 1114870 | docs: auto-update documentation (2026-03-07) |
-| Last run | 2026-03-13T07:08:30Z | Manual invocation |
-| Gaps found (last run) | 5 | Discord improvements features |
-| Branches created | docs/auto-update-2026-03-13 | Added Discord voice, attachments, output, guild, skills docs |
+| Last checked commit | 3662d18 | chore: version packages (#211) |
+| Last run | 2026-03-30T03:05:40Z | Manual invocation |
+| Gaps found (last run) | 1 | Windows platform support documentation |
+| Branches created | docs/auto-update-2026-03-30 | Added Windows to prerequisites and What's New |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Gaps Found | Action | Branch |
 |------|-----------------|------------|--------|--------|
+| 2026-03-30 | 2 | 1 | created-branch | docs/auto-update-2026-03-30 |
 | 2026-03-13 | 3 | 5 | created-branch | docs/auto-update-2026-03-13 |
 | 2026-03-07 | 4 | 1 | created-branch | docs/auto-update-2026-03-07 |
 | 2026-03-05 | 10 | 1 | created-branch | docs/auto-update-2026-03-05 |

--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -14,6 +14,7 @@ Before you begin, ensure you have:
 - **Node.js 20+** - herdctl requires Node.js 20 or later
 - **Claude Code CLI** - Agents use Claude Code under the hood ([install instructions](https://docs.anthropic.com/en/docs/claude-code))
 - **Git** - For workspace management and repo cloning
+- **Platform Support** - macOS, Linux, and Windows
 
 ## Installation
 

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Path Separator Fix
+**March 17, 2026** · `@herdctl/core@5.10.1`
+
+Fixed a critical bug where herdctl's path traversal safety checks used hardcoded forward slashes (`/`) instead of platform-specific path separators. On Windows, `path.resolve()` returns paths with backslashes (`\`), so the `startsWith` check always failed, causing false positive `PathTraversalError` on every state file operation. The fix uses `path.sep` for cross-platform compatibility and handles edge cases with root paths that already end with separators. Windows users can now run herdctl without encountering spurious path traversal errors. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
Automated documentation audit found 1 gap(s) across 2 commits.

## Gaps Addressed

### Gap 1: Windows Platform Support Documentation
- **Commit(s):** 31c675c "fix: use path.sep in path traversal check for Windows compatibility (#210)"
- **What changed:** Fixed a critical bug where herdctl's path traversal safety checks used hardcoded forward slashes instead of platform-specific path separators, making herdctl unusable on Windows
- **Documentation updates:**
  - Added Windows to prerequisites section in README.md
  - Added Windows to prerequisites section in docs/src/content/docs/getting-started/index.mdx
  - Added What's New entry documenting the Windows path separator fix
- **Priority:** Medium

## Files Updated
- `/opt/herdctl/README.md` - Added Windows to supported platforms
- `/opt/herdctl/docs/src/content/docs/getting-started/index.mdx` - Added Windows to prerequisites
- `/opt/herdctl/docs/src/content/docs/whats-new.md` - Added entry for Windows bug fix

Generated by docs-audit-daily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated getting started guide with required prerequisites: Node.js 20+, Claude Code CLI, and Git.
  * Added platform support information clarifying macOS, Linux, and Windows compatibility.

* **Bug Fixes**
  * Fixed path handling in herdctl v5.10.1 to correctly support Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->