### PR TITLE
test(web): real-browser UI/integration suite + fix agent not-found state (#268)

### DIFF
--- a/.changeset/web-agent-not-found-card.md
+++ b/.changeset/web-agent-not-found-card.md
@@ -1,0 +1,8 @@
+---
+"@herdctl/web": patch
+---
+
+Fix the agent detail page showing a generic, retryable error panel for a
+non-existent agent. A 404 now renders the dedicated "Agent Not Found" card (with
+a "Back to Dashboard" link) instead of an error box with a misleading "Retry"
+button that could only ever 404 again. Fixes #268.

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,12 @@ Thumbs.db
 # Test coverage
 coverage/
 
+# Playwright UI/integration test artifacts
+test-results/
+playwright-report/
+blob-report/
+.playwright/
+
 # Misc
 *.tsbuildinfo
 .ralph-tui

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,13 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["packages/*/src/**", "packages/*/vite.config.ts", "packages/*/vitest.config.ts"]
+    "includes": [
+      "packages/*/src/**",
+      "packages/*/test-ui/**",
+      "packages/*/vite.config.ts",
+      "packages/*/vitest.config.ts",
+      "packages/*/playwright.config.ts"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,6 +18,7 @@
     "dev:server": "tsc -p tsconfig.server.json --watch",
     "typecheck": "tsc --noEmit -p tsconfig.server.json && tsc --noEmit -p tsconfig.client.json",
     "test": "vitest run --coverage --passWithNoTests",
+    "test:ui": "playwright test",
     "lint": "biome check src/ vite.config.ts"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "^4.1.18",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for @herdctl/web UI/integration tests.
+ *
+ * These tests boot the REAL Fastify web server against a REAL @herdctl/core
+ * FleetManager (per-test temp fleet) with a FAKE `claude` on PATH, then drive
+ * the React dashboard in a real Chromium browser. See test-ui/harness.ts.
+ *
+ * Each test owns its own server (via the `harness` fixture), so the baseURL is
+ * set per-test through page navigation, not here.
+ */
+export default defineConfig({
+  testDir: "./test-ui/tests",
+  // Agent runs spawn the fake claude and wait on a real session-file watcher
+  // (up to 60s in core), so give chat/trigger journeys generous headroom.
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  // Booting a FleetManager + Fastify + browser page per test is heavy; cap
+  // parallelism so workers don't starve each other (which manifests as
+  // page.goto timeouts under contention).
+  fullyParallel: false,
+  workers: 2,
+  // The large SPA bundle + a long-lived WebSocket can make the `load` event
+  // lag under load; give navigation a generous bound.
+  use: {
+    navigationTimeout: 30_000,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 1,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : [["list"]],
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/packages/web/src/client/src/hooks/useAgentDetail.ts
+++ b/packages/web/src/client/src/hooks/useAgentDetail.ts
@@ -6,7 +6,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { fetchAgent } from "../lib/api";
+import { ApiError, fetchAgent } from "../lib/api";
 import type { AgentInfo } from "../lib/types";
 import { useAgent, useStore } from "../store";
 
@@ -87,6 +87,16 @@ export function useAgentDetail(qualifiedName: string | null): UseAgentDetailResu
         setLoading(false);
       } catch (err) {
         if (cancelled) return;
+
+        // A 404 means the agent genuinely doesn't exist — surface it as the
+        // dedicated "Agent Not Found" card (agent stays null, no error), rather
+        // than the generic error panel with a misleading "Retry" button that
+        // can only ever 404 again.
+        if (err instanceof ApiError && err.status === 404) {
+          setError(null);
+          setLoading(false);
+          return;
+        }
 
         const message = err instanceof Error ? err.message : "Failed to fetch agent";
         setError(message);

--- a/packages/web/test-ui/README.md
+++ b/packages/web/test-ui/README.md
@@ -1,0 +1,63 @@
+# @herdctl/web UI / integration tests
+
+End-to-end tests that boot the **real** web server against a **real**
+`@herdctl/core` `FleetManager` (per-test temp fleet) with a **fake** `claude`
+binary on `PATH`, render the React dashboard in a **real** Chromium browser
+(Playwright), and click through the actual user journeys. **Zero Anthropic
+calls.**
+
+These complement the existing `vitest` unit tests (`src/**/*.test.ts`), which
+cover store slices and server routes/handlers in isolation. The tests here cover
+the product as a whole: REST + WebSocket + React + the CLI runtime's
+session-file machinery.
+
+## How it works
+
+- `harness.ts` writes a temp `herdctl.yaml` + per-agent workspaces, boots a real
+  `FleetManager`, then starts the real Fastify server via the package's own
+  `createWebServer(...)` (the exact factory the production `WebManager` uses) on
+  an ephemeral port.
+- `fixtures/bin/claude` is a deterministic stand-in for the real `claude` CLI.
+  herdctl's CLI runtime spawns `claude` from `PATH` and then **watches the
+  `<sessionId>.jsonl` transcript it writes** under
+  `~/.claude/projects/<encoded-cwd>/` — it does not read stdout. So the fake
+  writes a real transcript (`user` / `assistant` / `result` lines) in the exact
+  location and shape the parser + chat translator consume. This is what makes
+  streaming, history, and `--resume` continuity testable. Replies are scripted
+  via `HERD_FAKE_SCRIPT` (a JSON file the harness writes from `fakeScript`).
+- The harness `realpathSync`s its temp root so macOS's `/var` → `/private/var`
+  symlink doesn't desync the configured `working_directory` from the cwd the
+  spawned `claude` reports (otherwise the session watcher times out).
+- `fixtures.ts` exposes a Playwright `harness` fixture; each test that requests
+  it gets a fresh server + fleet and tears it down afterward.
+
+## Running
+
+```bash
+# From the repo root or packages/web — build core + web first (the harness
+# imports the built dist/server output and @herdctl/core's dist).
+pnpm --filter @herdctl/core... build
+pnpm --filter @herdctl/web build
+
+# Run the UI/integration suite
+pnpm --filter @herdctl/web test:ui
+
+# One file / one test
+pnpm --filter @herdctl/web test:ui -- 03-chat
+pnpm --filter @herdctl/web test:ui -- -g "resume continuity"
+```
+
+Requires the Playwright Chromium browser (`npx playwright install chromium`).
+
+## Journeys covered
+
+| Spec | Journey |
+| --- | --- |
+| `00-ws-probe` | raw browser WebSocket ping → pong |
+| `01-dashboard` | fleet overview, agent cards, nav, connection status, empty states |
+| `02-schedules` | schedule list, enable/disable, trigger, empty state |
+| `03-chat` | new chat send → stream reply, resume continuity, history replay |
+| `04-jobs` | trigger via modal → run → job history + detail |
+| `05-agent-detail` | header, tab navigation, not-found |
+| `06-theme-and-chrome` | dark/light theme persistence, SPA deep-link, version footer |
+| `07-sessions-and-errors` | All Chats listing, empty + API-error states |

--- a/packages/web/test-ui/fixtures.ts
+++ b/packages/web/test-ui/fixtures.ts
@@ -1,0 +1,32 @@
+/**
+ * Playwright fixtures for @herdctl/web UI/integration tests.
+ *
+ * Exposes a `harness` fixture that boots a fresh real web server + FleetManager
+ * (with a temp fleet + fake claude) for each test that requests it, and tears it
+ * down afterwards. Tests that don't need a custom fleet get a sensible default.
+ */
+
+import { test as base } from "@playwright/test";
+import { type Harness, type HarnessOptions, startHarness } from "./harness.js";
+
+export interface Fixtures {
+  /** Options for the default harness. Override per-test via test.use({...}). */
+  harnessOptions: HarnessOptions;
+  /** A live harness: real web server + FleetManager + fake claude. */
+  harness: Harness;
+}
+
+export const test = base.extend<Fixtures>({
+  harnessOptions: [{}, { option: true }],
+
+  harness: async ({ harnessOptions }, use) => {
+    const harness = await startHarness(harnessOptions);
+    try {
+      await use(harness);
+    } finally {
+      await harness.stop();
+    }
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/packages/web/test-ui/fixtures/bin/claude
+++ b/packages/web/test-ui/fixtures/bin/claude
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * fake-claude — a deterministic stand-in for the real `claude` CLI, used by
+ * @herdctl/web's UI/integration tests so the WHOLE web + @herdctl/core stack
+ * runs with ZERO Anthropic calls.
+ *
+ * ── Why a fake binary (and not a mock) ──────────────────────────────────────
+ * herdctl's CLI runtime (@herdctl/core CLIRuntime) spawns `claude` from PATH and
+ * then WATCHES the session JSONL file it writes — it does NOT read the process's
+ * stdout for stream-json. So to exercise the real session-discovery / history /
+ * resume machinery we must (a) be spawnable as `claude`, and (b) write a real
+ * `<sessionId>.jsonl` transcript in the exact location + line shapes herdctl's
+ * parser and the @herdctl/chat translator consume. This file does both.
+ *
+ * Modelled on paddock/test/bin/claude, but with TWO important differences:
+ *   1. encodePathForCli mirrors @herdctl/core EXACTLY: it replaces every
+ *      non-alphanumeric character with a hyphen (not just path separators).
+ *      Test workspaces under /var/folders/... contain dots, so the looser
+ *      encoding would write the transcript to the wrong directory and the
+ *      session watcher would time out.
+ *   2. Scripted replies come from HERD_FAKE_SCRIPT (a JSON file path).
+ *
+ * ── What herdctl passes us (see cli-runtime.ts) ─────────────────────────────
+ *   claude -p --permission-mode <m> [--model <m>] [--system-prompt <s>]
+ *          [--allowedTools <csv>] [--disallowedTools <csv>] [--resume <id>]
+ *          [--mcp-config <json>] ...        (prompt arrives on STDIN)
+ * cwd is the agent's working_directory. For a NEW session herdctl waits for a
+ * NEW *.jsonl file to appear in getCliSessionDir(cwd) and derives the session id
+ * from the filename. For --resume it watches <id>.jsonl directly. So:
+ *   • new  → mint a uuid, write <uuid>.jsonl
+ *   • resume → append to <resume>.jsonl
+ */
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const flags = {
+    print: false,
+    model: undefined,
+    systemPrompt: undefined,
+    resume: undefined,
+    permissionMode: undefined,
+    allowedTools: undefined,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "-p" || a === "--print") flags.print = true;
+    else if (a === "--model") flags.model = argv[++i];
+    else if (a === "--system-prompt") flags.systemPrompt = argv[++i];
+    else if (a === "--resume") flags.resume = argv[++i];
+    else if (a === "--permission-mode") flags.permissionMode = argv[++i];
+    else if (a === "--allowedTools") flags.allowedTools = argv[++i];
+    else if (a === "--disallowedTools") argv[++i];
+    else if (a === "--mcp-config") argv[++i];
+    else if (a === "--setting-sources") argv[++i];
+    else if (a === "--tools") argv[++i];
+    // --fork-session and unknown bare flags are ignored.
+  }
+  return flags;
+}
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+// Mirror @herdctl/core encodePathForCli EXACTLY: every non-alphanumeric → "-".
+function encodePathForCli(absolutePath) {
+  return absolutePath.replace(/[^A-Za-z0-9]/g, "-");
+}
+function sessionDirFor(cwd) {
+  return path.join(os.homedir(), ".claude", "projects", encodePathForCli(cwd));
+}
+
+function loadScript() {
+  const p = process.env.HERD_FAKE_SCRIPT;
+  if (!p) return {};
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function replyFor(prompt, script, priorText) {
+  const trimmed = (prompt || "").trim();
+  if (Object.prototype.hasOwnProperty.call(script, trimmed)) {
+    return script[trimmed];
+  }
+
+  // Force-failure hook so tests can exercise the error path deterministically.
+  if (/^FAIL\b/i.test(trimmed)) {
+    process.stderr.write("fake-claude: forced failure\n");
+    process.exit(1);
+  }
+
+  // Continuity: "the codeword is X" / "remember the codeword: X"
+  const setMatch = trimmed.match(/codeword(?:\s+is|:)\s+([A-Za-z0-9_-]+)/i);
+  if (setMatch) {
+    return `Got it — I'll remember the codeword ${setMatch[1]}.`;
+  }
+  // Recall: "what was the codeword?" → find it in the prior transcript text.
+  if (/what.*codeword/i.test(trimmed)) {
+    const prior = priorText || "";
+    const fromAssistant = prior.match(/remember the codeword\s+([A-Za-z0-9_-]+)/i);
+    const fromUser = prior.match(/codeword(?:\s+is|\s+was|:)\s+([A-Za-z0-9_-]+)/i);
+    const found = fromAssistant || fromUser;
+    if (found) return `The codeword was ${found[1]}.`;
+    return "I don't have a codeword on record.";
+  }
+
+  // Default: a short, deterministic acknowledgement that echoes the prompt.
+  return `Acknowledged: ${trimmed}`;
+}
+
+function readPriorText(file) {
+  let raw = "";
+  try {
+    raw = fs.readFileSync(file, "utf8");
+  } catch {
+    return "";
+  }
+  const parts = [];
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let o;
+    try {
+      o = JSON.parse(t);
+    } catch {
+      continue;
+    }
+    if (o.type !== "user" && o.type !== "assistant") continue;
+    const c = o.message && o.message.content;
+    if (typeof c === "string") parts.push(c);
+    else if (Array.isArray(c)) {
+      for (const b of c) if (b && b.type === "text" && typeof b.text === "string") parts.push(b.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function sleep(ms) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    /* spin briefly so the watcher sees lines arrive incrementally */
+  }
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const flags = parseArgs(argv);
+  const prompt = readStdin();
+  const cwd = process.cwd();
+  const script = loadScript();
+
+  const dir = sessionDirFor(cwd);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    /* ignore */
+  }
+
+  const resuming = !!flags.resume;
+  const sessionId = resuming ? flags.resume : crypto.randomUUID();
+  const file = path.join(dir, `${sessionId}.jsonl`);
+
+  const priorText = resuming ? readPriorText(file) : "";
+  const reply = replyFor(prompt, script, priorText);
+  const messageId = `msg_${crypto.randomBytes(8).toString("hex")}`;
+  const model = flags.model || "claude-opus-4-8";
+
+  const append = (obj) => {
+    fs.appendFileSync(file, `${JSON.stringify(obj)}\n`);
+  };
+
+  // 1) user line (preview + history). Never isSidechain (keep it discoverable).
+  append({
+    parentUuid: null,
+    isSidechain: false,
+    type: "user",
+    message: { role: "user", content: prompt },
+    uuid: crypto.randomUUID(),
+    timestamp: nowIso(),
+    cwd,
+    sessionId,
+    version: "2.1.167",
+    gitBranch: "",
+    userType: "external",
+  });
+
+  // Small gap so the watcher streams the assistant separately from the user line.
+  sleep(60);
+
+  // 2) assistant line (text + usage). Single text block → one chat:response.
+  append({
+    parentUuid: null,
+    isSidechain: false,
+    type: "assistant",
+    message: {
+      id: messageId,
+      role: "assistant",
+      model,
+      content: [{ type: "text", text: reply }],
+      usage: {
+        input_tokens: 1200,
+        output_tokens: 64,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    },
+    uuid: crypto.randomUUID(),
+    timestamp: nowIso(),
+    cwd,
+    sessionId,
+  });
+
+  sleep(40);
+
+  // 3) result line — ends the watcher loop and marks the turn successful.
+  append({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    session_id: sessionId,
+    result: reply,
+    usage: {
+      input_tokens: 1200,
+      output_tokens: 64,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+  });
+
+  process.stdout.write(`${reply}\n`);
+  process.exit(0);
+}
+
+main();

--- a/packages/web/test-ui/harness.ts
+++ b/packages/web/test-ui/harness.ts
@@ -1,0 +1,202 @@
+/**
+ * UI/integration test harness for @herdctl/web.
+ *
+ * Boots the REAL Fastify web server (createWebServer) against a REAL
+ * @herdctl/core FleetManager, driven by a TEMP fleet config and a FAKE `claude`
+ * binary on PATH — so the dashboard, REST API, WebSocket and the chat/trigger
+ * flows all run end-to-end with ZERO Anthropic calls.
+ *
+ * Why createWebServer (and not FleetManager.start with web enabled)?
+ * FleetManager loads the web dashboard via `import("@herdctl/web")`, which only
+ * resolves where @herdctl/web is an installed dependency (the CLI). Inside this
+ * package we instead drive the same public factory the WebManager uses
+ * (createWebServer + fleetBridge.start + server.listen), giving us the identical
+ * server while keeping the harness self-contained.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { FleetManager } from "@herdctl/core";
+// Import from built server output — this is the exact code that ships.
+import { createWebServer, type WebServerResult } from "../dist/server/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the fake `claude` binary's directory (prepended to PATH). */
+export const FAKE_BIN_DIR = join(__dirname, "fixtures", "bin");
+
+export interface AgentSpec {
+  name: string;
+  description?: string;
+  /** Extra raw YAML lines spliced into the agent doc (schedules, chat, etc.). */
+  extraYaml?: string;
+}
+
+export interface HarnessOptions {
+  /** Agents to define in the temp fleet. Defaults to a single "hello" agent. */
+  agents?: AgentSpec[];
+  /** Fleet name. */
+  fleetName?: string;
+  /** Scripted replies for the fake claude (prompt → reply). */
+  fakeScript?: Record<string, string>;
+  /** Whether to start the scheduler (FleetManager.start). Default true. */
+  startScheduler?: boolean;
+}
+
+export interface Harness {
+  /** Base URL the dashboard is served from, e.g. http://127.0.0.1:54321 */
+  baseUrl: string;
+  /** The live FleetManager. */
+  fleet: FleetManager;
+  /** The web server bundle (server, wsHandler, fleetBridge, chatManager). */
+  web: WebServerResult;
+  /** Temp directory holding the fleet config + workspaces + state. */
+  tmpRoot: string;
+  /** The encoded ~/.claude/projects dir each agent writes its transcripts to. */
+  agentSessionDir: (agentName: string) => string;
+  /** Working directory for an agent. */
+  agentWorkdir: (agentName: string) => string;
+  /** Tear everything down and remove temp files / transcripts. */
+  stop: () => Promise<void>;
+}
+
+/** Mirror @herdctl/core encodePathForCli: every non-alphanumeric → "-". */
+function encodePathForCli(absolutePath: string): string {
+  return absolutePath.replace(/[^A-Za-z0-9]/g, "-");
+}
+
+function buildAgentYaml(agent: AgentSpec, workdir: string): string {
+  return [
+    `name: ${agent.name}`,
+    `description: ${JSON.stringify(agent.description ?? `Test agent ${agent.name}`)}`,
+    "runtime: cli",
+    "model: claude-sonnet-4-20250514",
+    "max_turns: 5",
+    "permission_mode: default",
+    `system_prompt: ${JSON.stringify("You are a helpful test agent.")}`,
+    `working_directory: ${JSON.stringify(workdir)}`,
+    "allowed_tools: [Read, Write]",
+    agent.extraYaml ?? "",
+    "",
+  ].join("\n");
+}
+
+export async function startHarness(options: HarnessOptions = {}): Promise<Harness> {
+  const {
+    agents = [{ name: "hello", description: "A friendly greeter" }],
+    fleetName = "ui-test-fleet",
+    fakeScript = {},
+    startScheduler = true,
+  } = options;
+
+  // realpathSync resolves macOS's /var -> /private/var symlink so the agent's
+  // configured working_directory matches the cwd the spawned `claude` reports
+  // (otherwise core watches ~/.claude/projects/-var-... while the binary writes
+  // to -private-var-..., and the session watcher times out).
+  const tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "herd-web-ui-")));
+  const stateDir = join(tmpRoot, ".herdctl");
+
+  // 1) Write a fake-claude script file the binary reads via HERD_FAKE_SCRIPT.
+  const scriptPath = join(tmpRoot, "fake-script.json");
+  writeFileSync(scriptPath, JSON.stringify(fakeScript), "utf8");
+  process.env.HERD_FAKE_SCRIPT = scriptPath;
+
+  // 2) Prepend the fake `claude` to PATH (idempotent across harness instances).
+  if (!process.env.PATH?.split(":").includes(FAKE_BIN_DIR)) {
+    process.env.PATH = `${FAKE_BIN_DIR}:${process.env.PATH ?? ""}`;
+  }
+
+  // 3) Materialise the fleet config + per-agent workspaces.
+  const agentDir = join(tmpRoot, "agents");
+  spawnSync("mkdir", ["-p", agentDir]);
+  const agentRefs: string[] = [];
+  for (const agent of agents) {
+    const workdir = join(tmpRoot, "work", agent.name);
+    spawnSync("mkdir", ["-p", workdir]);
+    const agentPath = join(agentDir, `${agent.name}.yaml`);
+    writeFileSync(agentPath, buildAgentYaml(agent, workdir), "utf8");
+    agentRefs.push(`  - path: ${JSON.stringify(agentPath)}`);
+  }
+
+  const fleetYaml = [
+    "version: 1",
+    "fleet:",
+    `  name: ${fleetName}`,
+    `  description: ${JSON.stringify("Temp fleet for web UI integration tests")}`,
+    agentRefs.length > 0 ? "agents:" : "agents: []",
+    ...agentRefs,
+    "",
+  ].join("\n");
+  const configPath = join(tmpRoot, "herdctl.yaml");
+  writeFileSync(configPath, fleetYaml, "utf8");
+
+  // 4) Boot the real FleetManager.
+  const fleet = new FleetManager({ configPath, stateDir });
+  await fleet.initialize();
+  if (startScheduler) {
+    await fleet.start();
+  }
+
+  // 5) Boot the real web server (the exact code the WebManager uses).
+  const web = await createWebServer(fleet, {
+    host: "127.0.0.1",
+    port: 0, // ephemeral port — avoids collisions across parallel workers
+    stateDir,
+    sessionExpiryHours: 24,
+    toolResults: true,
+    messageGrouping: "separate",
+  });
+
+  await web.server.listen({ host: "127.0.0.1", port: 0 });
+  web.fleetBridge.start();
+
+  const address = web.server.server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Web server did not bind to a TCP port");
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const agentWorkdir = (agentName: string) => join(tmpRoot, "work", agentName);
+  const agentSessionDir = (agentName: string) =>
+    join(process.env.HOME ?? "", ".claude", "projects", encodePathForCli(agentWorkdir(agentName)));
+
+  const stop = async (): Promise<void> => {
+    try {
+      web.fleetBridge.stop();
+      web.wsHandler.closeAll();
+      // The dashboard's WebSocket client auto-reconnects, so it races
+      // server.close() and can keep the HTTP server alive indefinitely (the
+      // browser page is still open during fixture teardown). Force every open
+      // socket shut first, then bound the graceful close so teardown can never
+      // hang the test.
+      web.server.server.closeAllConnections?.();
+      await Promise.race([web.server.close(), new Promise((resolve) => setTimeout(resolve, 2000))]);
+      web.server.server.closeAllConnections?.();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await fleet.stop({ waitForJobs: false, timeout: 5000, cancelOnTimeout: true });
+    } catch {
+      /* ignore */
+    }
+    // Remove transcripts the fake claude wrote for these agents, then temp root.
+    for (const agent of agents) {
+      try {
+        rmSync(agentSessionDir(agent.name), { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return { baseUrl, fleet, web, tmpRoot, agentSessionDir, agentWorkdir, stop };
+}

--- a/packages/web/test-ui/tests/00-ws-probe.spec.ts
+++ b/packages/web/test-ui/tests/00-ws-probe.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "../fixtures.js";
+
+/**
+ * Low-level WebSocket probe — runs INSIDE the real browser to confirm the
+ * server's inbound message handling (ping -> pong) works end-to-end over the
+ * actual wire, independent of any React code.
+ */
+test("server replies to a ping with a pong over a real browser WebSocket", async ({
+  page,
+  harness,
+}) => {
+  // The probe only needs a document context + page origin to open its own
+  // WebSocket; don't block on the full SPA bundle "load" (avoids cold-start
+  // flake when several fleets boot in parallel).
+  await page.goto(harness.baseUrl, { waitUntil: "domcontentloaded" });
+
+  const result = await page.evaluate(async (baseUrl) => {
+    const wsUrl = `${baseUrl.replace("http", "ws")}/ws`;
+    const ws = new WebSocket(wsUrl);
+    return await new Promise<{ pong: boolean; gotStatus: boolean }>((resolve, reject) => {
+      let gotStatus = false;
+      const timer = setTimeout(() => reject(new Error("ws probe timeout")), 10_000);
+      ws.addEventListener("open", () => ws.send(JSON.stringify({ type: "ping" })));
+      ws.addEventListener("message", (ev) => {
+        const msg = JSON.parse(ev.data as string);
+        if (msg.type === "fleet:status") gotStatus = true;
+        if (msg.type === "pong") {
+          clearTimeout(timer);
+          ws.close();
+          resolve({ pong: true, gotStatus });
+        }
+      });
+      ws.addEventListener("error", () => {
+        clearTimeout(timer);
+        reject(new Error("ws probe error"));
+      });
+    });
+  }, harness.baseUrl);
+
+  expect(result.gotStatus).toBe(true);
+  expect(result.pong).toBe(true);
+});

--- a/packages/web/test-ui/tests/01-dashboard.spec.ts
+++ b/packages/web/test-ui/tests/01-dashboard.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "../fixtures.js";
+
+/**
+ * Fleet overview / dashboard journeys: the landing page renders the fleet
+ * status, the configured agents, their statuses, and the recent-jobs section,
+ * all sourced from a REAL FleetManager over REST + WebSocket.
+ */
+
+test.describe("Fleet dashboard", () => {
+  test.use({
+    harnessOptions: {
+      fleetName: "ui-test-fleet",
+      agents: [
+        { name: "greeter", description: "Greets people warmly" },
+        { name: "scout", description: "Scouts for new work" },
+      ],
+    },
+  });
+
+  test("renders fleet overview header, status and stat chips", async ({ page, harness }) => {
+    await page.goto(harness.baseUrl);
+
+    await expect(page.getByRole("heading", { name: "Fleet Overview" })).toBeVisible();
+    // Fleet status badge reflects the running FleetManager.
+    await expect(page.getByText("Uptime:")).toBeVisible();
+    // Stat chips: 2 agents configured.
+    await expect(page.getByText("agents", { exact: true })).toBeVisible();
+    const agentsChip = page.locator("div", { hasText: /^2agents$/ }).first();
+    await expect(agentsChip).toBeVisible();
+  });
+
+  test("renders an agent card per configured agent with description and status", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(harness.baseUrl);
+
+    const greeterCard = page.locator("article", { hasText: "greeter" });
+    const scoutCard = page.locator("article", { hasText: "scout" });
+
+    await expect(greeterCard).toBeVisible();
+    await expect(scoutCard).toBeVisible();
+
+    await expect(greeterCard.getByText("Greets people warmly")).toBeVisible();
+    await expect(scoutCard.getByText("Scouts for new work")).toBeVisible();
+
+    // Idle agents show a status badge of "idle" and View/Chat actions.
+    await expect(greeterCard.getByRole("link", { name: /View/ })).toBeVisible();
+    await expect(greeterCard.getByRole("link", { name: /Chat/ })).toBeVisible();
+  });
+
+  test("clicking an agent card View navigates to the agent detail page", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(harness.baseUrl);
+
+    const greeterCard = page.locator("article", { hasText: "greeter" });
+    await greeterCard.getByRole("link", { name: /View/ }).click();
+
+    await expect(page).toHaveURL(/\/agents\/greeter/);
+    // Agent detail tab bar (scope to main content to avoid the sidebar's nav links).
+    const main = page.locator("main");
+    await expect(main.getByRole("link", { name: "Overview" })).toBeVisible();
+    await expect(main.getByRole("link", { name: "Jobs" })).toBeVisible();
+  });
+
+  test("sidebar navigation links route to Jobs, Schedules and All Chats", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(harness.baseUrl);
+
+    await page.getByRole("link", { name: "Jobs", exact: true }).click();
+    await expect(page).toHaveURL(/\/jobs$/);
+
+    await page.getByRole("link", { name: "Schedules", exact: true }).click();
+    await expect(page).toHaveURL(/\/schedules$/);
+
+    await page.getByRole("link", { name: "All Chats", exact: true }).click();
+    await expect(page).toHaveURL(/\/chats$/);
+  });
+
+  test("connection status shows Connected once the WebSocket is live", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(harness.baseUrl);
+    // Header shows the live WS connection label once the socket reports connected.
+    await expect(page.locator("header").getByText("Connected", { exact: true })).toBeVisible();
+  });
+});
+
+test.describe("Empty fleet states", () => {
+  test.use({
+    harnessOptions: {
+      // A fleet config with no agents still validates and boots.
+      agents: [],
+    },
+  });
+
+  test("shows the no-agents empty state when the fleet has no agents", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(harness.baseUrl);
+
+    const main = page.locator("main");
+    await expect(main.getByText("No agents configured")).toBeVisible();
+    await expect(main.getByText("Add agents to your herdctl.yaml to get started")).toBeVisible();
+  });
+
+  test("shows the no-jobs empty state before any job runs", async ({ page, harness }) => {
+    await page.goto(harness.baseUrl);
+    await expect(page.locator("main").getByText("No jobs yet")).toBeVisible();
+  });
+});

--- a/packages/web/test-ui/tests/02-schedules.spec.ts
+++ b/packages/web/test-ui/tests/02-schedules.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "../fixtures.js";
+
+/**
+ * Schedules page journeys: the schedule table renders real schedules from the
+ * FleetManager, and the enable/disable/trigger actions hit the real REST API
+ * and reflect back in the UI.
+ */
+
+const cronSchedule = [
+  "schedules:",
+  "  nightly:",
+  "    type: cron",
+  '    cron: "0 9 * * *"',
+  '    prompt: "Do the nightly run"',
+].join("\n");
+
+const intervalSchedule = [
+  "schedules:",
+  "  poller:",
+  "    type: interval",
+  "    interval: 6h",
+  '    prompt: "Poll for work"',
+].join("\n");
+
+test.describe("Schedules page", () => {
+  test.use({
+    harnessOptions: {
+      agents: [
+        { name: "nightowl", description: "Runs on a cron", extraYaml: cronSchedule },
+        { name: "poller", description: "Runs on an interval", extraYaml: intervalSchedule },
+      ],
+    },
+  });
+
+  test("lists schedules across all agents with type and expression", async ({ page, harness }) => {
+    await page.goto(`${harness.baseUrl}/schedules`);
+
+    await expect(page.getByRole("heading", { name: "All Schedules" })).toBeVisible();
+
+    const nightlyRow = page.locator("tr", { hasText: "nightly" });
+    await expect(nightlyRow).toBeVisible();
+    await expect(nightlyRow.getByText("Cron")).toBeVisible();
+    await expect(nightlyRow.getByText("0 9 * * *")).toBeVisible();
+
+    const pollerRow = page.locator("tr", { hasText: "poller" });
+    await expect(pollerRow).toBeVisible();
+    await expect(pollerRow.getByText("Interval")).toBeVisible();
+    await expect(pollerRow.getByText("6h")).toBeVisible();
+  });
+
+  test("disabling a schedule flips its status to disabled and offers enable", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(`${harness.baseUrl}/schedules`);
+
+    const nightlyRow = page.locator("tr", { hasText: "nightly" });
+    await expect(nightlyRow).toBeVisible();
+
+    // Disable it.
+    await nightlyRow.getByRole("button", { name: "Disable schedule" }).click();
+
+    // Status badge in the row should now read "disabled", and the enable
+    // affordance should appear (the action toggles from Disable to Enable).
+    await expect(nightlyRow.getByText(/disabled/i)).toBeVisible();
+    await expect(nightlyRow.getByRole("button", { name: "Enable schedule" })).toBeVisible();
+
+    // Re-enable it.
+    await nightlyRow.getByRole("button", { name: "Enable schedule" }).click();
+    await expect(nightlyRow.getByRole("button", { name: "Disable schedule" })).toBeVisible();
+  });
+
+  test("triggering a schedule from the table starts a real job", async ({ page, harness }) => {
+    await page.goto(`${harness.baseUrl}/schedules`);
+
+    const nightlyRow = page.locator("tr", { hasText: "nightly" });
+    await nightlyRow.getByRole("button", { name: "Trigger" }).click();
+
+    // The trigger fires a real job (fake claude). It surfaces as a toast
+    // ("Job completed for ...") once the run finishes.
+    await expect(page.getByText(/Job completed for/)).toBeVisible({ timeout: 80_000 });
+  });
+});
+
+test.describe("Schedules empty state", () => {
+  test.use({
+    harnessOptions: {
+      agents: [{ name: "scheduleless", description: "Has no schedules" }],
+    },
+  });
+
+  test("shows the no-schedules empty state", async ({ page, harness }) => {
+    await page.goto(`${harness.baseUrl}/schedules`);
+    await expect(page.getByText("No schedules configured")).toBeVisible();
+  });
+});

--- a/packages/web/test-ui/tests/03-chat.spec.ts
+++ b/packages/web/test-ui/tests/03-chat.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "../fixtures.js";
+
+/**
+ * Chat journeys — the highest-value end-to-end flow. A message typed in the
+ * browser is sent over the real WebSocket, runs a REAL agent (fake claude
+ * writing a real transcript), streams the assistant reply back, and the session
+ * becomes resumable for continuity. ZERO Anthropic calls.
+ */
+
+test.describe("Agent chat", () => {
+  test.use({
+    harnessOptions: {
+      agents: [{ name: "buddy", description: "A chatty assistant" }],
+      fakeScript: {
+        "Tell me a joke": "Why did the agent cross the road? To reach the other endpoint.",
+      },
+    },
+  });
+
+  test("new chat: send a message, stream the reply, and adopt the session URL", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(`${harness.baseUrl}/agents/buddy/chat`);
+
+    // Welcome state for a brand-new chat.
+    await expect(page.getByRole("heading", { name: "Chat with buddy" })).toBeVisible();
+
+    const composer = page.getByPlaceholder(/Send a message to buddy/);
+    await composer.fill("Tell me a joke");
+    await composer.press("Enter");
+
+    // User bubble appears immediately.
+    await expect(page.getByText("Tell me a joke")).toBeVisible();
+
+    // Assistant reply streams back from the real agent run.
+    await expect(
+      page.getByText("Why did the agent cross the road? To reach the other endpoint."),
+    ).toBeVisible({ timeout: 80_000 });
+
+    // After chat:complete, the URL adopts the server-assigned session id.
+    await expect(page).toHaveURL(/\/agents\/buddy\/chat\/[0-9a-f-]{36}/, { timeout: 20_000 });
+  });
+
+  test("resume continuity: a fact set in one turn is recalled after resume", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(`${harness.baseUrl}/agents/buddy/chat`);
+
+    const composer = page.getByPlaceholder(/Send a message to buddy/);
+
+    // Turn 1: set a codeword (the fake claude records it in the transcript).
+    await composer.fill("the codeword is ORANGE");
+    await composer.press("Enter");
+    await expect(page.getByText(/remember the codeword ORANGE/)).toBeVisible({ timeout: 80_000 });
+
+    // The session id is now in the URL — the chat is resumable.
+    await expect(page).toHaveURL(/\/agents\/buddy\/chat\/[0-9a-f-]{36}/, { timeout: 20_000 });
+
+    // Turn 2: same session, recall the codeword. This exercises --resume in the
+    // CLI runtime and the fake reading its own prior transcript.
+    await composer.fill("what was the codeword?");
+    await composer.press("Enter");
+    await expect(page.getByText("The codeword was ORANGE.")).toBeVisible({ timeout: 80_000 });
+  });
+
+  test("reloading a completed session replays its history from the transcript", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(`${harness.baseUrl}/agents/buddy/chat`);
+
+    const composer = page.getByPlaceholder(/Send a message to buddy/);
+    await composer.fill("Tell me a joke");
+    await composer.press("Enter");
+    await expect(
+      page.getByText("Why did the agent cross the road? To reach the other endpoint."),
+    ).toBeVisible({ timeout: 80_000 });
+
+    // Capture the session URL, then hard-reload it.
+    await expect(page).toHaveURL(/\/agents\/buddy\/chat\/[0-9a-f-]{36}/, { timeout: 20_000 });
+    const sessionUrl = page.url();
+    await page.goto(sessionUrl);
+
+    // History (user prompt + assistant reply) is rehydrated from the REST API,
+    // which reads the real JSONL transcript.
+    await expect(page.getByText("Tell me a joke")).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.getByText("Why did the agent cross the road? To reach the other endpoint."),
+    ).toBeVisible();
+  });
+});

--- a/packages/web/test-ui/tests/04-jobs.spec.ts
+++ b/packages/web/test-ui/tests/04-jobs.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "../fixtures.js";
+
+/**
+ * Jobs journeys: triggering an agent from the UI runs a REAL job (fake claude),
+ * which then appears in the job history table and can be inspected.
+ */
+
+test.describe("Jobs page", () => {
+  test.use({
+    harnessOptions: {
+      agents: [{ name: "worker", description: "Does the work" }],
+      fakeScript: { "Run a quick task": "Task complete." },
+    },
+  });
+
+  test("triggering a job via the modal runs it and lists it in history", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(`${harness.baseUrl}/jobs`);
+
+    // Empty state before any job.
+    await expect(page.getByRole("heading", { name: "All Jobs" })).toBeVisible();
+    await expect(page.locator("main").getByText("No jobs found")).toBeVisible();
+
+    // Open the Trigger Job modal.
+    await page.getByRole("button", { name: "Trigger Job" }).click();
+    await expect(page.getByRole("heading", { name: "Trigger Job" })).toBeVisible();
+
+    // Select the agent and provide a prompt that the fake claude has a script for.
+    await page.locator("#trigger-agent").selectOption("worker");
+    await page.locator("#trigger-prompt").fill("Run a quick task");
+    await page.getByRole("button", { name: "Trigger", exact: true }).click();
+
+    // Modal confirms the trigger.
+    await expect(page.getByText("Job triggered")).toBeVisible({ timeout: 20_000 });
+
+    // The job completes (toast) and then appears in the history table.
+    await expect(page.getByText(/Job completed for worker/)).toBeVisible({ timeout: 80_000 });
+
+    const jobRow = page.locator("tr", { hasText: "Run a quick task" });
+    await expect(jobRow.first()).toBeVisible({ timeout: 20_000 });
+    await expect(jobRow.first().getByText(/completed/i)).toBeVisible();
+  });
+
+  test("clicking a completed job opens its detail panel", async ({ page, harness }) => {
+    // Trigger via REST so the job exists, then assert the UI detail flow.
+    const res = await page.request.post(`${harness.baseUrl}/api/agents/worker/trigger`, {
+      data: { prompt: "Run a quick task" },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    // Wait for the run to finish by polling the jobs API.
+    await expect
+      .poll(
+        async () => {
+          const jobs = await (await page.request.get(`${harness.baseUrl}/api/jobs`)).json();
+          return jobs.jobs?.[0]?.status;
+        },
+        { timeout: 80_000, intervals: [1000] },
+      )
+      .toBe("completed");
+
+    await page.goto(`${harness.baseUrl}/jobs`);
+    const jobRow = page.locator("tr", { hasText: "Run a quick task" }).first();
+    await expect(jobRow).toBeVisible({ timeout: 20_000 });
+    await jobRow.click();
+
+    // Detail panel shows the job's prompt and a completed status.
+    const main = page.locator("main");
+    await expect(main.getByText("Run a quick task").first()).toBeVisible();
+  });
+});

--- a/packages/web/test-ui/tests/05-agent-detail.spec.ts
+++ b/packages/web/test-ui/tests/05-agent-detail.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "../fixtures.js";
+
+/**
+ * Agent detail page journeys: header, tab navigation (Overview / Chats / Jobs /
+ * Output), and the not-found state for unknown agents.
+ */
+
+test.describe("Agent detail", () => {
+  test.use({
+    harnessOptions: {
+      agents: [
+        {
+          name: "inspector",
+          description: "Inspects things",
+          extraYaml: [
+            "schedules:",
+            "  hourly:",
+            "    type: interval",
+            "    interval: 1h",
+            '    prompt: "Inspect"',
+          ].join("\n"),
+        },
+      ],
+    },
+  });
+
+  test("renders the agent header and default Overview tab", async ({ page, harness }) => {
+    await page.goto(`${harness.baseUrl}/agents/inspector`);
+
+    // Back link to dashboard.
+    await expect(page.getByRole("link", { name: "Back to Dashboard" })).toBeVisible();
+
+    const main = page.locator("main");
+    await expect(main.getByRole("link", { name: "Overview" })).toBeVisible();
+    await expect(main.getByRole("link", { name: "Chats" })).toBeVisible();
+    await expect(main.getByRole("link", { name: "Jobs" })).toBeVisible();
+    await expect(main.getByRole("link", { name: "Output" })).toBeVisible();
+  });
+
+  test("switching to the Jobs tab updates the URL and shows the jobs view", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(`${harness.baseUrl}/agents/inspector`);
+
+    await page.locator("main").getByRole("link", { name: "Jobs" }).click();
+    await expect(page).toHaveURL(/\/agents\/inspector\/jobs/);
+  });
+
+  // Regression test for the fix to edspencer/herdctl#268: a 404 for an unknown
+  // agent must render the dedicated "Agent Not Found" card, not the generic
+  // error panel with a misleading "Retry" button.
+  test("shows a not-found card for an unknown agent", async ({ page, harness }) => {
+    await page.goto(`${harness.baseUrl}/agents/does-not-exist`);
+
+    await expect(page.getByRole("heading", { name: "Agent Not Found" })).toBeVisible();
+    await expect(page.getByText(/No agent named "does-not-exist" exists/)).toBeVisible();
+    // The misleading retryable error state must NOT be shown for a 404.
+    await expect(page.locator("main").getByRole("button", { name: "Retry" })).toHaveCount(0);
+  });
+});

--- a/packages/web/test-ui/tests/06-theme-and-chrome.spec.ts
+++ b/packages/web/test-ui/tests/06-theme-and-chrome.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "../fixtures.js";
+
+/**
+ * App chrome journeys: dark/light/system theme toggle (persisted to
+ * localStorage + applied as the `dark` class on <html>), the version footer,
+ * and the SPA serving / deep-link refresh behaviour.
+ */
+
+test.describe("Theme toggle", () => {
+  test.use({ harnessOptions: { agents: [{ name: "any", description: "an agent" }] } });
+
+  test("switching to dark mode adds the dark class and persists it", async ({ page, harness }) => {
+    await page.goto(harness.baseUrl);
+
+    const html = page.locator("html");
+
+    // Force a known starting point.
+    await page.getByRole("button", { name: "Light mode" }).click();
+    await expect(html).not.toHaveClass(/dark/);
+
+    // Switch to dark.
+    await page.getByRole("button", { name: "Dark mode" }).click();
+    await expect(html).toHaveClass(/dark/);
+
+    // Persisted preference.
+    const stored = await page.evaluate(() => localStorage.getItem("herd-theme"));
+    expect(stored).toBe("dark");
+
+    // Survives a reload.
+    await page.reload();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+  });
+
+  test("switching back to light mode removes the dark class", async ({ page, harness }) => {
+    await page.goto(harness.baseUrl);
+    await page.getByRole("button", { name: "Dark mode" }).click();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+
+    await page.getByRole("button", { name: "Light mode" }).click();
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+  });
+});
+
+test.describe("SPA + version chrome", () => {
+  test.use({ harnessOptions: { agents: [{ name: "any", description: "an agent" }] } });
+
+  test("deep-linking to a route and refreshing serves the SPA (no 404)", async ({
+    page,
+    harness,
+  }) => {
+    // Hit a client route directly — the server SPA fallback must serve index.html.
+    const response = await page.goto(`${harness.baseUrl}/schedules`);
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { name: "All Schedules" })).toBeVisible();
+  });
+
+  test("the version endpoint reports a real web version in the sidebar footer", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(harness.baseUrl);
+    // Sidebar footer renders "herdctl vX ... core vY ... web vZ".
+    await expect(page.getByText(/web v\d+\.\d+\.\d+/)).toBeVisible();
+  });
+});

