### PR TITLE
fix(chat): preserve tool name/duration for CLI-runtime tool results in SDKMessageTranslator

### DIFF
--- a/.changeset/translator-cli-tool-pairing.md
+++ b/.changeset/translator-cli-tool-pairing.md
@@ -1,0 +1,23 @@
+---
+"@herdctl/chat": patch
+---
+
+Fix `SDKMessageTranslator` losing tool-call pairing on the CLI runtime.
+
+On the CLI runtime, a user/tool_result message carries its result twice: as an
+id-less top-level `tool_use_result` field AND as a nested
+`message.content[]` `tool_result` block that DOES carry the `tool_use_id` and
+`is_error`. The translator paired tool calls via core's `extractToolResults`,
+which short-circuits on the top-level field and returns the id-less result — so
+calls couldn't be matched back to their `tool_use` and rendered as a generic
+`toolName: "Tool"` with no `inputSummary` or `durationMs`.
+
+The translator now prefers the nested id-bearing `tool_result` blocks: when a
+message has both shapes, it strips the id-less top-level field (on a shallow
+clone — the SDK's object is never mutated) so extraction uses the nested,
+id-bearing branch and restores correct name / input summary / duration / error
+pairing. Messages that only carry a top-level `tool_use_result` (the SDK-runtime
+shape) are unchanged.
+
+This lets downstream apps (e.g. paddock) drop their `normalizeForTranslator()`
+workaround.

--- a/packages/chat/src/__tests__/sdk-message-translator.test.ts
+++ b/packages/chat/src/__tests__/sdk-message-translator.test.ts
@@ -36,6 +36,34 @@ function toolResult(toolUseId: string, output: string, isError = false): SDKMess
   } as unknown as SDKMessage;
 }
 
