### PR TITLE
fix(web): clear stale SDK session mapping on session-not-found resume (#126)

### DIFF
--- a/.changeset/web-session-cwd-126.md
+++ b/.changeset/web-session-cwd-126.md
@@ -1,0 +1,14 @@
+---
+"@herdctl/web": patch
+---
+
+Clear the stale SDK session mapping when a web-chat resume fails because the
+session can no longer be found (issue #126).
+
+When an agent's `working_directory` config changes, Claude Code keys its session
+files by the spawn-time cwd, so a session created under the old cwd becomes
+invisible under the new one and every resume of it fails. `WebChatManager` kept
+the now-dead session attributed, so the web chat would keep trying to resume it.
+On a session-not-found failure, the stored mapping for the resumed session is now
+cleared (best-effort — clearing never masks the original error), complementing the
+core retry shipped in #264.

--- a/packages/web/src/server/__tests__/web-chat-manager.test.ts
+++ b/packages/web/src/server/__tests__/web-chat-manager.test.ts
@@ -1058,6 +1058,101 @@ describe("WebChatManager", () => {
   });
 
   // ===========================================================================
+  // sendMessage Tests - Stale session mapping cleanup (issue #126)
+  // ===========================================================================
+
+  describe("sendMessage - stale session mapping cleanup (#126)", () => {
+    beforeEach(() => {
+      manager.initialize(
+        mockFleetManager,
+        "/state/dir",
+        createMockWebConfig(),
+        mockDiscoveryService,
+      );
+    });
+
+    it("clears the stale SDK session mapping when a resume fails with session-not-found", async () => {
+      // Simulates an agent whose working_directory changed: the session created
+      // under the old cwd is no longer findable, so the resume fails. The core
+      // retry recovers the turn, but the stored attribution must be cleared so
+      // the web chat stops resuming the dead session.
+      mockFleetManager.trigger.mockResolvedValue({
+        jobId: "job-789",
+        success: false,
+        error: { message: "No conversation found with session ID: old-session-id" },
+      });
+
+      const onChunk = vi.fn();
+      const result = await manager.sendMessage("test-agent", "old-session-id", "Continue", onChunk);
+
+      expect(result.success).toBe(false);
+      expect(mockStore.sessionManager.clearSession).toHaveBeenCalledWith("old-session-id");
+    });
+
+    it("matches 'session not found' phrasing case-insensitively", async () => {
+      mockFleetManager.trigger.mockResolvedValue({
+        jobId: "job-789",
+        success: false,
+        error: { message: "SDKStreamingError: Session Not Found" },
+      });
+
+      const onChunk = vi.fn();
+      await manager.sendMessage("test-agent", "dead-session", "Continue", onChunk);
+
+      expect(mockStore.sessionManager.clearSession).toHaveBeenCalledWith("dead-session");
+    });
+
+    it("does not clear the mapping for unrelated failures", async () => {
+      mockFleetManager.trigger.mockResolvedValue({
+        jobId: "job-789",
+        success: false,
+        error: { message: "Agent busy" },
+      });
+
+      const onChunk = vi.fn();
+      await manager.sendMessage("test-agent", "live-session", "Continue", onChunk);
+
+      expect(mockStore.sessionManager.clearSession).not.toHaveBeenCalled();
+    });
+
+    it("does not clear the mapping for new chats (no resume session id)", async () => {
+      mockFleetManager.trigger.mockResolvedValue({
+        jobId: "job-789",
+        success: false,
+        error: { message: "No conversation found with session ID: whatever" },
+      });
+
+      const onChunk = vi.fn();
+      await manager.sendMessage("test-agent", null, "Hello", onChunk);
+
+      expect(mockStore.sessionManager.clearSession).not.toHaveBeenCalled();
+    });
+
+    it("does not clear the mapping on a successful resume", async () => {
+      // Default trigger mock returns success: true
+      const onChunk = vi.fn();
+      await manager.sendMessage("test-agent", "live-session", "Continue", onChunk);
+
+      expect(mockStore.sessionManager.clearSession).not.toHaveBeenCalled();
+    });
+
+    it("still returns the original error if clearing the mapping throws", async () => {
+      mockFleetManager.trigger.mockResolvedValue({
+        jobId: "job-789",
+        success: false,
+        error: { message: "session expired" },
+      });
+      mockStore.sessionManager.clearSession.mockRejectedValue(new Error("disk full"));
+
+      const onChunk = vi.fn();
+      const result = await manager.sendMessage("test-agent", "dead-session", "Continue", onChunk);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("session expired");
+    });
+  });
+
+  // ===========================================================================
   // Working Directory Resolution Tests
   // ===========================================================================
 

--- a/packages/web/src/server/chat/web-chat-manager.ts
+++ b/packages/web/src/server/chat/web-chat-manager.ts
@@ -381,8 +381,9 @@ export class WebChatManager {
         },
       });
 
-      // Store attribution for this session
       const sessionManager = this.sessionManagers.get(agentName);
