### PR TITLE
docs: auto-update documentation (2026-06-22)

### DIFF
--- a/agents/docs/state.md
+++ b/agents/docs/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 1114870f5bcf4d2b7ce74e0df7e1f7d5e3f3b6b9
-last_run: "2026-03-13T07:08:30Z"
-docs_gaps_found: 5
-branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13"]
+last_checked_commit: ee8d115abf4bb69a9d8b349fdd08c5f4f1e4d4c7
+last_run: "2026-06-22T03:09:38Z"
+docs_gaps_found: 3
+branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13", "docs/auto-update-2026-06-22"]
 status: completed
 ---
 
 # Documentation Audit State
 
-**Last Updated:** 2026-03-13
+**Last Updated:** 2026-06-22
 
 This document tracks the state of the documentation audit agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 1114870 | docs: auto-update documentation (2026-03-07) |
-| Last run | 2026-03-13T07:08:30Z | Manual invocation |
-| Gaps found (last run) | 5 | Discord improvements features |
-| Branches created | docs/auto-update-2026-03-13 | Added Discord voice, attachments, output, guild, skills docs |
+| Last checked commit | ee8d115 | Programmatic agents, session management, what's new updates |
+| Last run | 2026-06-22T03:09:38Z | Automated daily audit |
+| Gaps found (last run) | 3 | FleetManager API, SDKMessageTranslator, What's New page |
+| Branches created | docs/auto-update-2026-06-22 | PR #271 |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Gaps Found | Action | Branch |
 |------|-----------------|------------|--------|--------|
+| 2026-06-22 | 13 | 3 | created-branch | docs/auto-update-2026-06-22 |
 | 2026-03-13 | 3 | 5 | created-branch | docs/auto-update-2026-03-13 |
 | 2026-03-07 | 4 | 1 | created-branch | docs/auto-update-2026-03-07 |
 | 2026-03-05 | 10 | 1 | created-branch | docs/auto-update-2026-03-05 |

--- a/docs/src/content/docs/architecture/chat-infrastructure.md
+++ b/docs/src/content/docs/architecture/chat-infrastructure.md
@@ -39,6 +39,7 @@ The `@herdctl/chat` package provides the following components, each extracted fr
 | **Streaming responder** | `streaming-responder.ts` | `StreamingResponder` class for buffered, rate-limited message delivery |
 | **Message splitting** | `message-splitting.ts` | `splitMessage()`, `findSplitPoint()`, `needsSplit()`, `truncateMessage()` |
 | **Message extraction** | `message-extraction.ts` | `extractMessageContent()` for parsing Claude SDK assistant messages |
+| **SDK message translator** | `sdk-message-translator.ts` | `SDKMessageTranslator`, `createSDKMessageHandler()` for translating SDK streams into chat-UI events (text deltas, boundaries, tool calls) |
 | **Tool parsing** | `tool-parsing.ts` | `extractToolUseBlocks()`, `extractToolResults()`, `getToolInputSummary()` |
 | **DM filtering** | `dm-filter.ts` | `checkDMUserFilter()`, `isDMEnabled()`, `getDMMode()`, `shouldProcessInMode()` |
 | **Error classes** | `errors.ts` | `ChatConnectorError` hierarchy with typed error codes and type guards |