+/**
+ * The CLI-runtime shape: a user message that carries the result BOTH as an
+ * id-less top-level `tool_use_result` (string/object, NO tool_use_id) AND as a
+ * nested `message.content[]` `tool_result` block that DOES carry the
+ * tool_use_id + is_error. Core's `extractToolResults` short-circuits on the
+ * top-level field (losing the id); the translator must prefer the nested block.
+ */
+function cliToolResult(toolUseId: string, output: string, isError = false): SDKMessage {
+  return {
+    type: "user",
+    // Id-less top-level result (this is what short-circuits extractToolResults).
+    tool_use_result: output,
+    message: {
+      content: [
+        { type: "tool_result", tool_use_id: toolUseId, content: output, is_error: isError },
+      ],
+    },
+  } as unknown as SDKMessage;
+}
+
+/** SDK-runtime shape: only a top-level `tool_use_result`, no nested blocks. */
+function sdkTopLevelToolResult(output: string): SDKMessage {
+  return {
+    type: "user",
+    tool_use_result: output,
+  } as unknown as SDKMessage;
+}
+
 describe("SDKMessageTranslator", () => {
   describe("text deltas", () => {
     it("emits assistant text via onText", async () => {
@@ -169,6 +197,78 @@ describe("SDKMessageTranslator", () => {
       await t.handle(toolResult("t1", "out"));
 
       expect(onToolCall).not.toHaveBeenCalled();
+    });
+
+    describe("CLI runtime (double-encoded results)", () => {
+      it("pairs via the nested id-bearing block even when an id-less top-level tool_use_result is present", async () => {
+        const calls: TranslatedToolCall[] = [];
+        let clock = 1000;
+        const t = new SDKMessageTranslator(
+          { onToolCall: (c) => void calls.push(c) },
+          { now: () => clock },
+        );
+
+        await t.handle(assistantToolUse("t1", "Bash", { command: "pwd" }));
+        clock = 1113; // 113ms later
+        // CLI shape: id-less top-level tool_use_result AND nested id-bearing block.
+        await t.handle(cliToolResult("t1", "/home/agent"));
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toEqual({
+          toolName: "Bash",
+          inputSummary: "pwd",
+          output: "/home/agent",
+          isError: false,
+          durationMs: 113,
+          toolUseId: "t1",
+        });
+      });
+
+      it("preserves is_error from the nested block in the CLI shape", async () => {
+        const calls: TranslatedToolCall[] = [];
+        const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+        await t.handle(assistantToolUse("t1", "Bash", { command: "false" }));
+        await t.handle(cliToolResult("t1", "boom", true));
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({
+          toolName: "Bash",
+          inputSummary: "false",
+          output: "boom",
+          isError: true,
+          toolUseId: "t1",
+        });
+        expect(calls[0].durationMs).toBeDefined();
+      });
+
+      it("does not mutate the original SDK message when stripping the top-level field", async () => {
+        const t = new SDKMessageTranslator({ onToolCall: vi.fn() });
+
+        await t.handle(assistantToolUse("t1", "Read", { file_path: "/a" }));
+        const msg = cliToolResult("t1", "contents");
+        await t.handle(msg);
+
+        // The id-less top-level field must still be present on the caller's object.
+        expect((msg as unknown as { tool_use_result?: unknown }).tool_use_result).toBe("contents");
+      });
+
+      it("still falls back to the id-less top-level result when there is no nested block (SDK shape)", async () => {
+        const calls: TranslatedToolCall[] = [];
+        const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+        // tool_use is tracked, but the SDK-shape result has no tool_use_id, so it
+        // cannot be paired — it falls back to the generic name (unchanged behavior).
+        await t.handle(assistantToolUse("t1", "Bash", { command: "ls" }));
+        await t.handle(sdkTopLevelToolResult("file-a\nfile-b"));
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].toolName).toBe("Tool");
+        expect(calls[0].output).toBe("file-a\nfile-b");
+        expect(calls[0].inputSummary).toBeUndefined();
+        expect(calls[0].durationMs).toBeUndefined();
+        expect(calls[0].toolUseId).toBeUndefined();
+      });
     });
   });
 

--- a/packages/chat/src/sdk-message-translator.ts
+++ b/packages/chat/src/sdk-message-translator.ts
@@ -19,7 +19,12 @@
  */
 
 import { extractMessageContent, type SDKMessage } from "./message-extraction.js";
-import { extractToolResults, extractToolUseBlocks, getToolInputSummary } from "./tool-parsing.js";
+import {
+  extractToolResults,
+  extractToolUseBlocks,
+  getToolInputSummary,
+  type ToolResult,
+} from "./tool-parsing.js";
 
 // =============================================================================
 // Types
@@ -85,6 +90,64 @@ interface PendingToolUse {
   name: string;
   input?: unknown;
   startTime: number;
+}
+
+/**
+ * Extract tool results from a user message, preferring the id-bearing nested
+ * `message.content[]` `tool_result` blocks over core's `extractToolResults`.
+ *
+ * The CLI runtime surfaces a tool result twice on the same user message:
+ *   1. a **top-level `tool_use_result`** (string/object) that carries NO
+ *      `tool_use_id`, and
+ *   2. a nested `message.content[]` `tool_result` block that DOES carry the
+ *      `tool_use_id` (plus `is_error` and string/array content).
+ *
+ * Core's {@link extractToolResults} short-circuits on the top-level field and
+ * returns the id-less result first — so the translator can't pair it back to
+ * its `tool_use` and falls back to a generic `toolName: "Tool"` with no input
+ * summary or duration.
+ *
+ * When a user message has BOTH a top-level `tool_use_result` AND nested
+ * id-bearing `tool_result` block(s), this helper strips the top-level field
+ * (on a shallow clone — the SDK's object is never mutated) so
+ * {@link extractToolResults} takes its nested branch and preserves the
+ * `tool_use_id` for correct name/summary/duration pairing. Every other shape
+ * — including SDK-runtime messages that only carry a top-level
+ * `tool_use_result` — is passed to {@link extractToolResults} unchanged, so
+ * existing SDK-runtime behavior is preserved.
+ */
+function extractToolResultsPreferringNested(message: {
+  type: string;
+  message?: { content?: unknown };
+  tool_use_result?: unknown;
+}): ToolResult[] {
+  const content = (message.message as { content?: unknown } | undefined)?.content;
+
+  if (Array.isArray(content)) {
+    const hasNestedToolResult = content.some(
+      (block) =>
+        block !== null &&
+        typeof block === "object" &&
+        "type" in block &&
+        (block as { type?: unknown }).type === "tool_result",
+    );
+
+    // Only prefer the nested path when the message actually carried nested
+    // tool_result blocks. When it does, extractToolResults already parses those
+    // id-bearing blocks correctly — the bug is only that the top-level
+    // `tool_use_result` short-circuit runs *first*, so we strip that field
+    // (on a shallow clone; the SDK's object is untouched) and let the core
+    // helper take its nested branch. Messages with only a top-level
+    // `tool_use_result` (SDK-runtime shape) fall through unchanged below.
+    if (hasNestedToolResult && message.tool_use_result !== undefined) {
+      const { tool_use_result: _dropped, ...withoutTopLevel } = message;
+      return extractToolResults(withoutTopLevel);
+    }
+  }
+
+  // No nested tool_result blocks: defer to the core helper, which also handles
+  // the top-level `tool_use_result` (SDK-runtime) shape.
+  return extractToolResults(message);
 }
 
 /**
@@ -181,7 +244,7 @@ export class SDKMessageTranslator {
   }
 
   private async handleUser(message: SDKMessage): Promise<void> {
-    const results = extractToolResults(
+    const results = extractToolResultsPreferringNested(
       message as { type: string; message?: { content?: unknown }; tool_use_result?: unknown },
     );
     if (results.length === 0) {


### PR DESCRIPTION
## Motivation

Fixes a bug shipped in `@herdctl/chat@0.4.0`: `SDKMessageTranslator` loses the tool name / input summary / duration for **CLI-runtime** tool results (they render as a generic `Tool` with no duration).

## The bug

On the CLI runtime, a user/tool_result message carries its result twice — an **id-less top-level `tool_use_result`** *and* a nested `message.content[]` `tool_result` block that **does** carry `tool_use_id` + `is_error`. `extractToolResults` short-circuits on the id-less top-level value, so the result can't be paired to its `tool_use` and renders as `toolName: "Tool"` with no `inputSummary` / `durationMs`.

## The fix

`handleUser()` now uses a small `extractToolResultsPreferringNested()` helper: when a message has both nested id-bearing `tool_result` block(s) and a top-level `tool_use_result`, it strips the id-less top-level field on a **shallow clone** and lets `extractToolResults` take its nested, id-bearing branch — restoring correct name/summary/duration/isError pairing. Every other shape (including SDK-runtime top-level-only results) is passed through unchanged, and the caller's object is never mutated. This lets downstream apps (e.g. paddock) drop their local workaround for the same issue.

## Tests & release

- 4 new translator tests covering the CLI double-encoded shape (name/summary/duration/isError), `is_error` preservation, no-mutation of the caller object, and the id-less-only fallback. File 12 → 17 tests; existing tests unchanged.
- Gates: `pnpm build` 7/7, `pnpm typecheck` 11/11, `pnpm test` all 6 packages, `biome` clean; new code above coverage thresholds.
- Changeset: `@herdctl/chat` **patch** → 0.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved tool result pairing issues in CLI runtime when both legacy and current result formats are present simultaneously.
  * Restores accurate rendering of tool details including name, input, duration, and error information.
  * Enables downstream applications to remove workaround normalization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->