### PR TITLE
docs: update What's New page (2026-06-27)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,8 +1,8 @@
 ---
-last_checked_commit: 6053872
-last_run: "2026-03-13T00:00:00Z"
-entries_added: 3
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13"]
+last_checked_commit: 9c7ac85
+last_run: "2026-06-27T00:00:00Z"
+entries_added: 5
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "changelog/auto-update-2026-06-27"]
 status: completed
 ---
 
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 6053872 | chore(engineer): daily housekeeping |
-| Last run | 2026-03-13T00:00:00Z | Latest update completed successfully |
-| Entries added (last run) | 3 | Discord file attachments, CLI MCP servers, Slack message dedup |
-| Branches created | changelog/auto-update-2026-03-13 | Current update branch |
+| Last checked commit | 9c7ac85 | ci: run the @herdctl/web Playwright integration suite in CI |
+| Last run | 2026-06-27T00:00:00Z | Latest update completed successfully |
+| Entries added (last run) | 5 | Programmatic APIs, session fixes, thinking support, Windows compat |
+| Branches created | changelog/auto-update-2026-06-27 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-06-27 | 19 | 5 | Ready for PR | changelog/auto-update-2026-06-27 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |
 | 2026-03-01 | 12 | 3 | Ready for PR | changelog/auto-update-2026-03-01 |

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2000
+token_estimate: 2100
 last_archived: null
 ---
 
@@ -9,6 +9,11 @@ Rolling summary of recent conversations across all chat sessions.
 Older entries are archived to `conversations-archive.md` when this file approaches ~20,000 tokens.
 
 ---
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-06-23 | **Type:** chat
+Performed daily housekeeping tasks: confirmed on main branch, reset to origin/main to resolve divergence (local had 114 commits ahead, remote had 3 commits ahead), checked conversations.md token count (~1900 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent job from 2026-02-26, nearly 4 months old), confirmed state.md has no stale entries, updated state.md with current date (2026-06-23). All state files remain clean and current.
+**Outcome:** State files verified and updated
 
 ### Daily housekeeping - state file maintenance
 **Date:** 2026-02-23 | **Type:** chat

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2300
+token_estimate: 2500
 last_archived: null
 ---
 
@@ -7,6 +7,13 @@ last_archived: null
 
 Rolling summary of recent conversations across all chat sessions.
 Older entries are archived to `conversations-archive.md` when this file approaches ~20,000 tokens.
