### PR TITLE
feat(chat): preserve agent attribution (parent_tool_use_id) in the translator

### DIFF
--- a/.changeset/translator-agent-attribution.md
+++ b/.changeset/translator-agent-attribution.md
@@ -1,0 +1,18 @@
+---
+"@herdctl/chat": minor
+---
+
+The SDK message translator now preserves agent attribution so consumers can
+separate the main agent from `Task`-spawned subagents into per-agent lanes.
+
+Every emitted event carries the originating agent's `parent_tool_use_id`
+(`null` = main agent, else the spawning `Task` tool_use id):
+
+- `onText(text, attribution)` and `onBoundary(attribution)` receive an
+  `AgentAttribution` argument.
+- `TranslatedToolCall` gains a `parentToolUseId` field (attributed to the agent
+  that issued the tool_use, falling back to the result message's own attribution).
+
+New `AgentAttribution` type and `getAgentAttribution(message)` helper are exported
+from `@herdctl/chat`. The change is additive — existing handlers that ignore the
+new argument/field keep working unchanged.

--- a/packages/chat/src/__tests__/message-extraction.test.ts
+++ b/packages/chat/src/__tests__/message-extraction.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractMessageContent,
+  getAgentAttribution,
   hasTextContent,
   isSyntheticMessage,
   isTextContentBlock,
@@ -203,6 +204,31 @@ describe("message-extraction", () => {
         message: { content: "Real reply" },
       };
       expect(isSyntheticMessage(message)).toBe(false);
+    });
+  });
+
+  describe("getAgentAttribution", () => {
+    it("returns null for the main agent (absent parent_tool_use_id)", () => {
+      const message: SDKMessage = { type: "assistant", message: { content: "hi" } };
+      expect(getAgentAttribution(message)).toEqual({ parentToolUseId: null });
+    });
+
+    it("returns null when parent_tool_use_id is explicitly null", () => {
+      const message: SDKMessage = {
+        type: "assistant",
+        parent_tool_use_id: null,
+        message: { content: "hi" },
+      };
+      expect(getAgentAttribution(message)).toEqual({ parentToolUseId: null });
+    });
+
+    it("returns the Task tool_use id for a subagent message", () => {
+      const message: SDKMessage = {
+        type: "assistant",
+        parent_tool_use_id: "task_abc",
+        message: { content: "hi" },
+      };
+      expect(getAgentAttribution(message)).toEqual({ parentToolUseId: "task_abc" });
     });
   });
 });

--- a/packages/chat/src/__tests__/sdk-message-translator.test.ts
+++ b/packages/chat/src/__tests__/sdk-message-translator.test.ts
@@ -75,6 +75,44 @@ function sdkTopLevelToolResult(output: string): SDKMessage {
   } as unknown as SDKMessage;
 }
 
