### PR TITLE
docs: auto-update documentation (2026-06-30)

### DIFF
--- a/agents/docs/state.md
+++ b/agents/docs/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 1114870f5bcf4d2b7ce74e0df7e1f7d5e3f3b6b9
-last_run: "2026-03-13T07:08:30Z"
-docs_gaps_found: 5
-branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13"]
+last_checked_commit: 9c7ac85
+last_run: "2026-06-30T03:08:55Z"
+docs_gaps_found: 3
+branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13", "docs/auto-update-2026-06-30"]
 status: completed
 ---
 
 # Documentation Audit State
 
-**Last Updated:** 2026-03-13
+**Last Updated:** 2026-06-30
 
 This document tracks the state of the documentation audit agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 1114870 | docs: auto-update documentation (2026-03-07) |
-| Last run | 2026-03-13T07:08:30Z | Manual invocation |
-| Gaps found (last run) | 5 | Discord improvements features |
-| Branches created | docs/auto-update-2026-03-13 | Added Discord voice, attachments, output, guild, skills docs |
+| Last checked commit | 9c7ac85 | ci: run the @herdctl/web Playwright integration suite in CI |
+| Last run | 2026-06-30T03:08:55Z | Manual invocation |
+| Gaps found (last run) | 3 | Programmatic agent management API, SDK message translator, session cache improvements |
+| Branches created | docs/auto-update-2026-06-30 | Added FleetManager API docs, @herdctl/chat translator, session methods |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Gaps Found | Action | Branch |
 |------|-----------------|------------|--------|--------|
+| 2026-06-30 | 20 | 3 | created-branch | docs/auto-update-2026-06-30 |
 | 2026-03-13 | 3 | 5 | created-branch | docs/auto-update-2026-03-13 |
 | 2026-03-07 | 4 | 1 | created-branch | docs/auto-update-2026-03-07 |
 | 2026-03-05 | 10 | 1 | created-branch | docs/auto-update-2026-03-05 |

--- a/docs/src/content/docs/architecture/chat-infrastructure.md
+++ b/docs/src/content/docs/architecture/chat-infrastructure.md
@@ -36,6 +36,7 @@ The `@herdctl/chat` package provides the following components, each extracted fr
 |-----------|------|---------|
 | **Shared types** | `types.ts` | `IChatConnector`, `IChatSessionManager`, `ChatConnectorState`, `ChatConnectionStatus`, `ChatMessageEvent`, `ChatConnectorEventMap`, `ChatConnectorLogger` |
 | **Session manager** | `session-manager/` | `ChatSessionManager` class, session types, Zod schemas, session error hierarchy |
+| **SDK message translator** | `sdk-message-translator.ts` | `SDKMessageTranslator` class and `createSDKMessageHandler()` factory for translating SDK message streams into chat-UI events |
 | **Streaming responder** | `streaming-responder.ts` | `StreamingResponder` class for buffered, rate-limited message delivery |
 | **Message splitting** | `message-splitting.ts` | `splitMessage()`, `findSplitPoint()`, `needsSplit()`, `truncateMessage()` |
 | **Message extraction** | `message-extraction.ts` | `extractMessageContent()` for parsing Claude SDK assistant messages |
@@ -147,6 +148,55 @@ When a user sends a message in Discord or Slack, it flows through the same pipel
 9. **Platform formatting** -- The reply is formatted for the target platform. Discord uses embeds and standard markdown; Slack converts to mrkdwn and posts in threads.
 
 10. **Delivery** -- The formatted message is sent back to the user in the same channel or thread.
