### PR TITLE
docs: update What's New page (2026-04-24)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,8 +1,8 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 3662d18
+last_run: "2026-04-24T19:47:00Z"
+entries_added: 1
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-04-24"]
 status: completed
 ---
 
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 3662d18 | chore: version packages (#211) |
+| Last run | 2026-04-24T19:47:00Z | Latest update completed successfully |
+| Entries added (last run) | 1 | Windows path handling fix |
+| Branches created | changelog/auto-update-2026-04-24 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-04-24 | 4 | 1 | Created PR #243 | changelog/auto-update-2026-04-24 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,13 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Windows Compatibility Fix for Path Handling
+**March 17, 2026** · `@herdctl/core@5.10.1` · `herdctl@1.5.8`
+
+Windows users can now run herdctl without encountering PathTraversalError on state file operations. The path traversal security check now uses platform-specific path separators instead of hardcoded forward slashes, fixing a bug where Windows users received false positive security errors that prevented the application from functioning. This patch also handles edge cases with root directory paths.
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
Automated changelog update added 1 new entry.

## Entries Added

### Windows Compatibility Fix for Path Handling
**2026-03-17** | `@herdctl/core@5.10.1`, `herdctl@1.5.8`

Windows users can now run herdctl without encountering PathTraversalError on state file operations. The path traversal security check now uses platform-specific path separators instead of hardcoded forward slashes, fixing a bug where Windows users received false positive security errors that prevented the application from functioning.

## Commits Analyzed
4 commits from 6053872 to 3662d18

Generated by changelog-update-daily