### PR TITLE
docs: update What's New page (2026-04-05)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,8 +1,8 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: fb2fa31
+last_run: "2026-04-05T00:00:00Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/update-2026-04-05"]
 status: completed
 ---
 
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | fb2fa31 | chore(engineer): daily housekeeping |
+| Last run | 2026-04-05T00:00:00Z | Latest update completed successfully |
+| Entries added (last run) | 1 | Windows path separator compatibility fix |
+| Branches created | changelog/update-2026-04-05 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-04-05 | 7 | 1 | Ready for PR | changelog/update-2026-04-05 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2100
+token_estimate: 2300
 last_archived: null
 ---
 
@@ -73,4 +73,9 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-04-03 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (docs/auto-update-2026-04-03) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-04-03). All state files remain clean and current.
+**Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-04-04 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (docs/auto-update-2026-04-04) to main branch after stashing security agent updates, checked conversations.md token count (~2100 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory empty), confirmed state.md has no stale entries, updated state.md with current date (2026-04-04). All state files remain clean and current.
 **Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2000
+token_estimate: 2100
 last_archived: null
 ---
 
@@ -68,4 +68,9 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-04-02 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-04-02) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from February 2026), confirmed state.md has no stale entries, updated state.md with current date (2026-04-02). All state files remain clean and current.
+**Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-04-03 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (docs/auto-update-2026-04-03) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-04-03). All state files remain clean and current.
 **Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -64,3 +64,8 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 **Date:** 2026-03-12 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-12) to main branch, checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory is empty), confirmed state.md has no stale entries, updated state.md with current date (2026-03-12). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-04-02 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-04-02) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from February 2026), confirmed state.md has no stale entries, updated state.md with current date (2026-04-02). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-04-03"
+last_active: "2026-04-04"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-04-03
+**Last Updated:** 2026-04-04
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-04-02"
+last_active: "2026-04-03"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-04-02
+**Last Updated:** 2026-04-03
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-12"
+last_active: "2026-04-02"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-04-02
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Path Separator Compatibility Fix
+**March 17, 2026** · `@herdctl/core@5.10.1`
+
+Fixed state file operations on Windows that were incorrectly triggering path traversal errors. The `buildSafeFilePath` security check was hardcoded to use "/" as the path separator, but Windows uses "\". When comparing resolved paths, the check would always fail since `path.resolve` returns Windows-style paths. The fix uses `path.sep` (the platform-specific separator) and handles edge cases like root directory base paths that already end with a separator. Windows users can now create and manage fleets without spurious PathTraversalError exceptions on every state operation. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
## Summary

- Add changelog entry for Windows path separator compatibility fix (@herdctl/core@5.10.1)

## What Changed

Added entry for the March 17, 2026 release that fixed path traversal errors on Windows. The `buildSafeFilePath` security check was using hardcoded "/" separators, but Windows uses "\", causing all path operations to fail with false positive PathTraversalError exceptions.

## Release Details

- **Package**: @herdctl/core@5.10.1
- **Release Date**: March 17, 2026
- **PR**: #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* **Windows Path Separator Compatibility**: Fixed state file operations on Windows that were incorrectly triggering path traversal validation errors. The fix improves path separator handling for platform-specific compatibility and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->