### PR TITLE
docs: update What's New page (2026-04-23)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 584c8a7
+last_run: "2026-04-23T04:04:26Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-04-23"]
 status: completed
 ---
 
 # Changelog Update State
 
-**Last Updated:** 2026-02-25T04:05:06Z
+**Last Updated:** 2026-04-23T04:04:26Z
 
 This document tracks the state of the changelog updater agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 584c8a7 | docs: update docs agent state (2026-04-23) |
+| Last run | 2026-04-23T04:04:26Z | Latest update completed successfully |
+| Entries added (last run) | 1 | Windows path separator fix |
+| Branches created | changelog/auto-update-2026-04-23 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-04-23 | 4 | 1 | Created PR #242 | changelog/auto-update-2026-04-23 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Path Separator Fix
+**March 17, 2026** · `@herdctl/core@5.10.1`
+
+Fixed a critical bug preventing herdctl from working on Windows. The path traversal security check was hardcoded to use forward slashes (`/`) which caused false positive errors on Windows systems where paths use backslashes (`\`). State file operations now work correctly on Windows using the platform-specific path separator. This also fixes an edge case with root directory base paths that could produce double separators. [#210](https://github.com/edspencer/herdctl/pull/210)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
Automated changelog update added 1 new entry.

## Entries Added

### Windows Path Separator Fix
**Date:** 2026-03-17  
**Version:** @herdctl/core v5.10.1

Fixed a critical bug preventing herdctl from working on Windows. The path traversal security check was hardcoded to use forward slashes which caused false positive errors on Windows systems where paths use backslashes. State file operations now work correctly on Windows using the platform-specific path separator.

## Commits Analyzed
4 commits from 6053872 to 584c8a7

Generated by changelog-update-daily