--- a/packages/web/test-ui/tests/07-sessions-and-errors.spec.ts
+++ b/packages/web/test-ui/tests/07-sessions-and-errors.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "../fixtures.js";
+
+/**
+ * Session-list (All Chats) journeys and error/empty states across the app.
+ */
+
+test.describe("All Chats session list", () => {
+  test.use({
+    harnessOptions: {
+      agents: [{ name: "talker", description: "Has conversations" }],
+      fakeScript: { "First message": "First reply from the agent." },
+    },
+  });
+
+  test("a completed chat appears in the All Chats directory listing", async ({ page, harness }) => {
+    // Run one chat turn via REST so a transcript exists on disk.
+    const res = await page.request.post(`${harness.baseUrl}/api/agents/talker/trigger`, {
+      data: { prompt: "First message", triggerType: "web" },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    // Wait for the job to complete.
+    await expect
+      .poll(
+        async () => {
+          const jobs = await (await page.request.get(`${harness.baseUrl}/api/jobs`)).json();
+          return jobs.jobs?.[0]?.status;
+        },
+        { timeout: 80_000, intervals: [1000] },
+      )
+      .toBe("completed");
+
+    await page.goto(`${harness.baseUrl}/chats`);
+    await expect(page.getByRole("heading", { name: "All Chats" })).toBeVisible();
+    // The agent's working directory group should be listed (it contains the
+    // session we just created). The agent name surfaces in the group header.
+    await expect(page.getByText("talker").first()).toBeVisible({ timeout: 20_000 });
+  });
+
+  // Note: /chats is machine-wide (it discovers every Claude Code session under
+  // ~/.claude, not just this fleet's), so we can't assert a global empty state
+  // on a real dev machine. Instead assert the deterministic "no search results"
+  // state for a query that cannot match any session.
+  test("renders the All Chats page and a no-results state for an impossible query", async ({
+    page,
+    harness,
+  }) => {
+    await page.goto(`${harness.baseUrl}/chats`);
+
+    await expect(page.getByRole("heading", { name: "All Chats" })).toBeVisible();
+    await expect(page.getByText("Every Claude Code session on this machine")).toBeVisible();
+
+    await page
+      .getByPlaceholder(/Search sessions/)
+      .fill("zzz-no-such-session-qqq-impossible-match-xyz");
+    await expect(page.getByText("No matching sessions")).toBeVisible({ timeout: 20_000 });
+  });
+});
+
+test.describe("API error surfacing", () => {
+  test.use({ harnessOptions: { agents: [{ name: "any", description: "an agent" }] } });
+
+  test("the schedules page surfaces a server error in an inline banner", async ({
+    page,
+    harness,
+  }) => {
+    // Force the schedules API to 500 for this page load.
+    await page.route("**/api/schedules", (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Scheduler exploded", statusCode: 500 }),
+      }),
+    );
+
+    await page.goto(`${harness.baseUrl}/schedules`);
+    await expect(page.getByText("Scheduler exploded")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+  });
+
+  test("the dashboard still renders its shell when the agents API fails", async ({
+    page,
+    harness,
+  }) => {
+    await page.route("**/api/agents", (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "agents down", statusCode: 500 }),
+      }),
+    );
+
+    await page.goto(harness.baseUrl);
+    // The layout shell (sidebar nav) renders even when the agents fetch fails.
+    await expect(page.getByRole("link", { name: "Dashboard", exact: true })).toBeVisible();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
         specifier: ^5.0.3
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.61.0
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@6.4.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
@@ -1500,6 +1503,11 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -4216,8 +4224,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.58.2:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6576,6 +6594,10 @@ snapshots:
     optional: true
 
   '@pinojs/redact@0.4.0': {}
+
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -9902,9 +9924,17 @@ snapshots:
 
   playwright-core@1.58.2: {}
 
+  playwright-core@1.61.0: {}
+
   playwright@1.58.2:
     dependencies:
       playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## What

Adds an **integration-grade UI test suite** for `@herdctl/web` that boots the **real** Fastify server against a **real** `@herdctl/core` `FleetManager` (per-test temp fleet) with a **fake `claude`** binary on `PATH`, and drives the **real React dashboard in Chromium** (Playwright). **Zero Anthropic calls.**

The existing ~157 web tests are unit-level (Zustand store slices + server routes/handlers via `fastify.inject()` with a mocked FleetManager). They never render the React app, boot the real server, or exercise the WebSocket/CLI-runtime path. This suite fills that gap end-to-end.

### How the harness works
- `test-ui/harness.ts` writes a temp `herdctl.yaml` + per-agent workspaces, boots a real `FleetManager`, then starts the real server via the package's own `createWebServer(...)` (the exact factory `WebManager` uses) on an ephemeral port.
- `test-ui/fixtures/bin/claude` is a deterministic stand-in for the `claude` CLI. herdctl's CLI runtime **watches the `<sessionId>.jsonl` transcript** the binary writes under `~/.claude/projects/<encoded-cwd>/` (it does *not* read stdout), so the fake writes a real transcript in the exact shape the parser + chat translator consume. This makes streaming, history, and `--resume` continuity genuinely testable. Replies are scripted via `HERD_FAKE_SCRIPT`.
- `realpathSync` on the temp root keeps the agent's `working_directory` in sync with the cwd the spawned `claude` reports (macOS `/var`→`/private/var`), so the session watcher doesn't time out.

### Journeys covered (28 tests, ~17s)
fleet overview / agent cards / status · agent detail + tab nav · schedules list / enable / disable / trigger · **chat: send → stream → resume continuity → history replay** · jobs trigger → run → history → detail · All Chats listing · dark/light theme persistence · SPA deep-linking · version footer · empty + API-error states.

Run with `pnpm --filter @herdctl/web test:ui` (requires `npx playwright install chromium`). Not wired into the default `pnpm test` (browser-based + heavyweight) — it's an on-demand suite.

## Bug ledger

| # | Severity | Status | Bug |
|---|----------|--------|-----|
| [#268](https://github.com/edspencer/herdctl/issues/268) | Low (UX) | **Fixed here** | Agent detail showed a generic, retryable error panel (with a misleading "Retry") for a non-existent agent instead of the dedicated "Agent Not Found" card. The card was unreachable because `fetchAgent` throws on 404 and `AgentDetail` checks `error` before `!agent`. Fixed in `useAgentDetail` by treating a 404 as not-found. |

All other red I saw during development was test-harness contention (concurrent Playwright runs + over-parallel workers manifesting as `page.goto` / teardown timeouts) or my own test-authoring slips (strict-mode locator ambiguity; an invalid "empty All Chats" assumption — that page is machine-wide). Those are fixed in the tests/harness, not product code. The teardown fix (force-close sockets + bounded `server.close`) was needed because the dashboard's auto-reconnecting WebSocket otherwise keeps the HTTP server alive through fixture teardown.

## Production change
Only `packages/web/src/client/src/hooks/useAgentDetail.ts` (the #268 fix) — minimal and conservative. Changeset included (`@herdctl/web` patch). `pnpm lint`, `pnpm typecheck`, `pnpm build`, and the existing 157 web unit tests all pass.

**Do not merge / publish** — release is handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent detail page now displays a dedicated "Agent Not Found" card when an agent doesn't exist, instead of showing a generic retryable error message.

* **Tests**
  * Added comprehensive end-to-end UI test suite covering dashboard, schedules, chat, jobs, agent details, theming, and session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->