+
+## SDK Message Translation
+
+The `SDKMessageTranslator` provides transport-agnostic translation from Claude SDK message streams to chat-UI events. Every chat surface built on herdctl (Discord, Slack, the web dashboard, and downstream apps) consumes the same stream of `SDKMessage`s from `FleetManager.trigger({ onMessage })` and needs to turn it into the same handful of UI events:
+
+- **Assistant text deltas** — incremental text as it streams in
+- **Turn boundaries** — when a new assistant turn begins after a previous one
+- **Paired tool calls** — a `tool_use` block matched to its later `tool_result`, enriched with an input summary and wall-clock duration
+
+Before the translator was extracted, this translation logic was reimplemented independently in each connector. Now transports only supply the destination handlers; the translator manages the stateful pairing and boundary detection.
+
+### How It Works
+
+```typescript
+import { createSDKMessageHandler } from '@herdctl/chat';
+
+// Create a message handler
+const onMessage = createSDKMessageHandler({
+  onText: (text) => stream(text),
+  onToolCall: (call) => renderTool(call),
+  onBoundary: () => startNewBubble(),
+});
+
+// Use it with trigger
+await fleet.trigger('agent', undefined, {
+  prompt,
+  onMessage,
+});
+```
+
+The translator tracks pending `tool_use` blocks so they can be paired with their `tool_result` when it arrives later in the stream. It also detects when a new assistant turn begins after a previous one produced text, so transports can split message bubbles appropriately.
+
+For reusable instances (e.g., a long-lived WebSocket connection), create the translator directly and call `handle()` per message:
+
+```typescript
+const translator = new SDKMessageTranslator({
+  onText: (t) => ws.send({ type: 'chat:response', text: t }),
+  onToolCall: (c) => ws.send({ type: 'chat:tool_call', ...c }),
+});
+
+// Per trigger
+await fleet.trigger('agent', undefined, {
+  prompt,
+  onMessage: (m) => translator.handle(m),
+});
+
+// Reset between triggers if reusing
+translator.reset();
+```
 
 ## Session Management
 

--- a/docs/src/content/docs/library-reference/fleet-manager.mdx
+++ b/docs/src/content/docs/library-reference/fleet-manager.mdx
@@ -534,6 +534,435 @@ await manager.enableSchedule('my-agent', 'hourly');
 
 ---
 
