### PR TITLE
docs: update What's New (2026-04-08)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,8 +1,8 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 1e472a2
+last_run: "2026-04-08T00:00:00Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-04-08"]
 status: completed
 ---
 
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 1e472a2 | chore(engineer): daily housekeeping |
+| Last run | 2026-04-08T00:00:00Z | Latest update completed successfully |
+| Entries added (last run) | 1 | Windows path separator fix |
+| Branches created | changelog/auto-update-2026-04-08 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-04-08 | 12 | 1 | Ready for PR | changelog/auto-update-2026-04-08 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/agents/docs/state.md
+++ b/agents/docs/state.md
@@ -1,6 +1,6 @@
 ---
-last_checked_commit: 1c3f5dbf8c8c8840d4ff10bdc482e4923496d658
-last_run: "2026-04-06T00:00:00Z"
+last_checked_commit: 8818ab16252952d0374f5389f51dd6c1059d8e35
+last_run: "2026-04-07T00:00:00Z"
 docs_gaps_found: 0
 branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13"]
 status: completed
@@ -8,7 +8,7 @@ status: completed
 
 # Documentation Audit State
 
-**Last Updated:** 2026-03-13
+**Last Updated:** 2026-04-07
 
 This document tracks the state of the documentation audit agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,8 +19,8 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 1c3f5db | chore(engineer): daily housekeeping |
-| Last run | 2026-04-06T00:00:00Z | Automated daily audit |
+| Last checked commit | 8818ab1 | chore(engineer): daily housekeeping |
+| Last run | 2026-04-07T00:00:00Z | Automated daily audit |
 | Gaps found (last run) | 0 | No documentation gaps |
 | Branches created | N/A | No branch created (no gaps) |
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Gaps Found | Action | Branch |
 |------|-----------------|------------|--------|--------|
+| 2026-04-07 | 2 | 0 | no-action | N/A |
 | 2026-04-06 | 8 | 0 | no-action | N/A |
 | 2026-03-13 | 3 | 5 | created-branch | docs/auto-update-2026-03-13 |
 | 2026-03-07 | 4 | 1 | created-branch | docs/auto-update-2026-03-07 |

--- a/agents/docs/state.md
+++ b/agents/docs/state.md
@@ -1,7 +1,7 @@
 ---
-last_checked_commit: 1114870f5bcf4d2b7ce74e0df7e1f7d5e3f3b6b9
-last_run: "2026-03-13T07:08:30Z"
-docs_gaps_found: 5
+last_checked_commit: 1c3f5dbf8c8c8840d4ff10bdc482e4923496d658
+last_run: "2026-04-06T00:00:00Z"
+docs_gaps_found: 0
 branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13"]
 status: completed
 ---
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 1114870 | docs: auto-update documentation (2026-03-07) |
-| Last run | 2026-03-13T07:08:30Z | Manual invocation |
-| Gaps found (last run) | 5 | Discord improvements features |
-| Branches created | docs/auto-update-2026-03-13 | Added Discord voice, attachments, output, guild, skills docs |
+| Last checked commit | 1c3f5db | chore(engineer): daily housekeeping |
+| Last run | 2026-04-06T00:00:00Z | Automated daily audit |
+| Gaps found (last run) | 0 | No documentation gaps |
+| Branches created | N/A | No branch created (no gaps) |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Gaps Found | Action | Branch |
 |------|-----------------|------------|--------|--------|
+| 2026-04-06 | 8 | 0 | no-action | N/A |
 | 2026-03-13 | 3 | 5 | created-branch | docs/auto-update-2026-03-13 |
 | 2026-03-07 | 4 | 1 | created-branch | docs/auto-update-2026-03-07 |
 | 2026-03-05 | 10 | 1 | created-branch | docs/auto-update-2026-03-05 |

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2400
+token_estimate: 2600
 last_archived: null
 ---
 
@@ -9,6 +9,11 @@ Rolling summary of recent conversations across all chat sessions.
 Older entries are archived to `conversations-archive.md` when this file approaches ~20,000 tokens.
 
 ---
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-04-07 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-04-07) to main branch, checked conversations.md token count (~2400 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-04-07). All state files remain clean and current.
+**Outcome:** State files verified and updated
 
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-02-23 | **Type:** chat

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2100
+token_estimate: 2300
 last_archived: null
 ---
 