--- a/docs/src/content/docs/library-reference/fleet-manager.mdx
+++ b/docs/src/content/docs/library-reference/fleet-manager.mdx
@@ -557,6 +557,7 @@ await manager.trigger(
 | `options.prompt` | `string` | No | Override the prompt for this trigger |
 | `options.workItems` | `WorkItem[]` | No | Custom work items instead of fetching from work source |
 | `options.bypassConcurrencyLimit` | `boolean` | No | Force trigger even if agent is at capacity (default: `false`) |
+| `options.workingDirectory` | `string` | No | Override the agent's working directory for this trigger only. Absolute or relative to `process.cwd()` |
 
 #### Returns
 
@@ -598,10 +599,19 @@ const job = await manager.trigger('my-agent', undefined, {
 const job = await manager.trigger('my-agent', undefined, {
   bypassConcurrencyLimit: true,
 });
+
+// Trigger with working directory override
+const job = await manager.trigger('my-agent', undefined, {
+  workingDirectory: '/path/to/different/project',
+});
 ```
 
 <Aside type="tip">
 Prompt priority: `options.prompt` > schedule prompt > undefined. If you specify a prompt in options, it overrides the schedule's configured prompt.
+</Aside>
+
+<Aside type="note">
+The `workingDirectory` option allows you to run the same agent against different directories without registering separate agent configs. Sessions created with this override are keyed by the override directory, so you'll need to use directory-based session discovery to access them.
 </Aside>
 
 ---
@@ -721,6 +731,426 @@ const result = await manager.forkJob('job-2024-01-15-abc123', {
 const result = await manager.forkJob('job-2024-01-15-abc123', {
   schedule: 'nightly',
 });
+```
+
+---
+
+## Agent Management Methods
+
+### `addAgent(agent, options?)`
+
+Register an agent at runtime without modifying YAML configuration files.
+
+```typescript
+await manager.addAgent(
+  agent: AgentConfig | (Record<string, unknown> & { name: string }),
+  options?: AddAgentOptions
+): Promise<AgentInfo>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent` | `AgentConfig` | **Yes** | Agent configuration object matching the agent schema |
+| `options.baseDir` | `string` | No | Base directory for resolving relative `working_directory`. Defaults to config directory or `process.cwd()` |
+| `options.mergeDefaults` | `boolean` | No | Whether to merge fleet defaults into the agent (default: `true`) |
+| `options.replace` | `boolean` | No | Replace existing agent with the same name instead of throwing (default: `false`) |
+
+#### Returns
+
+`Promise<AgentInfo>` with details of the newly registered agent.
+
+#### Description
+
+This method allows programmatic agent registration without writing YAML files and calling `reload()`. The provided configuration is validated against the agent schema, merged with fleet defaults (unless disabled), and normalized the same way file-loaded agents are. The resolved agent is immediately available for triggering and appears in fleet status. A `config:reloaded` event is emitted with the change.
+
+Programmatic agents are registered at the root fleet level, so their qualified name equals their local name. This is useful for building project-oriented applications on top of herdctl where agents are managed dynamically.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `ConfigurationError` | Agent config is invalid or name collision (without `replace: true`) |
+
+#### Example
+
+```typescript
+// Register a new agent programmatically
+const agentInfo = await manager.addAgent({
+  name: 'dynamic-agent',
+  description: 'Created at runtime',
+  working_directory: '/path/to/project',
+  model: 'claude-opus-4',
+});
+
+console.log(`Registered: ${agentInfo.name}`);
+
+// Replace an existing agent
+await manager.addAgent(
+  {
+    name: 'existing-agent',
+    description: 'Updated configuration',
+  },
+  { replace: true }
+);
+
+// Add without merging fleet defaults
+await manager.addAgent(
+  {
+    name: 'standalone-agent',
+    model: 'claude-sonnet-4',
+  },
+  { mergeDefaults: false }
+);
+```
+
+---
+
+### `removeAgent(name)`
+
+Unregister an agent at runtime.
+
+```typescript
+await manager.removeAgent(name: string): Promise<boolean>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | The agent qualified name or local name to remove |
+
+#### Returns
+
+`Promise<boolean>` - `true` if an agent was removed, `false` if no match was found.
+
+#### Description
+
+Removes the agent from the in-memory configuration and scheduler. Accepts either a qualified name (e.g., `"sub.agent"`) or a local name; qualified names are matched first. Running jobs are unaffected — the scheduler simply stops triggering the removed agent's schedules. A `config:reloaded` event is emitted with the change.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+
+#### Example
+
+```typescript
+// Remove a programmatic agent
+const removed = await manager.removeAgent('dynamic-agent');
+if (removed) {
+  console.log('Agent removed successfully');
+} else {
+  console.log('Agent not found');
+}
+```
+
+---
+
+## Session Management Methods
+
+### `getAgentSessions(name, options?)`
+
+Get all Claude Code sessions for an agent.
+
+```typescript
+await manager.getAgentSessions(
+  name: string,
+  options?: { limit?: number }
+): Promise<DiscoveredSession[]>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | The agent qualified name or local name |
+| `options.limit` | `number` | No | Maximum number of sessions to return |
+
+#### Returns
+
+```typescript
+interface DiscoveredSession {
+  sessionId: string;
+  workingDirectory: string;
+  mtime: string;                    // ISO 8601 timestamp
+  origin: 'Web' | 'CLI' | 'Discord' | 'Slack' | 'Schedule' | 'Unknown';
+  agentName: string | undefined;
+  resumable: boolean;
+  customName: string | undefined;    // User-set name
+  autoName: string | undefined;      // Auto-generated from Claude summary
+  preview: string | undefined;       // First user message preview
+}
+```
+
+Array of discovered sessions (empty if the agent has no working directory or no sessions yet).
+
+#### Description
+
+Returns all Claude Code conversation sessions for the specified agent. Sessions are discovered from the agent's working directory and enriched with attribution (origin), custom names, auto-generated names, and message previews. Results are sorted by modification time (newest first) and cached for 30 seconds.
+
+This is a convenience wrapper around the session discovery service that automatically resolves the agent's working directory and Docker mode from configuration.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+// Get all sessions for an agent
+const sessions = await manager.getAgentSessions('my-agent');
+for (const session of sessions) {
+  console.log(`${session.sessionId}: ${session.customName || session.autoName || 'Unnamed'}`);
+  console.log(`  Origin: ${session.origin}, Modified: ${session.mtime}`);
+}
+
+// Get the 10 most recent sessions
+const recent = await manager.getAgentSessions('my-agent', { limit: 10 });
+```
+
+---
+
+### `getAgentSessionMessages(name, sessionId)`
+
+Get all messages from a specific agent session.
+
+```typescript
+await manager.getAgentSessionMessages(
+  name: string,
+  sessionId: string
+): Promise<ChatMessage[]>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | The agent qualified name or local name |
+| `sessionId` | `string` | **Yes** | The session ID to read |
+
+#### Returns
+
+```typescript
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp?: string;
+}
+```
+
+Array of chat messages (empty if the agent has no working directory or session doesn't exist).
+
+#### Description
+
+Reads and parses all messages from a Claude Code session transcript (JSONL file). Messages are extracted from the session's conversation history and returned in chronological order. This is useful for displaying conversation history in UIs or for analysis.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+const messages = await manager.getAgentSessionMessages('my-agent', 'session-123');
+for (const msg of messages) {
+  console.log(`${msg.role}: ${msg.content}`);
+}
+```
+
+---
+
+### `getAgentSessionUsage(name, sessionId)`
+
+Get token usage statistics for a specific session.
+
+```typescript
+await manager.getAgentSessionUsage(
+  name: string,
+  sessionId: string
+): Promise<SessionUsage>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | The agent qualified name or local name |
+| `sessionId` | `string` | **Yes** | The session ID to analyze |
+
+#### Returns
+
+```typescript
+interface SessionUsage {
+  inputTokens: number;         // Total input tokens including cache
+  turnCount: number;           // Number of turns in conversation
+  hasData: boolean;            // Whether usage data was found
+}
+```
+
+#### Description
+
+Extracts token usage and conversation statistics from a session transcript. Returns aggregate input token count (including cache hits/writes) and the total number of conversation turns. If the session has no usage data in its transcript, returns `hasData: false` with zero counts.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+const usage = await manager.getAgentSessionUsage('my-agent', 'session-123');
+if (usage.hasData) {
+  console.log(`Tokens: ${usage.inputTokens}, Turns: ${usage.turnCount}`);
+} else {
+  console.log('No usage data available for this session');
+}
+```
+
+---
+
+### `deleteSession(name, sessionId)`
+
+Delete a Claude Code session transcript from disk.
+
+```typescript
+await manager.deleteSession(
+  name: string,
+  sessionId: string
+): Promise<boolean>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | The agent qualified name or local name |
+| `sessionId` | `string` | **Yes** | The session ID to delete |
+
+#### Returns
+
+`Promise<boolean>` - `true` if the session file was deleted, `false` if it didn't exist or agent has no working directory.
+
+#### Description
+
+Deletes a session transcript file from the agent's working directory and invalidates the session discovery cache so subsequent `getAgentSessions()` calls won't list it. The session ID is validated (only alphanumeric and hyphens allowed) to prevent path traversal attacks before any filesystem access.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+| `Error` | Session ID contains invalid characters |
+
+#### Example
+
+```typescript
+const deleted = await manager.deleteSession('my-agent', 'session-123');
+if (deleted) {
+  console.log('Session deleted successfully');
+} else {
+  console.log('Session not found');
+}
+```
+
+---
+
+### `setSessionName(name, sessionId, customName)`
+
+Set or clear a custom display name for a session.
+
+```typescript
+await manager.setSessionName(
+  name: string,
+  sessionId: string,
+  customName: string | null
+): Promise<void>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | The agent qualified name or local name |
+| `sessionId` | `string` | **Yes** | The session ID to rename |
+| `customName` | `string \| null` | **Yes** | The custom name to set, or `null` to clear |
+
+#### Description
+
+Sets or clears the custom display name for a session. Custom names take precedence over auto-generated names when displaying sessions in UIs. Passing `null` or an empty/whitespace string clears any existing custom name. Changes are persisted to the session metadata store and immediately reflected in subsequent `getAgentSessions()` calls.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+// Set a custom name
+await manager.setSessionName('my-agent', 'session-123', 'Bug fix conversation');
+
+// Clear the custom name
+await manager.setSessionName('my-agent', 'session-123', null);
+```
+
+---
+
+### `invalidateSessions(name)`
+
+Force refresh of an agent's session cache.
+
+```typescript
+manager.invalidateSessions(name: string): void
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | The agent qualified name or local name |
+
+#### Description
+
+Drops the cached session listing for an agent, forcing the next `getAgentSessions()` call to rebuild it from disk. The session discovery service caches directory listings for 30 seconds and uses mtime-awareness to detect new sessions, but this method allows forcing a fresh scan immediately. This is useful when you know a session was just created and want to ensure it appears in the listing despite filesystem timestamp granularity (1-second precision on some systems).
+
+Also invalidates the attribution index so sessions created in this turn (whose job record was just written) are properly attributed.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+// After creating a new session
+const result = await manager.trigger('my-agent', undefined, {
+  prompt: 'Start a new conversation',
+});
+
+// Force cache refresh to immediately see the new session
+manager.invalidateSessions('my-agent');
+
+// Now it will definitely appear
+const sessions = await manager.getAgentSessions('my-agent');
 ```
 
 ---

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,62 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Programmatic Agent Management
+**June 22, 2026** · `@herdctl/core@5.11.0` · `herdctl@1.6.0`
+
+FleetManager now supports runtime agent registration without YAML files. Use `FleetManager.addAgent()` to register agents programmatically with an AgentConfig object, and `removeAgent()` to unregister them. Added agents are validated, merged with fleet defaults, and immediately available for triggering. This enables project-oriented applications like paddock to manage agents dynamically without write-yaml-then-reload round trips. Agents can optionally replace existing ones via `{ replace: true }`. Both methods emit `config:reloaded` events with change tracking. [#256](https://github.com/edspencer/herdctl/pull/256)
+
+---
+
+### Per-Trigger Working Directory Override
+**June 22, 2026** · `@herdctl/core@5.11.0` · `herdctl@1.6.0`
+
+Triggers now accept a `workingDirectory` option to run an agent against a different directory without registering separate agent configs. Use `trigger(agentName, schedule, { workingDirectory: '/path' })` to override the agent's configured working directory for a single invocation. This enables patterns like a single "sweeper" agent run against many project directories. Sessions created with this override are keyed by the override directory, so use directory-based session discovery to access them. [#256](https://github.com/edspencer/herdctl/pull/256)
+
+---
+
+### Session Discovery Improvements
+**June 22, 2026** · `@herdctl/core@5.11.0` · `herdctl@1.6.0`
+
+FleetManager now provides first-class session management methods: `getAgentSessions()` returns all sessions for an agent with origin badges, custom names, and auto-generated names; `getAgentSessionMessages()` reads conversation history; `getAgentSessionUsage()` returns token counts and turn statistics; `deleteSession()` removes transcripts; `setSessionName()` manages custom display names; `invalidateSessions()` forces cache refresh. All helpers derive working directory and Docker mode from agent config automatically. Session discovery is now mtime-aware with a 30-second cache TTL that auto-invalidates on directory changes. Also fixed lossy path encoding collisions by adding unique suffixes when multiple directories encode to the same slug. [#256](https://github.com/edspencer/herdctl/pull/256), [#260](https://github.com/edspencer/herdctl/pull/260), [#265](https://github.com/edspencer/herdctl/pull/265)
+
+---
+
+### SDK Message Translator in @herdctl/chat
+**June 22, 2026** · `@herdctl/chat@0.4.0`
+
+Added `SDKMessageTranslator` and `createSDKMessageHandler` to the shared chat package for translating SDK message streams into chat-UI events (assistant text deltas, turn boundaries, paired tool calls). This extracts the common message processing logic previously duplicated across Discord, Slack, Web, and downstream apps. Transports now only implement destination handlers instead of reimplementing the same SDK parsing. The translator handles tool call pairing, duration measurement, and boundary detection across consecutive assistant turns. [#256](https://github.com/edspencer/herdctl/pull/256), [#258](https://github.com/edspencer/herdctl/pull/258)
+
+---
+
+### Extended Thinking Fix and CLI Session Path Encoding
+**June 22, 2026** · `@herdctl/core@5.11.0`
+
+Fixed a critical bug where extended thinking messages split across separate JSONL lines (one with `thinking` field, one with `text` content) were being merged into a single assistant turn, corrupting conversation context. Now preserves split thinking messages as distinct turns for correct session resumption. Also improved CLI session path encoding to prevent lossy collisions: when multiple directories encode to the same slug, a unique suffix is appended. Exposed `getCliSessionFile`, `getCliSessionDir`, and `encodePathForCli` as public exports for downstream apps. [#256](https://github.com/edspencer/herdctl/pull/256), [#261](https://github.com/edspencer/herdctl/pull/261), [#265](https://github.com/edspencer/herdctl/pull/265)
+
+---
+
+### Session Not Found Retry and Cross-Agent Resume
+**June 22, 2026** · `@herdctl/core@5.11.0`
+
+Fixed session resumption when Claude SDK yields "session not found" errors by adding retry-on-session-not-found logic. Also fixed cross-agent session resume: when a user explicitly passes `resume: "session-id"` via trigger options, the runner now honors that session even if the agent's working directory differs from where the session was created, enabling session handoffs between agents. [#264](https://github.com/edspencer/herdctl/pull/264)
+
+---
+
+### CLI Runtime MCP Server Fix and Tool Result Preservation
+**June 22, 2026** · `@herdctl/chat@0.4.0` · `@herdctl/core@5.11.0`
+
+Fixed CLI-runtime tool results losing their tool name and duration fields in SDKMessageTranslator. The CLI runtime surfaces tool results twice on the same user message (top-level `tool_use_result` without ID, nested `content[]` `tool_result` blocks with IDs). The translator now prefers the ID-bearing nested blocks to preserve tool pairing metadata. Also fixed `--mcp-config` wrapper for CLI runtime to always use `{ mcpServers: { ... } }` structure for compatibility with Claude CLI expectations. [#258](https://github.com/edspencer/herdctl/pull/258), [#266](https://github.com/edspencer/herdctl/pull/266)
+
+---
+
+### Web Dashboard Testing Suite
+**June 22, 2026** · `@herdctl/web@0.10.0`
+
+Added a comprehensive real-browser UI/integration test suite for the web dashboard using Playwright. Tests cover fleet overview rendering, agent detail pages, chat functionality, session management (rename/delete), schedule controls (trigger/enable/disable), and job operations. The suite runs against a live FleetManager instance with actual Claude SDK calls (mocked via msw) to verify end-to-end behavior. Also fixed the agent-not-found state to show a proper error message instead of an infinite loading spinner. [#269](https://github.com/edspencer/herdctl/pull/269)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -47,6 +47,10 @@ The DM filter enforces access control for direct messages: enabled/disabled togg
 
 Utilities for extracting text content from Claude SDK message formats, handling direct strings, nested message objects, and content block arrays.
 
+### SDK Message Translation
+
+`SDKMessageTranslator` and `createSDKMessageHandler` translate SDK message streams into chat-UI events (assistant text deltas, turn boundaries, paired tool calls). This extracts the common message processing logic used by Discord, Slack, Web, and downstream apps so each transport only implements destination handlers instead of reimplementing the same SDK parsing.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
Automated documentation audit found 3 gap(s) across 13 commits.

## Gaps Addressed

### Gap 1: Programmatic Agent Management API (High Priority)
Added comprehensive documentation to `/opt/herdctl/docs/src/content/docs/library-reference/fleet-manager.mdx` for new FleetManager methods:
- **Agent Management**: `addAgent()`, `removeAgent()` - register/unregister agents at runtime without YAML
- **Session Management**: `getAgentSessions()`, `getAgentSessionMessages()`, `getAgentSessionUsage()`, `deleteSession()`, `setSessionName()`, `invalidateSessions()`
- **Trigger Options**: Added `workingDirectory` parameter documentation

These methods enable programmatic fleet management and are production-ready APIs in @herdctl/core.

### Gap 2: SDKMessageTranslator in @herdctl/chat (Medium Priority)
Updated package README and architecture documentation to document the new `SDKMessageTranslator` component for translating SDK message streams into chat-UI events. This extracts logic previously duplicated across web/Discord/Slack connectors.

### Gap 3: What's New Page Updates (High Priority)
Added 8 new entries to the What's New page covering June 2026 features and fixes:
- Programmatic agent management
- Session discovery improvements (mtime-aware cache, collision disambiguation)
- Extended thinking fix (critical bug)
- Cross-agent session resume
- CLI tool call display improvements
- Web UI testing suite

The page was 3+ months out of date and now reflects all commits through June 22, 2026.

---

Generated by docs-audit-daily