+
+---
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-06-25 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-06-25) to main branch, stashed uncommitted changes, checked conversations.md token count (~2500 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (most recent jobs from Feb 26, 2026 - 4 months old), confirmed state.md has no stale entries, updated state.md with current date (2026-06-25). All state files remain clean and current.
+**Outcome:** State files verified and updated
 
 ---
 

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2100
+token_estimate: 2300
 last_archived: null
 ---
 
@@ -7,6 +7,13 @@ last_archived: null
 
 Rolling summary of recent conversations across all chat sessions.
 Older entries are archived to `conversations-archive.md` when this file approaches ~20,000 tokens.
+
+---
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-06-24 | **Type:** chat
+Performed daily housekeeping tasks: confirmed on main branch (already up-to-date), checked conversations.md token count (~2100 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory has no recent jobs), confirmed state.md has no stale entries, updated state.md with current date (2026-06-24). All state files remain clean and current.
+**Outcome:** State files verified and updated
 
 ---
 

--- a/agents/engineer/conversations.md
+++ b/agents/engineer/conversations.md
@@ -1,5 +1,5 @@
 ---
-token_estimate: 2500
+token_estimate: 2700
 last_archived: null
 ---
 
@@ -7,6 +7,13 @@ last_archived: null
 
 Rolling summary of recent conversations across all chat sessions.
 Older entries are archived to `conversations-archive.md` when this file approaches ~20,000 tokens.
+
+---
+
+### Daily housekeeping - state file maintenance
+**Date:** 2026-06-26 | **Type:** chat
+Performed daily housekeeping tasks: switched from feature branch (changelog/auto-update-2026-06-26) to main branch, checked conversations.md token count (~2500 tokens, well below 20k threshold - no archiving needed), verified no engineer-agent jobs in last 24h (.herdctl/jobs/ directory has no recent jobs), confirmed state.md has no stale entries, updated state.md with current date (2026-06-26). All state files remain clean and current.
+**Outcome:** State files verified and updated
 
 ---
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-06-23"
+last_active: "2026-06-24"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-06-23
+**Last Updated:** 2026-06-24
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-06-24"
+last_active: "2026-06-25"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-06-24
+**Last Updated:** 2026-06-25
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-06-25"
+last_active: "2026-06-26"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-06-25
+**Last Updated:** 2026-06-26
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/agents/engineer/state.md
+++ b/agents/engineer/state.md
@@ -1,12 +1,12 @@
 ---
 status: idle
 current_work: null
-last_active: "2026-03-12"
+last_active: "2026-06-23"
 ---
 
 # Engineer Agent State
 
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-06-23
 
 Central state file for the engineer agent, shared across all chat sessions.
 

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,41 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Programmatic Fleet Management and Session APIs
+**June 27, 2026** · `@herdctl/core@5.11.0` · `@herdctl/chat@0.4.0`
+
+Major new programmatic capabilities for building custom fleet management tools and integrations. Register and unregister agents at runtime with `addAgent()` and `removeAgent()` without writing YAML files, enabling dynamic fleet composition. New session management APIs include `getAgentSessions()` for listing conversations, `deleteSession()` for cleanup, and `setSessionName()` for custom naming. Override an agent's working directory per trigger call, enabling a single "sweeper" agent to work across multiple projects. The reusable `SDKMessageTranslator` simplifies building custom chat UIs on top of herdctl. Also fixed CLI session discovery to match Claude Code's path encoding behavior, correcting discovery for directories with dots or special characters. [#256](https://github.com/edspencer/herdctl/pull/256)
+
+---
+
+### Session Discovery Performance Improvements
+**June 27, 2026** · `@herdctl/core@5.12.0` · `@herdctl/core@5.13.0`
+
+Session discovery now automatically detects new sessions immediately via directory mtime (modification time) tracking, eliminating the previous 30-second cache delay. When agents create new sessions, they appear in the web dashboard and API responses instantly. Added `invalidateSessions()` method for manual cache invalidation when needed. Also exposed `getAgentSessionUsage()` to retrieve context window usage and turn count for any session, enabling UIs to display "context used" metrics for historical chats. [#260](https://github.com/edspencer/herdctl/pull/260), [#261](https://github.com/edspencer/herdctl/pull/261)
+
+---
+
+### Critical Session and Path Handling Fixes
+**June 27, 2026** · `@herdctl/core@5.13.1` · `@herdctl/web@0.9.14` · `@herdctl/web@0.9.16`
+
+Fixed multiple critical session handling issues. Session discovery now correctly handles agents with working directories that encode to the same path (e.g., `/a/b-c`, `/a-b/c`, `/a/b/c` all mapping to `-a-b-c`), reading each transcript's authoritative `cwd` field to prevent session misattribution. Cross-agent session resumption now works properly — agents can resume sessions created by other agents in the same fleet, with automatic retry when a session can't be found after a working directory change. The web dashboard now clears stale session mappings when a resume fails with "session not found", preventing infinite retry loops after an agent's working directory changes. [#264](https://github.com/edspencer/herdctl/pull/264), [#265](https://github.com/edspencer/herdctl/pull/265), [#272](https://github.com/edspencer/herdctl/pull/272)
+
+---
+
+### Extended Thinking Support and Tool Display Improvements
+**June 27, 2026** · `@herdctl/core@5.13.0` · `@herdctl/chat@0.4.1`
+
+Fixed a critical bug where assistant responses using extended thinking would disappear when reloading chat history. Final answers in thinking-enabled conversations are now correctly preserved and displayed across all chat interfaces. Tool calls in CLI runtime now display properly with the correct tool name, input summary, duration, and error status instead of showing as generic "Tool" entries. [#261](https://github.com/edspencer/herdctl/pull/261), [#258](https://github.com/edspencer/herdctl/pull/258)
+
+---
+
+### Windows Compatibility and Web UI Fixes
+**June 27, 2026** · `@herdctl/core@5.10.1` · `@herdctl/web@0.9.15`
+
+Fixed path traversal security check failing on Windows due to hardcoded Unix path separators. State file operations now work correctly on Windows systems using platform-appropriate path separators. The web dashboard agent detail page now displays a proper "Agent Not Found" card with a "Back to Dashboard" link instead of a misleading "Retry" button when viewing a non-existent agent. [#210](https://github.com/edspencer/herdctl/pull/210), [#269](https://github.com/edspencer/herdctl/pull/269)
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 


### PR DESCRIPTION
## Summary

Automated changelog update analyzing 19 commits since the last update (6053872..9c7ac85).

### New Entries Added

1. **Programmatic Fleet Management and Session APIs** (`@herdctl/core@5.11.0`, `@herdctl/chat@0.4.0`)
   - Runtime agent registration/unregistration without YAML files
   - Session management APIs (list, delete, rename)
   - Per-trigger working directory overrides
   - SDK message translator for custom UIs
   - CLI session discovery fixes

2. **Session Discovery Performance Improvements** (`@herdctl/core@5.12.0-5.13.0`)
   - Instant session detection via mtime tracking (no 30s cache delay)
   - Manual cache invalidation API
   - Session usage metrics API

3. **Critical Session and Path Handling Fixes** (`@herdctl/core@5.13.1`, `@herdctl/web@0.9.14-0.9.16`)
   - Path collision disambiguation for encoded directories
   - Cross-agent session resume support
   - Automatic retry on session-not-found
   - Stale session mapping cleanup in web

4. **Extended Thinking Support and Tool Display Improvements** (`@herdctl/core@5.13.0`, `@herdctl/chat@0.4.1`)
   - Fixed disappearing assistant answers in thinking mode
   - Proper tool name/duration display in CLI runtime

5. **Windows Compatibility and Web UI Fixes** (`@herdctl/core@5.10.1`, `@herdctl/web@0.9.15`)
   - Platform-aware path separators for Windows
   - Better agent-not-found error state in web

### State Updates

- Updated `last_checked_commit` to `9c7ac85`
- Updated `last_run` to `2026-06-27T00:00:00Z`
- Added run to history table

## Test Plan

- [x] Changelog entries are user-facing and clear
- [x] PR links are correct
- [x] Package versions match CHANGELOG.md files
- [x] state.md reflects latest commit position
- [x] All entries follow existing format and style

🤖 Generated by the changelog-updater agent