### PR TITLE
docs: update What's New page (Apr 2, 2026)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 3662d18
+last_run: "2026-04-02T04:01:26Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-04-02"]
 status: completed
 ---
 
 # Changelog Update State
 
-**Last Updated:** 2026-02-25T04:05:06Z
+**Last Updated:** 2026-04-02T04:01:26Z
 
 This document tracks the state of the changelog updater agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 3662d18 | chore: version packages (#211) |
+| Last run | 2026-04-02T04:01:26Z | Windows path compatibility fix |
+| Entries added (last run) | 1 | Windows path separator fix for state file operations |
+| Branches created | changelog/auto-update-2026-04-02 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-04-02 | 2 | 1 | Ready for PR | changelog/auto-update-2026-04-02 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Path Compatibility Fix
+**March 17, 2026** · `@herdctl/core@5.10.1`
+
+Fixed path traversal validation failing on Windows systems. The security check in `buildSafeFilePath` was using hardcoded `/` as the path separator, but Windows uses `\`, causing the `startsWith` check to always fail and throw false positive `PathTraversalError` on every state file operation. The fix uses `path.sep` for platform-specific separator handling and normalizes root directory paths that already end with a separator to avoid double-separator issues. This enables herdctl to work correctly on Windows systems. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
## Summary

- Added changelog entry for **@herdctl/core@5.10.1** Windows path compatibility fix

## Details

The new release fixes path traversal validation that was failing on Windows systems. The security check in `buildSafeFilePath` was using a hardcoded `/` separator, but Windows uses `\`, causing false positive `PathTraversalError` exceptions on every state file operation.

## Commits Analyzed

- `3662d18` chore: version packages (#211)
- `31c675c` fix: use path.sep in path traversal check (#210)

## Test Plan

- [x] Verified changelog entry follows existing format
- [x] Confirmed package version and PR reference are accurate
- [x] Updated state.md with run metadata

🤖 Generated by [changelog-updater agent](https://github.com/edspencer/herdctl/tree/main/agents/changelog)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path handling errors on Windows systems in state file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->