+
+      // Store attribution for this session
       if (sessionManager && result.sessionId && result.success) {
         // channelId = sessionId = SDK session ID (they're the same now)
         await sessionManager.setSession(result.sessionId, result.sessionId);
@@ -398,6 +399,34 @@ export class WebChatManager {
         const workDir = this.getWorkingDirectory(agent);
         const dockerEnabled = agent.docker?.enabled ?? false;
         this.discoveryService!.invalidateAttributionCache(workDir, { dockerEnabled });
+      }
+
+      // Clear stale SDK session mapping when a resume fails because the session
+      // can no longer be found (issue #126). This happens when an agent's
+      // working_directory config changes: Claude Code keys session files by the
+      // spawn-time cwd, so a session created under the old cwd is invisible under
+      // the new one. The stored attribution still points at that dead session,
+      // so without clearing it the web chat keeps the session attributed/resumable
+      // and every resume keeps failing. The core retry (#264) recovers the current
+      // turn with a fresh session; clearing here stops the dead pointer lingering.
+      if (sessionManager && sessionId && !result.success) {
+        if (WebChatManager.isSessionNotFoundError(result.error?.message)) {
+          try {
+            await sessionManager.clearSession(sessionId);
+            logger.info(`Cleared stale SDK session mapping after session-not-found`, {
+              agentName,
+              sessionId,
+            });
+          } catch (clearError) {
+            // Clearing is best-effort recovery — never let it mask the original
+            // failure that we're about to return to the caller.
+            logger.warn(`Failed to clear stale SDK session mapping`, {
+              agentName,
+              sessionId,
+              error: clearError instanceof Error ? clearError.message : String(clearError),
+            });
+          }
+        }
       }
 
       return {
@@ -618,6 +647,24 @@ export class WebChatManager {
   // ===========================================================================
   // Private Helpers
   // ===========================================================================
+
+  /**
+   * Detect whether an error message indicates the resumed session could not be
+   * found by Claude Code (e.g. after a working_directory change relocated the
+   * session storage directory — issue #126). Matches the same phrasings the
+   * core JobExecutor treats as session-expired/not-found.
+   */
+  private static isSessionNotFoundError(message: string | undefined): boolean {
+    if (!message) {
+      return false;
+    }
+    const normalized = message.toLowerCase();
+    return (
+      normalized.includes("session not found") ||
+      normalized.includes("no conversation") ||
+      normalized.includes("session expired")
+    );
+  }
 
   /**
    * Ensure the manager is initialized


### PR DESCRIPTION
Fixes the **@herdctl/web** half of **#126**. The core half shipped in #264 (5.13.1).

## Root cause
Claude Code keys its session files by the child process's spawn-time `cwd` (`~/.claude/projects/<encoded-cwd>/`). When an agent's `working_directory` config changes, herdctl passes a different `cwd` to the SDK, so a session created under the *old* cwd becomes invisible under the *new* one and every resume of it fails with a session-not-found error.

In the web layer, `WebChatManager.sendMessage()` only ever *wrote* attribution (`ChatSessionManager.setSession`) on success and never cleared it on failure. So after a `working_directory` change the per-agent attribution map (`.herdctl/web-sessions/<agent>.yaml`) kept pointing at the now-dead session — keeping it attributed/resumable in the UI, so each resume kept hitting the same dead session.

## Fix
`packages/web/src/server/chat/web-chat-manager.ts` — in `sendMessage()`, when a resume (`sessionId != null`) returns `success: false` with an error indicating the session can't be found (`session not found` / `no conversation` / `session expired`, matched case-insensitively via a new `isSessionNotFoundError` helper), clear the stored mapping for that session via `ChatSessionManager.clearSession(sessionId)`.

Conservative by design:
- Only fires on resume failures (never new chats, never successes).
- Only fires on session-not-found-shaped errors (unrelated failures untouched).
- Clearing is best-effort wrapped in try/catch — it can never mask the original error returned to the caller.

This complements the core yielded-error retry in #264: core recovers the *current* turn with a fresh session; this stops the dead pointer from lingering across turns.

## Tests
`packages/web/src/server/__tests__/web-chat-manager.test.ts` — 6 new regression tests (fail-before / pass-after):
- clears mapping on `No conversation found...` resume failure
- case-insensitive matching (`Session Not Found`)
- does **not** clear on unrelated failure (`Agent busy`)
- does **not** clear for new chats (no resume session id)
- does **not** clear on successful resume
- returns the original error even if `clearSession` throws

Verified fail-before by reverting the fix (the two positive-assertion tests fail).

## Checks
- `pnpm typecheck` (web) — clean
- `pnpm vitest run` (web) — 163 passed
- `pnpm lint` (web) — exit 0; changed files clean (the 2 pre-existing a11y warnings are in unrelated client `SessionRow.tsx`)
- Changeset: `@herdctl/web` patch

**Do not merge or publish** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved web chat session resumption by automatically clearing stale session mappings when the target session cannot be found. This best-effort cleanup prevents orphaned session data while preserving the original error message for visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->