+## Programmatic Agent Management
+
+### `addAgent(agent, options?)`
+
+Registers an agent at runtime without writing YAML or reloading configuration.
+
+```typescript
+await manager.addAgent(
+  agent: AgentConfig | (Record<string, unknown> & { name: string }),
+  options?: AddAgentOptions
+): Promise<AgentInfo>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent` | `AgentConfig` | **Yes** | Agent configuration object |
+| `options.baseDir` | `string` | No | Base directory for resolving relative `working_directory` paths (defaults to config directory or cwd) |
+| `options.mergeDefaults` | `boolean` | No | Whether to merge fleet defaults into the agent (default: `true`) |
+| `options.replace` | `boolean` | No | Replace existing agent with same name instead of throwing (default: `false`) |
+
+#### Returns
+
+```typescript
+interface AgentInfo {
+  name: string;
+  qualifiedName: string;
+  status: 'idle' | 'running' | 'error';
+  // ... (see getAgentInfo for full type)
+}
+```
+
+#### Description
+
+This method provides programmatic agent registration without the write-yaml-then-reload round trip. The agent configuration is validated against the agent schema, merged with fleet defaults (unless disabled), and integrated into the in-memory config. The resolved agent is immediately triggerable and visible in fleet status. A `config:reloaded` event is emitted describing the change.
+
+Programmatic agents are always registered at the root fleet level (`fleetPath: []`), so their qualified name equals their local name.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `ConfigurationError` | Validation fails or qualified name collides with existing agent (and `replace` is not set) |
+
+#### Example
+
+```typescript
+// Register a new agent
+const agent = await manager.addAgent({
+  name: 'my-agent',
+  prompt: 'You are a helpful assistant',
+  model: 'claude-opus-4-5',
+  working_directory: '/path/to/project',
+  schedules: [
+    {
+      name: 'hourly',
+      interval: '1h',
+      prompt: 'Check for updates',
+    },
+  ],
+});
+
+console.log(`Added agent: ${agent.qualifiedName}`);
+
+// Replace an existing agent
+await manager.addAgent(
+  {
+    name: 'my-agent',
+    prompt: 'Updated prompt',
+  },
+  { replace: true }
+);
+
+// Add agent without merging defaults
+await manager.addAgent(
+  {
+    name: 'standalone-agent',
+    prompt: 'I have my own config',
+  },
+  { mergeDefaults: false }
+);
+```
+
+---
+
+### `removeAgent(name)`
+
+Unregisters an agent at runtime.
+
+```typescript
+await manager.removeAgent(name: string): Promise<boolean>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | Agent qualified name or local name to remove |
+
+#### Returns
+
+Returns `true` if an agent was removed, `false` if no match was found.
+
+#### Description
+
+Removes the agent from the in-memory config and the scheduler. Accepts a qualified name (e.g., `"sub.agent"`) or a local name; qualified names are matched first. Running jobs are unaffected — the scheduler simply stops triggering the removed agent's schedules.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+
+#### Example
+
+```typescript
+// Remove by name
+const removed = await manager.removeAgent('my-agent');
+if (removed) {
+  console.log('Agent removed');
+} else {
+  console.log('Agent not found');
+}
+
+// Remove by qualified name
+await manager.removeAgent('myfleet.my-agent');
+```
+
+---
+
+## Session Management Methods
+
+### `getAgentSessions(name, options?)`
+
+Lists discovered Claude Code sessions for an agent.
+
+```typescript
+await manager.getAgentSessions(
+  name: string,
+  options?: { limit?: number }
+): Promise<DiscoveredSession[]>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | Agent qualified name or local name |
+| `options.limit` | `number` | No | Optional limit for top-N enrichment |
+
+#### Returns
+
+```typescript
+interface DiscoveredSession {
+  sessionId: string;
+  lastModified: string;          // ISO timestamp
+  customName?: string;           // Custom display name if set
+  firstPrompt?: string;          // First user message
+  lastAssistant?: string;        // Last assistant response
+  messageCount?: number;         // Total messages
+  createdByJobId?: string;       // Originating job ID
+  // ... (additional enrichment fields)
+}
+```
+
+#### Description
+
+Derives the agent's working directory and Docker mode from the loaded config. Sessions are returned sorted by modification time (newest first).
+
+**Note**: Sessions are keyed by working directory. This method uses the agent's *configured* `working_directory`. If you triggered the agent with a per-trigger `workingDirectory` override, the resulting sessions live under that override directory and will NOT appear here.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+const sessions = await manager.getAgentSessions('my-agent');
+for (const session of sessions) {
+  console.log(`${session.sessionId}: ${session.customName || session.firstPrompt}`);
+  console.log(`  Last modified: ${session.lastModified}`);
+  console.log(`  Messages: ${session.messageCount}`);
+}
+
+// Get top 10 sessions
+const recent = await manager.getAgentSessions('my-agent', { limit: 10 });
+```
+
+---
+
+### `getAgentSessionMessages(name, sessionId)`
+
+Gets the parsed chat messages for one of an agent's sessions.
+
+```typescript
+await manager.getAgentSessionMessages(
+  name: string,
+  sessionId: string
+): Promise<ChatMessage[]>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | Agent qualified name or local name |
+| `sessionId` | `string` | **Yes** | Session ID to read |
+
+#### Returns
+
+```typescript
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp?: string;
+  // ... (additional fields)
+}
+```
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+const messages = await manager.getAgentSessionMessages(
+  'my-agent',
+  'session-abc123'
+);
+
+for (const msg of messages) {
+  console.log(`[${msg.role}] ${msg.content}`);
+}
+```
+
+---
+
+### `getAgentSessionUsage(name, sessionId)`
+
+Gets token usage data for one of an agent's sessions.
+
+```typescript
+await manager.getAgentSessionUsage(
+  name: string,
+  sessionId: string
+): Promise<SessionUsage>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | Agent qualified name or local name |
+| `sessionId` | `string` | **Yes** | Session ID to read |
+
+#### Returns
+
+```typescript
+interface SessionUsage {
+  inputTokens: number;           // Last turn's input + cache tokens
+  turnCount: number;             // Total turns in session
+  hasData: boolean;              // Whether usage data exists
+}
+```
+
+#### Description
+
+Reads the session transcript and returns the most recent context-window fill level (last assistant turn's input + cache tokens) plus a turn count. This lets a UI show "context used" for a chat loaded from history — before any new turn streams a fresh `usage` value.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+const usage = await manager.getAgentSessionUsage('my-agent', 'session-abc123');
+if (usage.hasData) {
+  console.log(`Context used: ${usage.inputTokens} tokens`);
+  console.log(`Turn count: ${usage.turnCount}`);
+}
+```
+
+---
+
+### `deleteSession(name, sessionId)`
+
+Deletes one of an agent's Claude Code session transcripts from disk.
+
+```typescript
+await manager.deleteSession(
+  name: string,
+  sessionId: string
+): Promise<boolean>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | Agent qualified name or local name |
+| `sessionId` | `string` | **Yes** | Session ID whose transcript should be removed |
+
+#### Returns
+
+Returns `true` if a file was removed, `false` if no transcript existed (or the agent has no working directory).
+
+#### Description
+
+Resolves the agent's working directory and Docker mode from the loaded config, computes the CLI (or Docker) transcript file path, deletes it, and invalidates the session-discovery cache so a subsequent `getAgentSessions()` no longer lists it.
+
+The `sessionId` is validated (only `[A-Za-z0-9-]` is allowed) to prevent path traversal.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+| `Error` | `sessionId` contains invalid characters |
+
+#### Example
+
+```typescript
+const deleted = await manager.deleteSession('my-agent', 'session-abc123');
+if (deleted) {
+  console.log('Session deleted');
+} else {
+  console.log('Session not found');
+}
+```
+
+---
+
+### `setSessionName(name, sessionId, customName)`
+
+Sets (or clears) the custom display name for one of an agent's sessions.
+
+```typescript
+await manager.setSessionName(
+  name: string,
+  sessionId: string,
+  customName: string | null
+): Promise<void>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | Agent qualified name or local name |
+| `sessionId` | `string` | **Yes** | Session ID to (re)name |
+| `customName` | `string \| null` | **Yes** | Custom name to set, or `null`/empty to clear it |
+
+#### Description
+
+Writes through the fleet's shared session metadata store so a subsequent `getAgentSessions()` reflects the new `customName` immediately. Passing `null` or an empty/whitespace string clears any existing custom name.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+// Set custom name
+await manager.setSessionName('my-agent', 'session-abc123', 'Bug Fix Discussion');
+
+// Clear custom name
+await manager.setSessionName('my-agent', 'session-abc123', null);
+```
+
+---
+
+### `invalidateSessions(name)`
+
+Drops the cached session listing for an agent so the next `getAgentSessions()` call rebuilds it from disk.
+
+```typescript
+manager.invalidateSessions(name: string): void
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `string` | **Yes** | Agent qualified name or local name |
+
+#### Description
+
+The underlying session discovery service caches each working directory's listing for up to its TTL (default 30s). That cache is now mtime-aware, so newly created transcript files are normally picked up immediately. Call this when you want to force a fresh listing regardless — e.g., after each chat turn, or on filesystems whose directory mtime has coarse (1-second) granularity.
+
+Resolves the agent's working directory and Docker mode from the loaded config. A no-op when the agent has no working directory.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+
+#### Example
+
+```typescript
+// Force refresh session listing
+manager.invalidateSessions('my-agent');
+
+// Next call will rebuild from disk
+const sessions = await manager.getAgentSessions('my-agent');
+```
+
+---
+
 ## Action Methods
 
 ### `trigger(agentName, scheduleName?, options?)`
@@ -557,6 +986,7 @@ await manager.trigger(
 | `options.prompt` | `string` | No | Override the prompt for this trigger |
 | `options.workItems` | `WorkItem[]` | No | Custom work items instead of fetching from work source |
 | `options.bypassConcurrencyLimit` | `boolean` | No | Force trigger even if agent is at capacity (default: `false`) |
+| `options.workingDirectory` | `string` | No | Override the agent's configured working directory for this trigger only |
 
 #### Returns
 
@@ -598,10 +1028,20 @@ const job = await manager.trigger('my-agent', undefined, {
 const job = await manager.trigger('my-agent', undefined, {
   bypassConcurrencyLimit: true,
 });
+
+// Trigger with custom working directory
+const job = await manager.trigger('my-agent', undefined, {
+  workingDirectory: '/path/to/specific/project',
+  prompt: 'Analyze this project',
+});
 ```
 
 <Aside type="tip">
 Prompt priority: `options.prompt` > schedule prompt > undefined. If you specify a prompt in options, it overrides the schedule's configured prompt.
+</Aside>
+
+<Aside type="note">
+When using `workingDirectory` override, sessions created by this trigger will be stored in that directory, not the agent's configured working directory. Use `getAgentSessions()` with the agent's configured directory to see those sessions, or scan the override directory directly.
 </Aside>
 
 ---

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -27,6 +27,10 @@ npm install @herdctl/chat
 
 `ChatSessionManager` tracks conversation sessions per channel or DM. Sessions are persisted to disk and automatically expire after a configurable timeout (default: 24 hours). When a user sends a message, the session manager either resumes the existing session or creates a new one, preserving conversation context via Claude SDK session resumption.
 
+### SDK Message Translation
+
+`SDKMessageTranslator` provides transport-agnostic translation from Claude SDK message streams to chat-UI events. It extracts assistant text deltas, tracks turn boundaries, and pairs tool calls with their results (enriched with input summaries and durations). This eliminates the need to reimplement message processing logic in each chat connector or downstream application.
+
 ### Streaming Responses
 
 `StreamingResponder` delivers agent responses incrementally as they are generated, rather than waiting for the full response. It buffers content and sends complete chunks at configurable intervals, respecting platform rate limits.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,7 +44,9 @@ await fleet.stop();
 
 - **FleetManager** - Core orchestration class for managing agent fleets
 - **Configuration** - Load and validate herdctl YAML configs programmatically
+- **Programmatic Agent Management** - Add/remove agents at runtime without YAML files
 - **Job Control** - Trigger, cancel, and fork agent jobs
+- **Session Management** - List, read, delete, and rename agent conversation sessions
 - **Scheduling** - Built-in scheduler for cron and interval triggers
 - **Event System** - Subscribe to fleet events (job:created, job:completed, etc.)
 - **State Management** - Persistent state for jobs, sessions, and fleet status


### PR DESCRIPTION
Automated documentation audit found 3 gap(s) across 20 commits.

## Gaps Addressed

### Gap 1: Programmatic Agent Management API (High Priority)
**Commit:** 7956804 "Programmatic agents, per-trigger cwd, session access, SDK translator + CLI path-encoding fix"

Added major new FleetManager API methods for programmatic fleet management:
- `addAgent(agent, options?)` / `removeAgent(name)` - Register/unregister agents at runtime without YAML
- `getAgentSessions(name)` / `getAgentSessionMessages(name, sessionId)` - Convenience session access
- `deleteSession(name, sessionId)` - First-class session deletion
- `setSessionName(name, sessionId, customName)` - Session renaming
- `workingDirectory` option on `TriggerOptions` - Per-trigger working directory override

**Documentation added:**
- New "Programmatic Agent Management" section in FleetManager library reference
- New "Session Management Methods" section documenting all session-related methods
- Updated `trigger()` method parameters to include `workingDirectory`
- Updated @herdctl/core README to highlight programmatic agent management

### Gap 2: SDK Message Translator (@herdctl/chat) (Medium Priority)
**Commit:** 7956804 (same commit)

Added `SDKMessageTranslator` and `createSDKMessageHandler` factory - a reusable helper that translates SDKMessage streams from `trigger({ onMessage })` into chat-UI events.

**Documentation added:**
- Added SDK Message Translation section to @herdctl/chat README
- Added comprehensive SDK Message Translation section to chat infrastructure architecture docs
- Included code examples for both factory and direct usage patterns

### Gap 3: Session Discovery Cache Improvements (Medium Priority)
**Commits:** 
- 49f9d4c "fix(core): mtime-aware session-discovery cache + FleetManager.invalidateSessions"
- 177f224 "fix(core): keep assistant answers split across thinking+text JSONL lines; expose getAgentSessionUsage"

Added:
- `FleetManager.invalidateSessions(name)` - force-clear session discovery cache
- `FleetManager.getAgentSessionUsage(name, sessionId)` - get context-window usage

**Documentation added:**
- Documented both methods in Session Management Methods section of FleetManager reference

---

Generated by docs-audit-daily