### PR TITLE
fix(core): make cancelJob actually interrupt a running job

### DIFF
--- a/.changeset/cancel-job-interrupt.md
+++ b/.changeset/cancel-job-interrupt.md
@@ -1,0 +1,10 @@
+---
+"@herdctl/core": patch
+---
+
+Fix `cancelJob` so it actually interrupts a running job. Previously cancelling only
+rewrote the job's status file to `cancelled` while the agent process kept running to
+completion. `trigger()` now creates an `AbortController` per run and registers it by
+job id; `cancelJob` aborts it, killing the CLI subprocess (or aborting the SDK query).
+Aborted runs are finalized as `cancelled` rather than `failed`, and the SDK runtime now
+honors `abortController` for one-shot execution.

--- a/packages/core/src/fleet-manager/__tests__/job-control.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/job-control.test.ts
@@ -18,7 +18,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { updateSessionInfo } from "../../state/index.js";
+import { getJob, updateSessionInfo } from "../../state/index.js";
 import { InvalidStateError, JobForkError, JobNotFoundError } from "../errors.js";
 import { FleetManager } from "../fleet-manager.js";
 import type { FleetManagerLogger } from "../types.js";
@@ -153,6 +153,56 @@ describe("FleetManager Job Control (US-6)", () => {
       });
 
       expect(result.success).toBe(true);
+    });
+
+    it("interrupts an in-flight job and marks it cancelled", async () => {
+      const manager = await createInitializedManager();
+      const { query } = await import("@anthropic-ai/claude-agent-sdk");
+
+      // Mock the SDK to block mid-turn until the run's AbortController fires.
+      // This proves cancelJob actually aborts the live run (rather than only
+      // rewriting the status file while the agent keeps going).
+      let sawAbort = false;
+      const blockingImpl = ({ options }: { options?: { abortController?: AbortController } }) =>
+        (async function* () {
+          yield { type: "system", subtype: "init", session_id: "cancel-session" };
+          const signal = options?.abortController?.signal;
+          await new Promise<void>((resolve) => {
+            if (!signal || signal.aborted) return resolve();
+            signal.addEventListener("abort", () => {
+              sawAbort = true;
+              resolve();
+            });
+          });
+        })();
+      // Cast: the real query() returns a full Query object; the test only needs
+      // the async-iterable stream, so a bare async generator suffices.
+      vi.mocked(query).mockImplementationOnce(blockingImpl as never);
+
+      let jobId: string | undefined;
+      const triggerPromise = manager.trigger("test-agent", undefined, {
+        onJobCreated: (id) => {
+          jobId = id;
+        },
+      });
+
+      // Wait until the job id is known (job is registered as running).
+      await vi.waitFor(() => {
+        expect(jobId).toBeDefined();
+      });
+
+      const cancelResult = await manager.cancelJob(jobId!);
+      expect(cancelResult.success).toBe(true);
+      expect(cancelResult.terminationType).toBe("graceful");
+
+      const triggerResult = await triggerPromise;
+      expect(triggerResult.success).toBe(false);
+      expect(sawAbort).toBe(true);
+
+      // The persisted job status reflects the cancellation, not a failure.
+      const job = await getJob(join(stateDir, "jobs"), jobId!);
+      expect(job?.status).toBe("cancelled");
+      expect(job?.exit_reason).toBe("cancelled");
     });
   });
 

