### PR TITLE
docs: update What's New page (2026-04-18)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,8 +1,8 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 3866731
+last_run: "2026-04-18T04:03:18Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-04-18"]
 status: completed
 ---
 
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 3866731 | chore(security): daily security audit 2026-04-17 |
+| Last run | 2026-04-18T04:03:18Z | Latest update completed successfully |
+| Entries added (last run) | 1 | Windows path separator fix |
+| Branches created | changelog/auto-update-2026-04-18 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-04-18 | 4 | 1 | Created PR #237 | changelog/auto-update-2026-04-18 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Path Separator Fix
+**March 17, 2026** · `@herdctl/core@5.10.1` · `herdctl@1.5.8`
+
+Windows users can now run herdctl without encountering path traversal security errors. The state file path validation was hardcoded to use forward slashes ("/"), causing false positive PathTraversalError exceptions on Windows which uses backslashes ("\"). The security check now uses the platform-appropriate path separator via `path.sep`, making herdctl fully compatible with Windows environments. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
Automated changelog update added 1 new entry.

## Entries Added

### Windows Compatibility Fix
- **Date:** 2026-03-17
- **Versions:** @herdctl/core v5.10.1, herdctl v1.5.8
- **Description:** Fixes a critical bug that prevented herdctl from working on Windows. The path traversal security check was hardcoded to use forward slashes ("/"), causing it to fail on Windows which uses backslashes ("\"). This resulted in false positive PathTraversalError exceptions on every state file operation. Windows users can now run herdctl without encountering spurious path security errors.

## Commits Analyzed
4 commits from 6053872 to 3866731

Generated by changelog-update-daily