@@ -73,4 +73,9 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-04-03 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (docs/auto-update-2026-04-03) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-04-03). All state files remain clean and current.
+**Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-04-04 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (docs/auto-update-2026-04-04) to main branch after stashing security agent updates, checked conversations.md token count (~2100 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory empty), confirmed state.md has no stale entries, updated state.md with current date (2026-04-04). All state files remain clean and current.
 **Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2000
+token_estimate: 2100
 last_archived: null
 ---
 
@@ -68,4 +68,9 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-04-02 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-04-02) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from February 2026), confirmed state.md has no stale entries, updated state.md with current date (2026-04-02). All state files remain clean and current.
+**Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-04-03 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (docs/auto-update-2026-04-03) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h, confirmed state.md has no stale entries, updated state.md with current date (2026-04-03). All state files remain clean and current.
 **Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -84,3 +84,8 @@ Performed daily housekeeping tasks: switched from feature branch (docs/auto-upda
 **Date:** 2026-04-05 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/update-2026-04-05) to main branch after stashing security agent updates, checked conversations.md token count (~2100 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs still from February 2026), confirmed state.md has no stale entries, updated state.md with current date (2026-04-05). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-04-06 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-04-06) to main branch, checked conversations.md token count (~2100 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent job from 2026-02-26 was security-auditor), confirmed state.md has no stale entries, updated state.md with current date (2026-04-06). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2300
+token_estimate: 2400
 last_archived: null
 ---
 
@@ -78,4 +78,9 @@ Performed daily housekeeping tasks: switched from feature branch (docs/auto-upda
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-04-04 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (docs/auto-update-2026-04-04) to main branch after stashing security agent updates, checked conversations.md token count (~2100 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory empty), confirmed state.md has no stale entries, updated state.md with current date (2026-04-04). All state files remain clean and current.
+**Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-04-05 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/update-2026-04-05) to main branch after stashing security agent updates, checked conversations.md token count (~2100 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs still from February 2026), confirmed state.md has no stale entries, updated state.md with current date (2026-04-05). All state files remain clean and current.
 **Outcome:** State files verified and updated

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -64,3 +64,8 @@ Performed daily housekeeping tasks: switched from feature branch (changelog/auto
 **Date:** 2026-03-12 | **Type:** chat
 Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-03-12) to main branch, checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory is empty), confirmed state.md has no stale entries, updated state.md with current date (2026-03-12). All state files remain clean and current.
 **Outcome:** State files verified and updated
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-04-02 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-04-02) to main branch, checked conversations.md token count (~2000 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from February 2026), confirmed state.md has no stale entries, updated state.md with current date (2026-04-02). All state files remain clean and current.
+**Outcome:** State files verified and updated

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-04-05"
+last_active: "2026-04-06"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-04-05
+**Last Updated:** 2026-04-06
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-04-03"
+last_active: "2026-04-04"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-04-03
+**Last Updated:** 2026-04-04
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-04-04"
+last_active: "2026-04-05"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-04-04
+**Last Updated:** 2026-04-05
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-04-06"
+last_active: "2026-04-07"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-04-06
+**Last Updated:** 2026-04-07
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-04-02"
+last_active: "2026-04-03"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-04-02
+**Last Updated:** 2026-04-03
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-12"
+last_active: "2026-04-02"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-04-02
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Path Separator Fix
+**March 17, 2026** · `@herdctl/core@5.10.1` · `herdctl@1.5.8`
+
+Fixed path traversal security checks failing on Windows systems. The path validation logic was using hardcoded forward slashes (`/`) when checking if resolved paths stay within intended directories, but Windows uses backslashes (`\`) as path separators. This caused legitimate file operations to be incorrectly rejected with PathTraversalError on Windows. The validation now uses the platform-specific path separator (`path.sep`) and correctly handles root directory base paths that already include a trailing separator. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
## Summary
- Added entry for Windows path separator fix (PR #210)
- Analyzed 12 commits since last run (6053872..1e472a2)
- Updated state file to track completion

## Details
The only user-facing change in this batch was the Windows path separator fix in @herdctl/core@5.10.1. This fixed path traversal security validation that was incorrectly failing on Windows systems due to hardcoded forward slashes in the check logic.

Other commits were housekeeping, audit state updates, or the version packages commit itself.

## Test plan
- [x] Entry follows existing format and style
- [x] Date is correct (2026-03-17 for the actual fix, formatted properly)
- [x] Version numbers match package CHANGELOGs
- [x] PR link is included
- [x] State file updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows path traversal validation that was incorrectly rejecting valid operations due to platform-specific path separator handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->