--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -47,6 +47,15 @@ import type {
  * using the FleetManagerContext pattern.
  */
 export class JobControl {
+  /**
+   * In-memory registry of currently-running jobs to their AbortController, keyed
+   * by job id. A job is registered the moment its id is known (via the executor's
+   * `onJobCreated`) and removed when the run finishes. {@link cancelJob} consults
+   * this to actually interrupt a live run — without it, cancelling only rewrote
+   * the job's status file while the agent process kept running.
+   */
+  private readonly runningControllers = new Map<string, AbortController>();
+
   constructor(
     private ctx: FleetManagerContext,
     private getAgentInfoFn: () => Promise<AgentInfo[]>,
@@ -167,23 +176,61 @@ export class JobControl {
     const runtime = RuntimeFactory.create(effectiveAgent, { stateDir });
     const executor = new JobExecutor(runtime, { logger });
 
+    // Cancellation support: give this run an AbortController and register it under
+    // its job id (known once the executor creates the job record, via
+    // onJobCreated) so cancelJob() can actually interrupt the live process — the
+    // CLI runtime kills its subprocess on this signal, the SDK runtime aborts its
+    // query. Registered on creation, removed in the finally below.
+    const abortController = new AbortController();
+    let registeredJobId: string | undefined;
+
     // Execute the job - this creates the job record and runs it
     // Note: Job output is written to JSONL by JobExecutor; log streaming picks it up
     // If onMessage callback is provided, it will be called for each SDK message
-    const result = await executor.execute({
-      agent: effectiveAgent,
-      prompt,
-      stateDir,
-      triggerType: (options?.triggerType ??
-        "manual") as import("../state/schemas/job-metadata.js").TriggerType,
-      schedule: scheduleName,
-      outputToFile: schedule?.outputToFile ?? false,
-      onMessage: options?.onMessage,
-      onJobCreated: options?.onJobCreated,
-      resume: sessionId,
-      injectedMcpServers: options?.injectedMcpServers,
-      systemPromptAppend: options?.systemPromptAppend,
-    });
+    let result: Awaited<ReturnType<typeof executor.execute>>;
+    try {
+      result = await executor.execute({
+        agent: effectiveAgent,
+        prompt,
+        stateDir,
+        triggerType: (options?.triggerType ??
+          "manual") as import("../state/schemas/job-metadata.js").TriggerType,
+        schedule: scheduleName,
+        outputToFile: schedule?.outputToFile ?? false,
+        onMessage: options?.onMessage,
+        onJobCreated: (id) => {
+          registeredJobId = id;
+          this.runningControllers.set(id, abortController);
+          options?.onJobCreated?.(id);
+        },
+        resume: sessionId,
+        injectedMcpServers: options?.injectedMcpServers,
+        systemPromptAppend: options?.systemPromptAppend,
+        abortController,
+      });
+    } finally {
+      if (registeredJobId) {
+        this.runningControllers.delete(registeredJobId);
+      }
+    }
+
+    // If the run was cancelled mid-flight, cancelJob() has already recorded the
+    // cancellation and emitted job:cancelled — don't also emit a job:completed /
+    // job:failed for the aborted run.
+    if (abortController.signal.aborted) {
+      logger.info(`Job ${result.jobId} was cancelled`);
+      return {
+        jobId: result.jobId,
+        agentName,
+        scheduleName: scheduleName ?? null,
+        startedAt: timestamp,
+        prompt,
+        success: false,
+        sessionId: result.sessionId,
+        error: result.error,
+        errorDetails: result.errorDetails,
+      };
+    }
 
     // Emit job:created event
     const jobsDir = join(stateDir, "jobs");
@@ -367,6 +414,19 @@ export class JobControl {
 
     if (!job) {
       throw new JobNotFoundError(jobId);
+    }
+
+    // Actually interrupt the live run. If this process is executing the job, its
+    // AbortController is registered here — aborting it kills the CLI subprocess /
+    // aborts the SDK query, so the agent genuinely stops (rather than only having
+    // its status file rewritten while it keeps running). Jobs owned by another
+    // process won't be in the registry; those fall back to the status-file update
+    // below (best-effort, unchanged behavior).
+    const controller = this.runningControllers.get(jobId);
+    if (controller) {
+      logger.info(`Aborting in-flight job ${jobId}`);
+      controller.abort();
+      this.runningControllers.delete(jobId);
     }
 
     const timestamp = new Date().toISOString();

--- a/packages/core/src/runner/job-executor.ts
+++ b/packages/core/src/runner/job-executor.ts
@@ -706,15 +706,24 @@ export class JobExecutor {
     }
 
     // Step 5: Update job with final status
-    const success = !lastError;
+    // A run that was aborted mid-flight (cancelJob → AbortController) is recorded
+    // as "cancelled", not "failed": the CLI runtime surfaces the kill as a
+    // terminal error, but that's an intentional cancellation, not a failure.
+    const aborted = options.abortController?.signal.aborted ?? false;
+    const success = !lastError && !aborted;
     const finishedAt = new Date().toISOString();
 
-    // Determine exit reason based on error classification
-    const exitReason = success ? "success" : classifyError(lastError!);
+    // Determine status + exit reason: cancelled > success > failed.
+    const status: "completed" | "failed" | "cancelled" = aborted
+      ? "cancelled"
+      : success
+        ? "completed"
+        : "failed";
+    const exitReason = aborted ? "cancelled" : success ? "success" : classifyError(lastError!);
 
     try {
       await updateJob(jobsDir, job.id, {
-        status: success ? "completed" : "failed",
+        status,
         finished_at: finishedAt,
         session_id: sessionId,
         summary,

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -129,12 +129,16 @@ export class SDKRuntime implements RuntimeInterface {
   async *execute(options: RuntimeExecuteOptions): AsyncIterable<SDKMessage> {
     const sdkOptions = this.buildSdkOptions(options);
 
-    // Execute via SDK query()
-    // Note: SDK does not currently support AbortController for cancellation
-    // This is tracked for future enhancement when SDK adds support
+    // Execute via SDK query(). Thread through the AbortController so the run is
+    // cancellable: the SDK `query()` options accept an `abortController` and stop
+    // the query when it aborts. This is what makes cancelJob able to interrupt an
+    // in-flight SDK turn (the CLI runtime aborts its subprocess separately).
     const messages = query({
       prompt: options.prompt,
-      options: sdkOptions as Record<string, unknown>,
+      options: {
+        ...(sdkOptions as Record<string, unknown>),
+        abortController: options.abortController,
+      },
     });
 
     // Stream messages from SDK


### PR DESCRIPTION
## Problem

`FleetManager.cancelJob(jobId)` didn't actually stop a running job — it only rewrote the job's status file to `cancelled` and emitted `job:cancelled`, while the underlying agent (CLI subprocess or SDK query) kept running to completion. Any downstream Stop/Cancel button built on `cancelJob` was therefore a no-op: the turn kept streaming and burning tokens, and `trigger()` didn't resolve any sooner.

Fixes #288.

## Root cause

The cancellation plumbing already existed but was never wired on the one-shot `trigger()` path:

- `RuntimeExecuteOptions.abortController` exists and `JobExecutor.execute()` already forwards it to `runtime.execute()`.
- `CLIRuntime` already kills its subprocess on `abortController` abort.
- **But** `trigger()` never created/passed an `AbortController`, and there was no registry mapping a running `jobId` → its controller — so `cancelJob()` had no handle on the live run.
- `SDKRuntime.execute()` also ignored `abortController` (stale "not supported" comment), though the SDK `query()` options accept one.

## Change

- **`JobControl`**: added an in-memory `Map<jobId, AbortController>`. `trigger()` creates a controller, registers it when the job id is known (`onJobCreated`), passes it to the executor, and removes it in a `finally`. `cancelJob()` aborts the registered controller (actually killing the CLI subprocess / aborting the SDK query) before the existing status-file update; jobs owned by another process fall back to the prior file-only behavior.
- **`JobExecutor`**: an aborted run is finalized as `status: cancelled` / `exit_reason: cancelled` instead of `failed`.
- **`SDKRuntime.execute()`**: threads `abortController` into `query()` so the SDK one-shot path is cancellable too.
- **`trigger()`**: skips the `job:completed`/`job:failed` emit for an aborted run (cancel already emitted `job:cancelled`).

## Tests

Added a `job-control` test that blocks a run mid-turn, calls `cancelJob`, and asserts the run is interrupted (abort observed) and persisted as `cancelled`. Full `@herdctl/core` suite passes locally (the one unrelated `directory.test.ts` failure is an environment artifact — it asserts a non-writable dir rejects, which a root test runner bypasses; it fails identically on `main`).

## Semver

Patch — bug fix, no API changes. Changeset included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canceling a running job now stops it immediately instead of letting it continue in the background.
  * Aborted jobs are now recorded as **cancelled** rather than **failed**.
  * Cancellation handling now works more reliably for live CLI and SDK runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->