### PR TITLE
feat(core): session forking via trigger({ fork })

### DIFF
--- a/.changeset/session-fork.md
+++ b/.changeset/session-fork.md
@@ -1,0 +1,16 @@
+---
+"@herdctl/core": minor
+---
+
+Add session forking to `trigger()`. Passing `fork: <sourceSessionId>` in `TriggerOptions`
+runs a turn that resumes the source session's transcript as context but writes all new
+turns to a brand-new session id (via Claude Code's `--fork-session`), leaving the source
+untouched — letting a caller branch an existing conversation into independent children.
+
+The runner already understood `RunnerOptions.fork`, but nothing on the public API passed
+it, and the CLI runtime mis-handled it: it appended `--fork-session` yet still watched the
+*resumed source* file, so it reported the parent's session id and missed the child's turns.
+Now `trigger()`/`JobExecutor` thread `fork` (and optional `forkedFrom` lineage) through,
+seed the resume target from the fork source (skipping agent-level session fallback), and the
+CLI runtime waits for the newly-created fork file and reports its id — matching the SDK
+runtime. Forks retry as a plain fresh session if the source is gone.

--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -147,8 +147,10 @@ export class JobControl {
     // This prevents unexpected logouts by automatically resuming the agent's session
     // Note: resume=null means "explicitly start fresh" (e.g. new Slack thread),
     // while resume=undefined means "use fallback session lookup"
+    // A fork names its own source session (options.fork) and must NOT inherit
+    // the agent's last session as a resume target — skip the fallback lookup.
     let sessionId = options?.resume ?? undefined;
-    if (sessionId === undefined && options?.resume !== null) {
+    if (sessionId === undefined && options?.resume !== null && !options?.fork) {
       try {
         const sessionsDir = join(stateDir, "sessions");
         // Use session timeout config for expiry validation (default: 24h)
@@ -204,6 +206,8 @@ export class JobControl {
           options?.onJobCreated?.(id);
         },
         resume: sessionId,
+        fork: options?.fork,
+        forkedFrom: options?.forkedFrom,
         injectedMcpServers: options?.injectedMcpServers,
         systemPromptAppend: options?.systemPromptAppend,
         abortController,

--- a/packages/core/src/fleet-manager/types.ts
+++ b/packages/core/src/fleet-manager/types.ts
@@ -541,6 +541,30 @@ export interface TriggerOptions {
   resume?: string | null;
 
   /**
+   * Session ID to FORK for this trigger.
+   *
+   * When provided, the agent resumes `fork`'s transcript as context but writes
+   * all new turns to a **brand-new session id** (via Claude Code's
+   * `--fork-session`), leaving the source session untouched. This lets a caller
+   * branch an existing conversation into an independent child — e.g. exploring
+   * several directions from a shared context without exhausting one window.
+   *
+   * The new session id is reported the same way a fresh session's is (on the
+   * `system`/`init` message and the final result). Mutually exclusive with
+   * {@link resume}; when both are set, `fork` takes precedence and the
+   * agent-level session fallback is skipped.
+   */
+  fork?: string;
+
+  /**
+   * Parent job ID recorded as this run's `forked_from` lineage (optional).
+   *
+   * Only meaningful alongside {@link fork}; purely informational metadata on the
+   * new job record. Omit when the caller forks by session without a job handle.
+   */
+  forkedFrom?: string;
+
+  /**
    * Work items to process during this trigger
    *
    * These work items will be passed to the agent instead of fetching

--- a/packages/core/src/runner/__tests__/job-executor.test.ts
+++ b/packages/core/src/runner/__tests__/job-executor.test.ts
@@ -712,6 +712,33 @@ describe("JobExecutor", () => {
       expect(receivedOptions?.fork).toBe(true);
     });
 
+    it("resumes the fork source AND sets fork so the runtime forks from it", async () => {
+      let receivedOptions: Record<string, unknown> | undefined;
+
+      const runtime = createMockRuntime(async function* (options) {
+        receivedOptions = options;
+        yield { type: "assistant", content: "Forked" };
+      });
+
+      const executor = new JobExecutor(runtime, {
+        logger: createMockLogger(),
+      });
+
+      await executor.execute({
+        agent: createTestAgent(),
+        prompt: "branch off",
+        stateDir,
+        fork: "session-to-fork",
+      });
+
+      // The runtime must resume the SOURCE session (so the CLI/SDK has a
+      // transcript to fork from) while fork:true tells it to write new turns to
+      // a brand-new session id. Seeding resume from the fork source is what makes
+      // `--resume <src> --fork-session` (CLI) / resume+forkSession (SDK) work.
+      expect(receivedOptions?.resume).toBe("session-to-fork");
+      expect(receivedOptions?.fork).toBe(true);
+    });
+
     it("creates job with trigger_type 'fork' and forked_from when forking", async () => {
       const messages: SDKMessage[] = [
         { type: "system", content: "Init", subtype: "init", session_id: "forked-session-123" },

--- a/packages/core/src/runner/job-executor.ts
+++ b/packages/core/src/runner/job-executor.ts
@@ -385,6 +385,15 @@ export class JobExecutor {
       }
     }
 
+    // Forking: resume the explicit source session but tell the runtime to fork
+    // (write new turns to a brand-new session id). We deliberately bypass the
+    // agent-level session adoption/validation above — the caller named a
+    // specific source to fork, not the agent's own stored session — and let the
+    // runtime find the source transcript by id under the agent's cwd.
+    if (options.fork) {
+      effectiveResume = options.fork;
+    }
+
     // Step 4: Execute agent and stream output
     // Track whether we've already retried after a session expiration or token expiry
     let retriedAfterSessionExpiry = false;
@@ -400,7 +409,11 @@ export class JobExecutor {
             prompt,
             agent: options.agent,
             resume: resumeSessionId,
-            fork: options.fork ? true : undefined,
+            // Only fork when we actually have a source session to fork from. On a
+            // retry that cleared the resume target (e.g. the source expired), fall
+            // back to a plain fresh session rather than `--fork-session` with no
+            // `--resume`, which the CLI can't satisfy.
+            fork: options.fork && resumeSessionId ? true : undefined,
             abortController: options.abortController,
             injectedMcpServers: options.injectedMcpServers,
             systemPromptAppend: options.systemPromptAppend,

--- a/packages/core/src/runner/runtime/__tests__/cli-runtime.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/cli-runtime.test.ts
@@ -32,7 +32,7 @@ vi.mock("../cli-session-watcher.js", () => ({
 }));
 
 import { CLIRuntime } from "../cli-runtime.js";
-import { getCliSessionDir } from "../cli-session-path.js";
+import { getCliSessionDir, getCliSessionFile, waitForNewSessionFile } from "../cli-session-path.js";
 
 function makeSubprocess(exitCode = 0): Promise<{ exitCode: number }> & {
   pid: number;
@@ -243,5 +243,73 @@ describe("CLIRuntime --mcp-config serialization (issue #182)", () => {
   it("omits --mcp-config entirely when no mcp_servers are configured", async () => {
     expect(await captureMcpConfigArg({})).toBeUndefined();
     expect(await captureMcpConfigArg({ mcp_servers: {} })).toBeUndefined();
+  });
+});
+
+describe("CLIRuntime session fork (--fork-session)", () => {
+  beforeEach(() => {
+    watchMessages.length = 0;
+    flushMessages.length = 0;
+    vi.mocked(getCliSessionFile).mockClear();
+    vi.mocked(waitForNewSessionFile).mockClear();
+    // Distinct paths so we can tell which resolver drove the watched file: a
+    // plain resume watches the source file in place; a fork must wait for a new
+    // one (Claude Code writes a new session file for `--fork-session`).
+    vi.mocked(getCliSessionFile).mockReturnValue("/tmp/sessions/source.jsonl");
+    vi.mocked(waitForNewSessionFile).mockResolvedValue("/tmp/sessions/forked-child.jsonl");
+  });
+
+  async function run(opts: { resume?: string; fork?: boolean }): Promise<{
+    spawnedArgs: string[];
+    messages: SDKMessage[];
+  }> {
+    let spawnedArgs: string[] = [];
+    const runtime = new CLIRuntime({
+      processSpawner: ((args: string[]) => {
+        spawnedArgs = args;
+        return makeSubprocess() as never;
+      }) as never,
+    });
+    const messages: SDKMessage[] = [];
+    for await (const message of runtime.execute({
+      prompt: "branch off here",
+      agent: { name: "keeper", configPath: "/tmp/agent.yaml" } as never,
+      ...opts,
+    })) {
+      messages.push(message);
+    }
+    return { spawnedArgs, messages };
+  }
+
+  const initId = (messages: SDKMessage[]): string | undefined =>
+    (
+      messages.find((m) => m.type === "system") as
+        | (SDKMessage & { session_id?: string })
+        | undefined
+    )?.session_id;
+
+  it("passes --resume <source> and --fork-session to the CLI", async () => {
+    const { spawnedArgs } = await run({ resume: "source", fork: true });
+    const rIdx = spawnedArgs.indexOf("--resume");
+    expect(rIdx).toBeGreaterThan(-1);
+    expect(spawnedArgs[rIdx + 1]).toBe("source");
+    expect(spawnedArgs).toContain("--fork-session");
+  });
+
+  it("watches the NEW forked file and reports its id, not the source's", async () => {
+    const { messages } = await run({ resume: "source", fork: true });
+    // A fork must resolve via waitForNewSessionFile (the new file), never the
+    // resumed source path — otherwise it would report the parent's id and miss
+    // the child's turns entirely.
+    expect(vi.mocked(waitForNewSessionFile)).toHaveBeenCalled();
+    expect(vi.mocked(getCliSessionFile)).not.toHaveBeenCalled();
+    expect(initId(messages)).toBe("forked-child");
+  });
+
+  it("a plain resume (no fork) still watches the source file in place", async () => {
+    const { messages } = await run({ resume: "source" });
+    expect(vi.mocked(getCliSessionFile)).toHaveBeenCalled();
+    expect(vi.mocked(waitForNewSessionFile)).not.toHaveBeenCalled();
+    expect(initId(messages)).toBe("source");
   });
 });

--- a/packages/core/src/runner/runtime/cli-runtime.ts
+++ b/packages/core/src/runner/runtime/cli-runtime.ts
@@ -397,9 +397,15 @@ export class CLIRuntime implements RuntimeInterface {
         },
       );
 
-      // Determine which session file to watch
+      // Determine which session file to watch.
+      //
+      // A FORK (`--resume <src> --fork-session`) does NOT append to the source
+      // file — Claude Code writes a brand-new session file with a new id. So a
+      // fork must wait for that new file just like a fresh session, even though
+      // `options.resume` is set (to the source). Only a plain resume (no fork)
+      // watches the resumed source file in place.
       let sessionFilePath: string;
-      if (options.resume) {
+      if (options.resume && !options.fork) {
         // When resuming, use sessionDirOverride if provided (for Docker execution)
         // Otherwise fall back to native CLI path
         if (this.sessionDirOverride) {
@@ -409,8 +415,13 @@ export class CLIRuntime implements RuntimeInterface {
         }
         logger.debug(`Resuming session, watching file: ${sessionFilePath}`);
       } else {
-        // When starting new session, wait for a NEW file created after process start
-        logger.debug("Waiting for new session file...");
+        // A brand-new session, or a fork writing a new session file: wait for a
+        // NEW file created after process start and adopt its id.
+        logger.debug(
+          options.fork
+            ? "Forking session, waiting for new session file..."
+            : "Waiting for new session file...",
+        );
         sessionFilePath = await waitForNewSessionFile(sessionDir, processStartTime, {
           timeoutMs: 60000, // Allow up to 60s for MCP servers to initialize
           pollIntervalMs: 200,


### PR DESCRIPTION
## What

Adds **session forking** to the public `trigger()` API. Passing `fork: <sourceSessionId>` in `TriggerOptions` runs a turn that resumes the source session's transcript as context but writes all new turns to a **brand-new session id** (via Claude Code's `--fork-session`), leaving the source session untouched. This lets a caller branch an existing conversation into independent children — e.g. exploring several directions from a shared context without exhausting one window.

## Why it wasn't already usable

The runner already had `RunnerOptions.fork`, but **nothing on the public API passed it** (only tests set it), and the **CLI runtime mis-handled it**: it appended `--fork-session` to the args yet still watched the *resumed source* session file, so it reported the parent's session id and never saw the child's turns. So fork worked on the SDK runtime but was broken on the CLI runtime (the one Max-plan agents use).

## Changes

- **`TriggerOptions`**: adds `fork?: string` (source session id) and optional `forkedFrom?: string` (job lineage), documented as mutually exclusive with `resume`.
- **`trigger()`**: threads `fork`/`forkedFrom` to `JobExecutor`, and skips the agent-level session fallback when forking (a fork names its own source).
- **`JobExecutor`**: seeds the resume target from the fork source (so the CLI/SDK has a transcript to fork from), bypassing agent-session adoption; only sets the runtime fork flag when a resume target survived — so a retry after the source is gone degrades to a plain fresh session instead of `--fork-session` with no `--resume`.
- **CLI runtime**: when forking, waits for the newly-created fork file and reports **its** id (like a fresh session) instead of watching the resumed source — matching SDK-runtime behavior.

## Tests

- `cli-runtime.test.ts` (+3): fork passes `--resume <src>` + `--fork-session`; watches the **new** file and reports the child id (not the source's); a plain resume still watches the source in place.
- `job-executor.test.ts` (+1): forking resumes the source **and** sets `fork` on the runtime call.
- Green: 96 tests across the two files; **879** across `runner` + `fleet-manager`, no regressions. Typecheck + biome clean.

## Note / follow-up

The `--fork-session` transcript-flush timing against a real `claude` binary (does the copied history fully settle before the runtime's skip-existing read?) is not covered by the mock harness and warrants one empirical run; the routing/id-reporting fix here is unit-tested. Consumed downstream by a Paddock "Fork chat" button (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for session forking in the `trigger()` flow, allowing a run to continue from an existing session’s context while creating a new session ID.

* **Bug Fixes**
  * Improved handling when forking and resuming together so the app waits for the new forked session instead of reusing the original session file.
  * If the original session is missing, runs now retry cleanly as a fresh session.
  * Updated session reporting so forked runs return the new session ID consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->