### PR TITLE
docs: update What's New page (2026-03-31)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 3662d18
+last_run: "2026-03-31T04:03:23Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-03-31"]
 status: completed
 ---
 
 # Changelog Update State
 
-**Last Updated:** 2026-02-25T04:05:06Z
+**Last Updated:** 2026-03-31T04:03:23Z
 
 This document tracks the state of the changelog updater agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 3662d18 | chore: version packages (#211) |
+| Last run | 2026-03-31T04:03:23Z | Latest update completed successfully |
+| Entries added (last run) | 1 | Windows path traversal fix |
+| Branches created | changelog/auto-update-2026-03-31 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-03-31 | 2 | 1 | Created PR #226 | changelog/auto-update-2026-03-31 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Support: Path Traversal Fix
+**March 17, 2026** · `@herdctl/core@5.10.1` · `herdctl@1.5.9` · `@herdctl/web@0.9.10` · `@herdctl/discord@1.2.1` · `@herdctl/slack@1.2.14` · `@herdctl/chat@0.3.3`
+
+Fixed a critical bug that prevented herdctl from working on Windows. The path traversal security check was using Unix-style path separators hardcoded as "/" which caused all state file operations to fail on Windows with "PathTraversalError" false positives. herdctl now uses platform-specific path separators, enabling it to run correctly on Windows systems. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
Automated changelog update added 1 new entry.

## Entries Added
- **Windows Support: Path Traversal Fix** (March 17, 2026) - Critical bug fix enabling herdctl to work on Windows by using platform-specific path separators instead of hardcoded Unix-style separators. Affects @herdctl/core v5.10.1 and all dependent packages.

## Commits Analyzed
2 commits from 993f597 to 3662d18

Generated by changelog-update-daily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Windows compatibility issue where path traversal security validation was causing errors during state file operations.

* **Documentation**
  * Updated "What's New" with information about the Windows compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->