### PR TITLE
docs: update What's New page (2026-04-03)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,8 +1,8 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 0881316
+last_run: "2026-04-03T04:03:30Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-04-03"]
 status: completed
 ---
 
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 0881316 | chore(engineer): daily housekeeping |
+| Last run | 2026-04-03T04:03:30Z | Latest update completed successfully |
+| Entries added (last run) | 1 | Windows path separator fix |
+| Branches created | changelog/auto-update-2026-04-03 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-04-03 | 5 | 1 | created-branch | changelog/auto-update-2026-04-03 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Path Separator Fix
+**March 17, 2026** · `@herdctl/core@5.10.1` · `herdctl@1.5.8`
+
+Fixed a critical bug that prevented herdctl from working on Windows systems. The path traversal safety check in state file operations was hardcoded to use "/" as the path separator, but Windows uses "\". This caused every state file operation to fail with a false positive PathTraversalError. The fix now uses the platform-specific path separator (path.sep) so the check works correctly on both Windows and Unix systems. Windows users can now run herdctl without encountering path-related errors. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
Automated changelog update added 1 new entry.

## Entries Added

### Windows Path Separator Fix
**March 17, 2026** · `@herdctl/core@5.10.1` · `herdctl@1.5.8`

Fixed a critical bug that prevented herdctl from working on Windows systems. The path traversal safety check in state file operations was hardcoded to use "/" as the path separator, but Windows uses "\". This caused every state file operation to fail with a false positive PathTraversalError. The fix now uses the platform-specific path separator (path.sep) so the check works correctly on both Windows and Unix systems. Windows users can now run herdctl without encountering path-related errors.

## Commits Analyzed
5 commits from 6053872 to 0881316

Generated by changelog-update-daily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path traversal safety validation failures on Windows systems. File path security checks now correctly use the operating system's native path separator instead of hardcoded values, preventing false `PathTraversalError` exceptions. Included in @herdctl/core@5.10.1 and herdctl@1.5.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->