+/** Assistant text produced by a subagent (carries a `parent_tool_use_id`). */
+function subagentText(text: string, parentToolUseId: string): SDKMessage {
+  return {
+    type: "assistant",
+    parent_tool_use_id: parentToolUseId,
+    message: { content: [{ type: "text", text }] },
+  } as unknown as SDKMessage;
+}
+
+/** A subagent's `tool_use` (carries the spawning `Task` tool_use id). */
+function subagentToolUse(
+  id: string,
+  name: string,
+  parentToolUseId: string,
+  input?: unknown,
+): SDKMessage {
+  return {
+    type: "assistant",
+    parent_tool_use_id: parentToolUseId,
+    message: { content: [{ type: "tool_use", id, name, input }] },
+  } as unknown as SDKMessage;
+}
+
+/** A subagent's `tool_result` user message (carries `parent_tool_use_id`). */
+function subagentToolResult(
+  toolUseId: string,
+  output: string,
+  parentToolUseId: string,
+): SDKMessage {
+  return {
+    type: "user",
+    parent_tool_use_id: parentToolUseId,
+    message: {
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content: output, is_error: false }],
+    },
+  } as unknown as SDKMessage;
+}
+
 describe("SDKMessageTranslator", () => {
   describe("text deltas", () => {
     it("emits assistant text via onText", async () => {
@@ -84,8 +122,8 @@ describe("SDKMessageTranslator", () => {
       await t.handle(assistantText("Hello "));
       await t.handle(assistantText("world"));
 
-      expect(onText).toHaveBeenNthCalledWith(1, "Hello ");
-      expect(onText).toHaveBeenNthCalledWith(2, "world");
+      expect(onText).toHaveBeenNthCalledWith(1, "Hello ", { parentToolUseId: null });
+      expect(onText).toHaveBeenNthCalledWith(2, "world", { parentToolUseId: null });
     });
 
     it("ignores non-assistant/non-user messages", async () => {
@@ -217,6 +255,7 @@ describe("SDKMessageTranslator", () => {
         isError: false,
         durationMs: 250,
         toolUseId: "t1",
+        parentToolUseId: null,
       });
     });
 
@@ -276,6 +315,7 @@ describe("SDKMessageTranslator", () => {
           isError: false,
           durationMs: 113,
           toolUseId: "t1",
+          parentToolUseId: null,
         });
       });
 
@@ -324,6 +364,96 @@ describe("SDKMessageTranslator", () => {
         expect(calls[0].durationMs).toBeUndefined();
         expect(calls[0].toolUseId).toBeUndefined();
       });
+    });
+  });
+
+  describe("agent attribution (parent_tool_use_id)", () => {
+    it("attaches parentToolUseId: null to main-agent text", async () => {
+      const onText = vi.fn();
+      const t = new SDKMessageTranslator({ onText });
+
+      await t.handle(assistantText("main agent speaking"));
+
+      expect(onText).toHaveBeenCalledWith("main agent speaking", { parentToolUseId: null });
+    });
+
+    it("attaches the spawning Task tool_use id to subagent text", async () => {
+      const onText = vi.fn();
+      const t = new SDKMessageTranslator({ onText });
+
+      await t.handle(subagentText("subagent speaking", "task_abc"));
+
+      expect(onText).toHaveBeenCalledWith("subagent speaking", { parentToolUseId: "task_abc" });
+    });
+
+    it("routes main and subagent text into separate lanes on the same turn", async () => {
+      const events: Array<{ text: string; lane: string | null }> = [];
+      const t = new SDKMessageTranslator({
+        onText: (text, attribution) => {
+          events.push({ text, lane: attribution.parentToolUseId });
+        },
+      });
+
+      await t.handle(assistantText("main before Task"));
+      await t.handle(subagentText("subagent working", "task_abc"));
+      await t.handle(assistantText("main after Task"));
+
+      expect(events).toEqual([
+        { text: "main before Task", lane: null },
+        { text: "subagent working", lane: "task_abc" },
+        { text: "main after Task", lane: null },
+      ]);
+    });
+
+    it("carries the issuing agent's attribution onto a subagent tool call", async () => {
+      const calls: TranslatedToolCall[] = [];
+      const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+      await t.handle(subagentToolUse("t1", "Bash", "task_abc", { command: "ls" }));
+      await t.handle(subagentToolResult("t1", "out", "task_abc"));
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].toolName).toBe("Bash");
+      expect(calls[0].parentToolUseId).toBe("task_abc");
+    });
+
+    it("attributes a main-agent tool call to null", async () => {
+      const calls: TranslatedToolCall[] = [];
+      const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+      await t.handle(assistantToolUse("t1", "Read", { file_path: "/a" }));
+      await t.handle(toolResult("t1", "contents"));
+
+      expect(calls[0].parentToolUseId).toBeNull();
+    });
+
+    it("falls back to the result message's attribution when the tool_use wasn't tracked", async () => {
+      const calls: TranslatedToolCall[] = [];
+      const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+      // Orphan result (no preceding tool_use) still carries the lane from its
+      // own parent_tool_use_id.
+      await t.handle(subagentToolResult("orphan", "result", "task_xyz"));
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].toolName).toBe("Tool");
+      expect(calls[0].parentToolUseId).toBe("task_xyz");
+    });
+
+    it("attaches attribution of the turn beginning to a boundary", async () => {
+      const boundaries: Array<string | null> = [];
+      const t = new SDKMessageTranslator({
+        onText: vi.fn(),
+        onBoundary: (attribution) => {
+          boundaries.push(attribution.parentToolUseId);
+        },
+      });
+
+      await t.handle(assistantText("main text"));
+      // A subagent turn after main text → boundary attributed to the subagent lane.
+      await t.handle(subagentText("subagent text", "task_abc"));
+
+      expect(boundaries).toEqual(["task_abc"]);
     });
   });
 
@@ -385,7 +515,7 @@ describe("createSDKMessageHandler", () => {
     await handler(assistantToolUse("t1", "Read", { file_path: "/f" }));
     await handler(toolResult("t1", "contents"));
 
-    expect(onText).toHaveBeenCalledWith("hi");
+    expect(onText).toHaveBeenCalledWith("hi", { parentToolUseId: null });
     expect(calls[0]).toMatchObject({ toolName: "Read", inputSummary: "/f", output: "contents" });
   });
 });

--- a/packages/chat/src/__tests__/sdk-message-translator.test.ts
+++ b/packages/chat/src/__tests__/sdk-message-translator.test.ts
@@ -427,6 +427,20 @@ describe("SDKMessageTranslator", () => {
       expect(calls[0].parentToolUseId).toBeNull();
     });
 
+    it("keeps a tracked tool_use's own null attribution even if the result message carries an id", async () => {
+      const calls: TranslatedToolCall[] = [];
+      const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+      // A tracked main-agent tool_use (parentToolUseId: null). The result message
+      // carries a different attribution — the tracked value must win, not fall
+      // through to the message's (a nullish-coalescing merge would lose the null).
+      await t.handle(assistantToolUse("t1", "Bash", { command: "ls" }));
+      await t.handle(subagentToolResult("t1", "out", "task_zzz"));
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].parentToolUseId).toBeNull();
+    });
+
     it("falls back to the result message's attribution when the tool_use wasn't tracked", async () => {
       const calls: TranslatedToolCall[] = [];
       const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -97,8 +97,10 @@ export {
 // =============================================================================
 
 export {
+  type AgentAttribution,
   type ContentBlock,
   extractMessageContent,
+  getAgentAttribution,
   hasTextContent,
   isSyntheticMessage,
   isTextContentBlock,

--- a/packages/chat/src/message-extraction.ts
+++ b/packages/chat/src/message-extraction.ts
@@ -36,6 +36,13 @@ export interface ContentBlock {
 export interface SDKMessage {
   type: string;
   content?: string;
+  /**
+   * Agent attribution for this message: `null`/absent for the main agent, or the
+   * `Task` tool_use id of the subagent that produced it. The Claude Agent SDK
+   * sets this on every `assistant`/`user` message so consumers can separate the
+   * main agent from `Task`-spawned subagents into distinct lanes.
+   */
+  parent_tool_use_id?: string | null;
   message?: {
     content?: string | ContentBlock[];
     /**
@@ -70,6 +77,32 @@ export const SYNTHETIC_MODEL = "<synthetic>";
  */
 export function isSyntheticMessage(message: SDKMessage): boolean {
   return message.message?.model === SYNTHETIC_MODEL;
+}
+
+/**
+ * Agent attribution for a translated event: which agent produced it.
+ *
+ * `parentToolUseId` is `null` for the main agent, or the `Task` tool_use id of
+ * the subagent that produced the message. Consumers group events by this id to
+ * reconstruct per-agent lanes (the `Task` tool_use id seen on the main stream
+ * correlates to the subagent's `parent_tool_use_id`).
+ */
+export interface AgentAttribution {
+  /** `null` for the main agent, else the spawning `Task` tool_use id. */
+  parentToolUseId: string | null;
+}
+
+/**
+ * Read the agent attribution off an SDK message.
+ *
+ * Normalizes the SDK's snake_case `parent_tool_use_id` (which may be `null` or
+ * absent for the main agent) into an {@link AgentAttribution}.
+ *
+ * @param message - SDK message object
+ * @returns The agent attribution (`parentToolUseId: null` = main agent)
+ */
+export function getAgentAttribution(message: SDKMessage): AgentAttribution {
+  return { parentToolUseId: message.parent_tool_use_id ?? null };
 }
 
 // =============================================================================

--- a/packages/chat/src/sdk-message-translator.ts
+++ b/packages/chat/src/sdk-message-translator.ts
@@ -74,9 +74,11 @@ export interface SDKMessageHandlers {
    */
   onText?: (text: string, attribution: AgentAttribution) => void | Promise<void>;
   /**
-   * Called when a new assistant turn begins after a previous one produced text
-   * (or after a tool call interrupts the text), so transports can split bubbles.
-   * The attribution identifies the agent whose turn is beginning.
+   * Called when a new assistant turn begins after a previous one produced text,
+   * so transports can split bubbles. A tool-call interruption alone does NOT
+   * trigger a boundary — a tool result resets the text run, so the next
+   * assistant text simply begins a fresh bubble with no boundary event. The
+   * attribution identifies the agent whose turn is beginning.
    */
   onBoundary?: (attribution: AgentAttribution) => void | Promise<void>;
   /** Called once per tool result, paired with its originating tool_use. */
@@ -313,9 +315,11 @@ export class SDKMessageTranslator {
         isError: result.isError,
         durationMs: toolUse ? this.now() - toolUse.startTime : undefined,
         toolUseId: result.toolUseId,
-        // Attribute to the agent that issued the tool_use; fall back to the
-        // result message's own attribution if that tool_use wasn't tracked.
-        parentToolUseId: toolUse?.parentToolUseId ?? messageAttribution.parentToolUseId,
+        // Attribute to the agent that issued the tool_use. A tracked tool_use
+        // keeps its own attribution (including a legitimate `null` for the main
+        // agent); only a truly untracked result falls back to the result
+        // message's own attribution.
+        parentToolUseId: toolUse ? toolUse.parentToolUseId : messageAttribution.parentToolUseId,
       });
     }
   }

--- a/packages/chat/src/sdk-message-translator.ts
+++ b/packages/chat/src/sdk-message-translator.ts
@@ -19,7 +19,9 @@
  */
 
 import {
+  type AgentAttribution,
   extractMessageContent,
+  getAgentAttribution,
   isSyntheticMessage,
   type SDKMessage,
 } from "./message-extraction.js";
@@ -50,6 +52,12 @@ export interface TranslatedToolCall {
   durationMs?: number;
   /** The originating tool_use id, when present */
   toolUseId?: string;
+  /**
+   * Agent attribution: `null` when the main agent invoked the tool, or the
+   * `Task` tool_use id of the subagent that invoked it. Lets consumers group
+   * tool calls into per-agent lanes.
+   */
+  parentToolUseId: string | null;
 }
 
 /**
@@ -58,13 +66,19 @@ export interface TranslatedToolCall {
  * backpressure (e.g. a slow WebSocket send).
  */
 export interface SDKMessageHandlers {
-  /** Called with each assistant text delta as it streams in. */
-  onText?: (text: string) => void | Promise<void>;
+  /**
+   * Called with each assistant text delta as it streams in. The second argument
+   * carries agent attribution (`parentToolUseId: null` = main agent, else the
+   * spawning `Task` tool_use id) so consumers can route text into per-agent
+   * lanes. Existing handlers that ignore the second argument keep working.
+   */
+  onText?: (text: string, attribution: AgentAttribution) => void | Promise<void>;
   /**
    * Called when a new assistant turn begins after a previous one produced text
    * (or after a tool call interrupts the text), so transports can split bubbles.
+   * The attribution identifies the agent whose turn is beginning.
    */
-  onBoundary?: () => void | Promise<void>;
+  onBoundary?: (attribution: AgentAttribution) => void | Promise<void>;
   /** Called once per tool result, paired with its originating tool_use. */
   onToolCall?: (toolCall: TranslatedToolCall) => void | Promise<void>;
 }
@@ -94,6 +108,8 @@ interface PendingToolUse {
   name: string;
   input?: unknown;
   startTime: number;
+  /** Attribution of the agent that issued this tool_use (main = null). */
+  parentToolUseId: string | null;
 }
 
 /**
@@ -229,15 +245,20 @@ export class SDKMessageTranslator {
     // to text or turn boundaries, and don't let them disturb per-turn state.
     if (isSyntheticMessage(message)) return;
 
+    // Agent attribution: null for the main agent, or the spawning Task tool_use
+    // id for a subagent. Threaded onto every emitted event so consumers can
+    // separate main vs. subagent lanes.
+    const attribution = getAgentAttribution(message);
+
     const content = extractMessageContent(message);
     if (content) {
       // A new assistant turn after a previous one produced text → boundary.
       if (this.hasAssistantText) {
         this.hasAssistantText = false;
-        await this.handlers.onBoundary?.();
+        await this.handlers.onBoundary?.(attribution);
       }
       this.hasAssistantText = true;
-      await this.handlers.onText?.(content);
+      await this.handlers.onText?.(content, attribution);
     }
 
     // Track tool_use blocks so we can pair them with results later. We track
@@ -248,6 +269,7 @@ export class SDKMessageTranslator {
           name: block.name,
           input: block.input,
           startTime: this.now(),
+          parentToolUseId: attribution.parentToolUseId,
         });
       }
     }
@@ -260,6 +282,10 @@ export class SDKMessageTranslator {
     if (results.length === 0) {
       return;
     }
+
+    // Fallback attribution from the result-carrying user message, used when the
+    // originating tool_use wasn't tracked (so we can't read the issuing agent).
+    const messageAttribution = getAgentAttribution(message);
 
     // A tool result ends the current text run; the next assistant text is a new
     // bubble. Drop the text flag so we don't emit a spurious boundary, but the
@@ -287,6 +313,9 @@ export class SDKMessageTranslator {
         isError: result.isError,
         durationMs: toolUse ? this.now() - toolUse.startTime : undefined,
         toolUseId: result.toolUseId,
+        // Attribute to the agent that issued the tool_use; fall back to the
+        // result message's own attribution if that tool_use wasn't tracked.
+        parentToolUseId: toolUse?.parentToolUseId ?? messageAttribution.parentToolUseId,
       });
     }
   }


### PR DESCRIPTION
Fixes #282.

## Problem

The SDK message translator in `@herdctl/chat` collapsed every `assistant`/`user` message into one undifferentiated stream and never propagated `parent_tool_use_id`. The attribution data is present on the raw stream (`null` for the main agent, or the `Task` tool_use id for a subagent) — the translator just dropped it, so consumers (Paddock, the web dashboard) couldn't tell the main agent apart from `Task`-spawned subagents. Subagent activity was unattributable and per-agent "lane" views were impossible to build.

## Fix

Thread agent attribution through to every emitted event, exactly as the issue's "Minimum" proposes. `parentToolUseId` is `null` for the main agent, else the spawning `Task` tool_use id; consumers group events by it to reconstruct per-agent lanes.

- **`onText(text, attribution)`** and **`onBoundary(attribution)`** now receive an `AgentAttribution` second argument.
- **`TranslatedToolCall`** gains a **`parentToolUseId`** field, attributed to the agent that *issued* the tool_use (tracked on the pending tool_use), falling back to the result message's own attribution when the tool_use wasn't tracked (orphan results).
- New **`AgentAttribution`** type + **`getAgentAttribution(message)`** helper, exported from `@herdctl/chat`. `SDKMessage` gains the top-level `parent_tool_use_id` field.

Boundary-triggering semantics are unchanged (a subagent turn after main text is already a "new assistant turn" → boundary); the boundary now simply carries the attribution of the turn that's beginning.

### Backward compatibility

Additive by design. Existing handlers typed `(text: string) => void` remain assignable to the widened callback type, and readers of `TranslatedToolCall` are unaffected by the new field. The only in-repo consumer, `@herdctl/web`'s `WebChatManager`, has its own inline SDK loop and doesn't use the translator — it builds and typechecks unchanged. Bumped `minor` for `@herdctl/chat`.

## Tests

New coverage in `sdk-message-translator.test.ts` and `message-extraction.test.ts`:
- main-agent text → `{ parentToolUseId: null }`; subagent text → the `Task` id.
- interleaved main/subagent text on one turn routes into separate lanes.
- subagent tool call carries the issuing agent's id; main tool call → `null`; orphan result falls back to the result message's attribution.
- boundary carries the beginning turn's attribution.
- `getAgentAttribution` maps absent/`null`/set `parent_tool_use_id` correctly.

`@herdctl/chat`: full suite 276/276; typecheck + lint + build clean for `chat` and `web`.

## Note on the runtime caveat from the issue

Whether subagent-*internal* messages actually appear on the live stream can differ between `runtime: "cli"` and `runtime: "sdk"` — this PR makes the translator faithfully preserve attribution for whatever the runtime emits. Surfacing subagent internals that only exist in the on-disk `subagents/agent-*.jsonl` sidechains (and explicit start/stop lifecycle markers) is the issue's "nice-to-have" and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent attribution support to translated chat events, letting consumers distinguish main-agent activity from subagent activity.
  * Text, boundary, and tool-call events now include attribution details, including a parent tool-use ID when relevant.
  * Added a helper for reading attribution from messages and exposed the new attribution type for SDK consumers.

* **Bug Fixes**
  * Preserved attribution across tool calls and tool results, including fallback handling for orphaned results.
  * Updated test coverage for main-agent and subagent message flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->