### PR TITLE
feat(core): session-lifecycle reaper + wake registry (#307, part 1)

### DIFF
--- a/.changeset/session-reaper.md
+++ b/.changeset/session-reaper.md
@@ -1,0 +1,16 @@
+---
+"@herdctl/core": minor
+---
+
+Add streaming-session lifecycle management: a session reaper and a wake registry (part 1 of edspencer/herdctl#307).
+
+Long-lived chat sessions (`openChatSession` / `SDKRuntime.openSession`) now have the building blocks to be reaped the instant they go idle — rather than accumulating warm native `claude` processes at ~300 MB each — and to have their timer-class wakeups (`ScheduleWakeup` / `CronCreate`) re-triggered through herdctl's own scheduler after the reap.
+
+New, additive surface under `@herdctl/core`:
+
+- **`session/` module** — `decideReap` (the one-rule reap policy), `reconcileSessionWakes` + the wake-store helpers (reconcile SDK `session_crons` by id into durable wake entries with an absolute `nextRunAt`, one-shot vs recurring semantics, 7-day recurring expiry), `WakeRegistry` (async-locked, concurrency-limited, deadlock-free due-firing that skips still-live sessions), `SessionReaper` (drives reap vs keep-alive from turn-end / `background_tasks_changed` / activity signals), `buildLifecycleHooks` / `tapLifecycleStream`, and `FleetStateWakePersistence`.
+- **`SDKRuntime.openSession`** now installs `Stop`/`SubagentStop` lifecycle hooks and taps the message stream when a new `onLifecycleSignal` execute-option is provided, and threads an `AbortController` into the query for clean teardown.
+- **`Scheduler`** gains an `onTick` option so wake firing reuses the existing scheduler loop instead of a second timer.
+- Fleet state gains an optional `session_wakes` slice.
+
+No behavior changes to existing paths: sessions are only managed when a caller opts in via `onLifecycleSignal`, and the reaper/registry are not yet wired into `FleetManager.openChatSession` (that end-to-end wiring + consumer surface is part 2).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,8 @@ export * from "./hooks/index.js";
 export * from "./runner/index.js";
 // Scheduler exports (PRD 6)
 export * from "./scheduler/index.js";
+// Streaming-session lifecycle: reaper + wake re-trigger (#307)
+export * from "./session/index.js";
 // State exports (PRD 2)
 export * from "./state/index.js";
 // Utils exports (Logger, etc.)

--- a/packages/core/src/runner/runtime/interface.ts
+++ b/packages/core/src/runner/runtime/interface.ts
@@ -47,6 +47,20 @@ export interface RuntimeExecuteOptions {
 
   /** Text to append to the agent's system prompt for this run */
   systemPromptAppend?: string;
+
+  /**
+   * Streaming sessions only: observe the session's background-work lifecycle.
+   *
+   * Called at each turn boundary (the SDK `Stop`/`SubagentStop` hook) and when
+   * the live background-task set changes (`background_tasks_changed`), with a
+   * snapshot of the session's pending timer-class wakeups (`sessionCrons`) and
+   * continuous-class background work (`backgroundTasks`). The session-reaper
+   * uses this to decide when to close an idle session and to capture wakeups for
+   * re-triggering. Ignored by {@link RuntimeInterface.execute}.
+   */
+  onLifecycleSignal?: (
+    signal: import("../../session/types.js").SessionLifecycleSignal,
+  ) => void | Promise<void>;
 }
 
 /**

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -15,6 +15,7 @@ import {
   tool,
 } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
+import { buildLifecycleHooks, tapLifecycleStream } from "../../session/session-hooks.js";
 import { toSDKOptions } from "../sdk-adapter.js";
 import type { InjectedMcpServerDef, SDKMessage } from "../types.js";
 import type { RuntimeExecuteOptions, RuntimeInterface, RuntimeSession } from "./interface.js";
@@ -168,21 +169,43 @@ export class SDKRuntime implements RuntimeInterface {
   openSession(options: RuntimeExecuteOptions): RuntimeSession {
     const sdkOptions = this.buildSdkOptions(options);
 
+    // Install turn-boundary lifecycle hooks when the caller wants to observe the
+    // session's background-work lifecycle (the session-reaper). The Stop hook
+    // carries the authoritative session_crons/background_tasks snapshot.
+    if (options.onLifecycleSignal) {
+      sdkOptions.hooks = {
+        ...(sdkOptions.hooks ?? {}),
+        ...buildLifecycleHooks(options.onLifecycleSignal),
+      };
+    }
+
     // A pushable iterable keeps the query open across turns.
     const input = new MessageQueue<SDKUserMessage>();
     if (options.prompt) {
       input.push(toUserMessage(options.prompt));
     }
 
+    // Thread the AbortController through so teardown has a lever beyond close()
+    // (mirrors execute()); create one if the caller didn't supply it.
+    const abortController = options.abortController ?? new AbortController();
+
     const q = query({
       prompt: input as AsyncIterable<SDKUserMessage>,
-      options: sdkOptions as Record<string, unknown>,
+      options: {
+        ...(sdkOptions as Record<string, unknown>),
+        abortController,
+      },
     });
 
+    // Widen the Query (an AsyncGenerator<SDKMessage>) to herdctl's structural
+    // SDKMessage, then tap the stream for mid-turn lifecycle events when needed.
+    const rawMessages = q as unknown as AsyncIterable<SDKMessage>;
+    const messages = options.onLifecycleSignal
+      ? tapLifecycleStream(rawMessages, options.onLifecycleSignal)
+      : rawMessages;
+
     return {
-      // The Query is itself an AsyncGenerator<SDKMessage>; cast to herdctl's
-      // structural SDKMessage (same widening execute() applies per-message).
-      messages: q as unknown as AsyncIterable<SDKMessage>,
+      messages,
       send: async (text: string) => {
         input.push(toUserMessage(text));
       },
@@ -202,6 +225,9 @@ export class SDKRuntime implements RuntimeInterface {
         } catch {
           // Already closed / never started — nothing to clean up.
         }
+        // Abort as a backstop in case the generator was already detached and
+        // q.return() didn't reach the underlying process.
+        if (!abortController.signal.aborted) abortController.abort();
       },
     };
   }

--- a/packages/core/src/runner/types.ts
+++ b/packages/core/src/runner/types.ts
@@ -245,6 +245,12 @@ export interface SDKQueryOptions {
   cwd?: string;
   /** Model to use for the session */
   model?: string;
+  /**
+   * SDK lifecycle hooks (`Stop`, `SubagentStop`, …). Not set by `toSDKOptions`;
+   * injected by the SDK runtime for streaming sessions to observe turn
+   * boundaries. Typed against the SDK's own `Options["hooks"]`.
+   */
+  hooks?: import("@anthropic-ai/claude-agent-sdk").Options["hooks"];
 }
 
 // =============================================================================

--- a/packages/core/src/scheduler/__tests__/scheduler.test.ts
+++ b/packages/core/src/scheduler/__tests__/scheduler.test.ts
@@ -1560,4 +1560,45 @@ describe("Scheduler", () => {
       await startPromise;
     });
   });
+
+  describe("onTick", () => {
+    it("invokes the tick hook once per loop iteration", async () => {
+      const onTick = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new Scheduler({
+        stateDir: tempDir,
+        logger: mockLogger,
+        checkInterval: 20,
+        onTick,
+      });
+
+      const startPromise = scheduler.start([]);
+      await wait(70);
+      await scheduler.stop();
+      await startPromise;
+
+      expect(onTick.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("swallows a throwing tick hook without stopping the loop", async () => {
+      let calls = 0;
+      const onTick = vi.fn().mockImplementation(() => {
+        calls++;
+        throw new Error("tick boom");
+      });
+      const scheduler = new Scheduler({
+        stateDir: tempDir,
+        logger: mockLogger,
+        checkInterval: 20,
+        onTick,
+      });
+
+      const startPromise = scheduler.start([]);
+      await wait(70);
+      await scheduler.stop();
+      await startPromise;
+
+      expect(calls).toBeGreaterThanOrEqual(2);
+      expect(mockLogger.errors.some((e) => e.includes("tick hook"))).toBe(true);
+    });
+  });
 });

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -93,6 +93,7 @@ export class Scheduler {
   private readonly stateDir: string;
   private readonly logger: SchedulerLogger;
   private readonly onTrigger?: SchedulerTriggerCallback;
+  private readonly onTick?: () => Promise<void> | void;
 
   private status: SchedulerStatus = "stopped";
   private abortController: AbortController | null = null;
@@ -111,6 +112,7 @@ export class Scheduler {
     this.stateDir = options.stateDir;
     this.logger = options.logger ?? createDefaultLogger();
     this.onTrigger = options.onTrigger;
+    this.onTick = options.onTick;
   }
 
   /**
@@ -269,6 +271,16 @@ export class Scheduler {
         this.logger.error(
           `Error during schedule check: ${error instanceof Error ? error.message : String(error)}`,
         );
+      }
+
+      if (this.onTick) {
+        try {
+          await this.onTick();
+        } catch (error) {
+          this.logger.error(
+            `Error during scheduler tick hook: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
       }
 
       // Sleep until next check, but allow interruption via AbortController

--- a/packages/core/src/scheduler/types.ts
+++ b/packages/core/src/scheduler/types.ts
@@ -69,6 +69,16 @@ export interface SchedulerOptions {
    * Callback invoked when a schedule is due and should trigger an agent run
    */
   onTrigger?: SchedulerTriggerCallback;
+
+  /**
+   * Callback invoked once per tick, after config schedules are checked.
+   *
+   * A seam for time-based work that isn't a config schedule — notably the
+   * session-wake registry firing due wakes (edspencer/herdctl#307). Reuses the
+   * scheduler's existing loop rather than standing up a second timer. A throw is
+   * logged and swallowed so it can't wedge the loop.
+   */
+  onTick?: () => Promise<void> | void;
 }
 
 // =============================================================================

--- a/packages/core/src/session/__tests__/fleet-state-wake-persistence.test.ts
+++ b/packages/core/src/session/__tests__/fleet-state-wake-persistence.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readFleetState, writeFleetState } from "../../state/fleet-state.js";
+import { STATE_FILE_NAME } from "../../state/types.js";
+import { FleetStateWakePersistence } from "../fleet-state-wake-persistence.js";
+import type { SessionWakeEntry } from "../types.js";
+
+const NOW = new Date("2026-07-09T12:00:00.000Z");
+
+function entry(overrides: Partial<SessionWakeEntry> = {}): SessionWakeEntry {
+  return {
+    id: "c1",
+    agent: "team/agent",
+    sessionId: "sess-1",
+    schedule: "*/5 * * * *",
+    recurring: true,
+    prompt: "WAKE",
+    nextRunAt: NOW.toISOString(),
+    createdAt: NOW.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("FleetStateWakePersistence", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(join(tmpdir(), "herdctl-wake-"));
+  });
+
+  afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty set when no state file exists", async () => {
+    const persistence = new FleetStateWakePersistence({ stateDir });
+    expect(await persistence.load()).toEqual([]);
+  });
+
+  it("round-trips wake entries through state.yaml keyed by id", async () => {
+    const persistence = new FleetStateWakePersistence({ stateDir });
+    const wakes = [entry({ id: "a" }), entry({ id: "b", sessionId: "sess-2" })];
+    await persistence.save(wakes);
+
+    const reloaded = await persistence.load();
+    expect(reloaded.map((e) => e.id).sort()).toEqual(["a", "b"]);
+
+    // Persisted as a keyed record under session_wakes.
+    const raw = await readFile(join(stateDir, STATE_FILE_NAME), "utf8");
+    expect(raw).toContain("session_wakes");
+    expect(raw).toContain("a");
+  });
+
+  it("overwrites the previous set (save is a full replace)", async () => {
+    const persistence = new FleetStateWakePersistence({ stateDir });
+    await persistence.save([entry({ id: "a" }), entry({ id: "b" })]);
+    await persistence.save([entry({ id: "c" })]);
+    expect((await persistence.load()).map((e) => e.id)).toEqual(["c"]);
+  });
+
+  it("preserves unrelated fleet state when saving wakes", async () => {
+    const stateFilePath = join(stateDir, STATE_FILE_NAME);
+    await writeFleetState(stateFilePath, {
+      fleet: { started_at: NOW.toISOString() },
+      agents: { "team/agent": { status: "running", current_job: "job-1" } },
+    });
+
+    const persistence = new FleetStateWakePersistence({ stateDir });
+    await persistence.save([entry({ id: "a" })]);
+
+    const state = await readFleetState(stateFilePath);
+    expect(state.fleet.started_at).toBe(NOW.toISOString());
+    expect(state.agents["team/agent"].current_job).toBe("job-1");
+    expect(Object.keys(state.session_wakes ?? {})).toEqual(["a"]);
+  });
+});

--- a/packages/core/src/session/__tests__/reaper-policy.test.ts
+++ b/packages/core/src/session/__tests__/reaper-policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { decideReap } from "../reaper-policy.js";
+import type { SessionLifecycleSignal } from "../types.js";
+
+function signal(overrides: Partial<SessionLifecycleSignal> = {}): SessionLifecycleSignal {
+  return {
+    kind: "turn_end",
+    sessionId: "sess-1",
+    sessionCrons: [],
+    backgroundTasks: [],
+    ...overrides,
+  };
+}
+
+describe("decideReap", () => {
+  it("reaps an idle session with no background work", () => {
+    expect(decideReap(signal())).toEqual({ action: "reap" });
+  });
+
+  it("reaps even when timer-class wakeups are pending (they are re-triggered, not pinned)", () => {
+    const decision = decideReap(
+      signal({
+        sessionCrons: [{ id: "c1", schedule: "*/5 * * * *", recurring: true, prompt: "go" }],
+      }),
+    );
+    expect(decision).toEqual({ action: "reap" });
+  });
+
+  it("keeps alive while continuous-class background work is running", () => {
+    const tasks = [{ id: "t1", type: "shell", status: "running", description: "dev server" }];
+    const decision = decideReap(signal({ backgroundTasks: tasks }));
+    expect(decision.action).toBe("keepAlive");
+    if (decision.action === "keepAlive") {
+      expect(decision.reason).toBe("background_tasks");
+      expect(decision.tasks).toEqual(tasks);
+    }
+  });
+});

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -1,0 +1,118 @@
+import type { HookInput } from "@anthropic-ai/claude-agent-sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { SDKMessage } from "../../runner/types.js";
+import { buildLifecycleHooks, tapLifecycleStream } from "../session-hooks.js";
+import type { SessionLifecycleSignal } from "../types.js";
+
+function stopInput(overrides: Partial<HookInput> = {}): HookInput {
+  return {
+    hook_event_name: "Stop",
+    session_id: "sess-1",
+    transcript_path: "/tmp/t.jsonl",
+    cwd: "/tmp",
+    stop_hook_active: false,
+    session_crons: [{ id: "c1", schedule: "35 13 * * *", recurring: false, prompt: "go" }],
+    background_tasks: [],
+    ...overrides,
+  } as HookInput;
+}
+
+async function* stream(messages: SDKMessage[]): AsyncGenerator<SDKMessage> {
+  for (const m of messages) yield m;
+}
+
+describe("buildLifecycleHooks", () => {
+  it("registers Stop and SubagentStop matchers", () => {
+    const hooks = buildLifecycleHooks(vi.fn());
+    expect(hooks?.Stop?.[0].hooks).toHaveLength(1);
+    expect(hooks?.SubagentStop?.[0].hooks).toHaveLength(1);
+  });
+
+  it("forwards a turn_end signal carrying the crons/tasks snapshot", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    const result = await cb(stopInput(), undefined, { signal: new AbortController().signal });
+
+    expect(result).toEqual({ continue: true });
+    expect(sink).toHaveBeenCalledTimes(1);
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal).toMatchObject({
+      kind: "turn_end",
+      sessionId: "sess-1",
+      sessionCrons: [{ id: "c1", recurring: false }],
+      backgroundTasks: [],
+    });
+  });
+
+  it("defaults absent crons/tasks to empty arrays", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    await cb(stopInput({ session_crons: undefined, background_tasks: undefined }), undefined, {
+      signal: new AbortController().signal,
+    });
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.sessionCrons).toEqual([]);
+    expect(signal.backgroundTasks).toEqual([]);
+  });
+
+  it("does nothing for non-stop hook inputs", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    const other = { hook_event_name: "PreToolUse", session_id: "s" } as unknown as HookInput;
+    await cb(other, undefined, { signal: new AbortController().signal });
+    expect(sink).not.toHaveBeenCalled();
+  });
+});
+
+describe("tapLifecycleStream", () => {
+  it("yields every message through unchanged", async () => {
+    const messages: SDKMessage[] = [
+      { type: "assistant", session_id: "s" },
+      { type: "result", session_id: "s" },
+    ];
+    const out: SDKMessage[] = [];
+    for await (const m of tapLifecycleStream(stream(messages), vi.fn())) out.push(m);
+    expect(out).toEqual(messages);
+  });
+
+  it("emits a background_tasks_changed signal with mapped tasks", async () => {
+    const sink = vi.fn();
+    const messages: SDKMessage[] = [
+      {
+        type: "system",
+        subtype: "background_tasks_changed",
+        session_id: "sess-1",
+        tasks: [{ task_id: "t1", task_type: "shell", description: "dev server" }],
+      } as unknown as SDKMessage,
+    ];
+    for await (const _ of tapLifecycleStream(stream(messages), sink)) {
+      /* drain */
+    }
+    expect(sink).toHaveBeenCalledTimes(1);
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.kind).toBe("background_tasks_changed");
+    expect(signal.backgroundTasks).toEqual([
+      { id: "t1", type: "shell", status: "running", description: "dev server" },
+    ]);
+  });
+
+  it("emits exactly one activity signal per turn (reset on result)", async () => {
+    const sink = vi.fn();
+    const messages: SDKMessage[] = [
+      { type: "assistant", session_id: "s" },
+      { type: "assistant", session_id: "s" },
+      { type: "result", session_id: "s" },
+      { type: "assistant", session_id: "s" },
+    ];
+    for await (const _ of tapLifecycleStream(stream(messages), sink)) {
+      /* drain */
+    }
+    const activity = sink.mock.calls
+      .map((c) => c[0] as SessionLifecycleSignal)
+      .filter((s) => s.kind === "activity");
+    expect(activity).toHaveLength(2);
+  });
+});

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -65,6 +65,17 @@ describe("buildLifecycleHooks", () => {
     await cb(other, undefined, { signal: new AbortController().signal });
     expect(sink).not.toHaveBeenCalled();
   });
+
+  it("resolves { continue: true } even when the sink rejects", async () => {
+    const sink = vi.fn().mockRejectedValue(new Error("sink boom"));
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    await expect(
+      cb(stopInput(), undefined, { signal: new AbortController().signal }),
+    ).resolves.toEqual({ continue: true });
+    // Let the swallowed rejection settle so it can't surface as unhandled.
+    await new Promise((r) => setTimeout(r, 5));
+  });
 });
 
 describe("tapLifecycleStream", () => {
@@ -97,6 +108,18 @@ describe("tapLifecycleStream", () => {
     expect(signal.backgroundTasks).toEqual([
       { id: "t1", type: "shell", status: "running", description: "dev server" },
     ]);
+  });
+
+  it("keeps streaming when the sink rejects (no unhandled rejection)", async () => {
+    const sink = vi.fn().mockRejectedValue(new Error("sink boom"));
+    const messages: SDKMessage[] = [
+      { type: "assistant", session_id: "s" },
+      { type: "result", session_id: "s" },
+    ];
+    const out: SDKMessage[] = [];
+    for await (const m of tapLifecycleStream(stream(messages), sink)) out.push(m);
+    expect(out).toEqual(messages);
+    await new Promise((r) => setTimeout(r, 5));
   });
 
   it("emits exactly one activity signal per turn (reset on result)", async () => {

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeSession } from "../../runner/runtime/interface.js";
+import { SessionReaper } from "../session-reaper.js";
+import type { SessionLifecycleSignal } from "../types.js";
+import type { WakeRegistry } from "../wake-registry.js";
+
+const tick = () => new Promise((r) => setTimeout(r, 5));
+
+function fakeSession(): RuntimeSession & { close: ReturnType<typeof vi.fn> } {
+  async function* empty(): AsyncGenerator<never> {}
+  return {
+    messages: empty(),
+    send: vi.fn().mockResolvedValue(undefined),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    listCommands: vi.fn().mockResolvedValue([]),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function fakeRegistry() {
+  return { reconcile: vi.fn().mockResolvedValue(undefined) } as unknown as WakeRegistry & {
+    reconcile: ReturnType<typeof vi.fn>;
+  };
+}
+
+function signal(overrides: Partial<SessionLifecycleSignal> = {}): SessionLifecycleSignal {
+  return {
+    kind: "turn_end",
+    sessionId: "sess-1",
+    sessionCrons: [],
+    backgroundTasks: [],
+    ...overrides,
+  };
+}
+
+const TASK = { id: "t1", type: "shell", status: "running", description: "server" };
+
+describe("SessionReaper", () => {
+  it("reaps an idle session: reconciles crons, fires onReap, closes", async () => {
+    const registry = fakeRegistry();
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry, onReap });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    const crons = [{ id: "c1", schedule: "35 13 * * *", recurring: false, prompt: "go" }];
+    await managed.handleSignal(signal({ sessionCrons: crons }));
+
+    expect(registry.reconcile).toHaveBeenCalledWith("team/agent", "sess-1", crons);
+    expect(onReap).toHaveBeenCalledWith({ agent: "team/agent", sessionId: "sess-1" });
+    expect(managed.isLive()).toBe(false);
+    await tick();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a session alive while background tasks are running", async () => {
+    const registry = fakeRegistry();
+    const onKeepAlive = vi.fn();
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry, onKeepAlive, onReap });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+
+    expect(onKeepAlive).toHaveBeenCalledWith({
+      agent: "team/agent",
+      sessionId: "sess-1",
+      tasks: [TASK],
+    });
+    expect(onReap).not.toHaveBeenCalled();
+    expect(managed.isLive()).toBe(true);
+    await tick();
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("reaps a kept-alive session once background_tasks_changed reports empty", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+    expect(managed.isLive()).toBe(true);
+
+    await managed.handleSignal(signal({ kind: "background_tasks_changed", backgroundTasks: [] }));
+    expect(managed.isLive()).toBe(false);
+    await tick();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores background_tasks_changed when the session was never kept alive", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ kind: "background_tasks_changed", backgroundTasks: [] }));
+    expect(managed.isLive()).toBe(true);
+    await tick();
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("does not reap mid-turn: activity clears the idle-waiting state", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    // Kept alive, then the consumer resumes the session (activity), then a task ends.
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+    await managed.handleSignal(signal({ kind: "activity" }));
+    await managed.handleSignal(signal({ kind: "background_tasks_changed", backgroundTasks: [] }));
+
+    expect(managed.isLive()).toBe(true);
+    await tick();
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("tracks session liveness for the registry", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const managed = reaper.manage(fakeSession(), "team/agent");
+    expect(reaper.isSessionLive("sess-1")).toBe(false);
+
+    await managed.handleSignal(signal({ kind: "activity" }));
+    expect(reaper.isSessionLive("sess-1")).toBe(true);
+
+    await managed.handleSignal(signal());
+    expect(reaper.isSessionLive("sess-1")).toBe(false);
+  });
+
+  it("ignores signals after the session has been reaped", async () => {
+    const registry = fakeRegistry();
+    const reaper = new SessionReaper({ registry });
+    const managed = reaper.manage(fakeSession(), "team/agent");
+
+    await managed.handleSignal(signal());
+    registry.reconcile.mockClear();
+    await managed.handleSignal(
+      signal({ sessionCrons: [{ id: "x", schedule: "* * * * *", recurring: true, prompt: "p" }] }),
+    );
+    expect(registry.reconcile).not.toHaveBeenCalled();
+  });
+
+  it("detach stops management without reaping", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+    await managed.handleSignal(signal({ kind: "activity" }));
+
+    managed.detach();
+    expect(managed.isLive()).toBe(false);
+    expect(reaper.isSessionLive("sess-1")).toBe(false);
+    await tick();
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("exposes the resolved session id once learned", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const managed = reaper.manage(fakeSession(), "team/agent");
+    expect(managed.sessionId()).toBeUndefined();
+    await managed.handleSignal(signal({ sessionId: "sess-42", kind: "activity" }));
+    expect(managed.sessionId()).toBe("sess-42");
+  });
+});

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -160,4 +160,58 @@ describe("SessionReaper", () => {
     await managed.handleSignal(signal({ sessionId: "sess-42", kind: "activity" }));
     expect(managed.sessionId()).toBe("sess-42");
   });
+
+  it("still closes the session when the onReap callback throws", async () => {
+    const reaper = new SessionReaper({
+      registry: fakeRegistry(),
+      onReap: () => {
+        throw new Error("consumer boom");
+      },
+    });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal());
+    expect(managed.isLive()).toBe(false);
+    await tick();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("reaps even when wake reconciliation fails", async () => {
+    const registry = {
+      reconcile: vi.fn().mockRejectedValue(new Error("state io error")),
+    } as unknown as WakeRegistry;
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry, onReap });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(
+      signal({
+        sessionCrons: [{ id: "c1", schedule: "* * * * *", recurring: false, prompt: "p" }],
+      }),
+    );
+    expect(onReap).toHaveBeenCalledTimes(1);
+    await tick();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps processing signals after a failed reconcile (no queue wedge)", async () => {
+    const registry = {
+      reconcile: vi.fn().mockRejectedValueOnce(new Error("io")).mockResolvedValue(undefined),
+    } as unknown as WakeRegistry;
+    const reaper = new SessionReaper({ registry });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    // First turn_end keeps the session alive (its reconcile rejects but is caught).
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+    expect(managed.isLive()).toBe(true);
+
+    // A later signal must still be processed — the queue wasn't poisoned.
+    await managed.handleSignal(signal({ kind: "background_tasks_changed", backgroundTasks: [] }));
+    expect(managed.isLive()).toBe(false);
+    await tick();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/core/src/session/__tests__/wake-registry.test.ts
+++ b/packages/core/src/session/__tests__/wake-registry.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionWakeEntry } from "../types.js";
+import { type WakePersistence, WakeRegistry } from "../wake-registry.js";
+import { RECURRING_WAKE_MAX_AGE_MS } from "../wake-store.js";
+
+const NOW = new Date("2026-07-09T12:00:00.000Z");
+const resolveNextRun = (_s: string, from: Date) => new Date(from.getTime() + 5 * 60_000);
+
+/** In-memory persistence returning independent copies (like a real read). */
+function memoryPersistence(initial: SessionWakeEntry[] = []): WakePersistence & {
+  entries: SessionWakeEntry[];
+} {
+  let store = [...initial];
+  return {
+    get entries() {
+      return store;
+    },
+    load: async () => store.map((e) => ({ ...e })),
+    save: async (entries) => {
+      store = entries.map((e) => ({ ...e }));
+    },
+  };
+}
+
+function entry(overrides: Partial<SessionWakeEntry> = {}): SessionWakeEntry {
+  return {
+    id: "c1",
+    agent: "team/agent",
+    sessionId: "sess-1",
+    schedule: "*/5 * * * *",
+    recurring: false,
+    prompt: "WAKE",
+    nextRunAt: new Date(NOW.getTime() - 1000).toISOString(),
+    createdAt: NOW.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("WakeRegistry.reconcile", () => {
+  it("captures pending crons into persistence", async () => {
+    const persistence = memoryPersistence();
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire: vi.fn() });
+    await registry.reconcile(
+      "team/agent",
+      "sess-1",
+      [{ id: "c1", schedule: "*/5 * * * *", recurring: true, prompt: "go" }],
+      NOW,
+    );
+    expect(persistence.entries).toHaveLength(1);
+    expect(persistence.entries[0]).toMatchObject({ id: "c1", recurring: true });
+  });
+
+  it("prunes expired recurring wakes on reconcile", async () => {
+    const aged = entry({
+      id: "aged",
+      recurring: true,
+      createdAt: new Date(NOW.getTime() - RECURRING_WAKE_MAX_AGE_MS - 1).toISOString(),
+    });
+    const persistence = memoryPersistence([aged]);
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire: vi.fn() });
+    await registry.reconcile("team/agent", "sess-2", [], NOW);
+    expect(persistence.entries).toEqual([]);
+  });
+});
+
+describe("WakeRegistry.dispatchDue", () => {
+  it("fires due wakes and drops one-shots afterward", async () => {
+    const persistence = memoryPersistence([entry({ id: "one", recurring: false })]);
+    const fire = vi.fn().mockResolvedValue(undefined);
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire });
+    const dispatched = await registry.dispatchDue(NOW);
+    expect(dispatched.map((e) => e.id)).toEqual(["one"]);
+    expect(fire).toHaveBeenCalledTimes(1);
+    expect(persistence.entries).toEqual([]);
+  });
+
+  it("advances recurring wakes to their next fire time", async () => {
+    const persistence = memoryPersistence([entry({ id: "rec", recurring: true })]);
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire: vi.fn() });
+    await registry.dispatchDue(NOW);
+    expect(persistence.entries).toHaveLength(1);
+    expect(persistence.entries[0].nextRunAt).toBe(
+      new Date(NOW.getTime() + 5 * 60_000).toISOString(),
+    );
+  });
+
+  it("skips wakes whose session is currently live (gap 6)", async () => {
+    const persistence = memoryPersistence([entry({ id: "live", sessionId: "sess-live" })]);
+    const fire = vi.fn();
+    const registry = new WakeRegistry({
+      persistence,
+      resolveNextRun,
+      fire,
+      isSessionLive: (id) => id === "sess-live",
+    });
+    const dispatched = await registry.dispatchDue(NOW);
+    expect(dispatched).toEqual([]);
+    expect(fire).not.toHaveBeenCalled();
+    // Left in place, not dropped — the live session re-captures it.
+    expect(persistence.entries).toHaveLength(1);
+  });
+
+  it("does not fire wakes that are not yet due", async () => {
+    const persistence = memoryPersistence([
+      entry({ id: "future", nextRunAt: new Date(NOW.getTime() + 60_000).toISOString() }),
+    ]);
+    const fire = vi.fn();
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire });
+    expect(await registry.dispatchDue(NOW)).toEqual([]);
+    expect(fire).not.toHaveBeenCalled();
+  });
+
+  it("respects the concurrency limit", async () => {
+    const many = Array.from({ length: 6 }, (_, i) => entry({ id: `w${i}`, recurring: true }));
+    const persistence = memoryPersistence(many);
+    let inFlight = 0;
+    let peak = 0;
+    const fire = vi.fn().mockImplementation(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+    });
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire, concurrency: 2 });
+    await registry.dispatchDue(NOW);
+    expect(fire).toHaveBeenCalledTimes(6);
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  it("swallows a fire error without wedging (recurring already advanced)", async () => {
+    const persistence = memoryPersistence([entry({ id: "rec", recurring: true })]);
+    const fire = vi.fn().mockRejectedValue(new Error("boom"));
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire });
+    await expect(registry.dispatchDue(NOW)).resolves.toHaveLength(1);
+    // Advanced despite the failed fire — it simply retries next cycle.
+    expect(persistence.entries[0].nextRunAt).toBe(
+      new Date(NOW.getTime() + 5 * 60_000).toISOString(),
+    );
+  });
+});
+
+describe("WakeRegistry.remove / forgetSession", () => {
+  it("removes a single wake by id", async () => {
+    const persistence = memoryPersistence([entry({ id: "a" }), entry({ id: "b" })]);
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire: vi.fn() });
+    await registry.remove("a");
+    expect(persistence.entries.map((e) => e.id)).toEqual(["b"]);
+  });
+
+  it("forgets all wakes for a session", async () => {
+    const persistence = memoryPersistence([
+      entry({ id: "a", sessionId: "s1" }),
+      entry({ id: "b", sessionId: "s2" }),
+    ]);
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire: vi.fn() });
+    await registry.forgetSession("s1");
+    expect(persistence.entries.map((e) => e.id)).toEqual(["b"]);
+  });
+});

--- a/packages/core/src/session/__tests__/wake-store.test.ts
+++ b/packages/core/src/session/__tests__/wake-store.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import type { SessionCronSummary, SessionWakeEntry } from "../types.js";
+import {
+  advanceWake,
+  findDueWakes,
+  isExpired,
+  pruneExpiredWakes,
+  RECURRING_WAKE_MAX_AGE_MS,
+  reconcileSessionWakes,
+  removeSessionWakes,
+  removeWake,
+} from "../wake-store.js";
+
+const NOW = new Date("2026-07-09T12:00:00.000Z");
+
+/** Deterministic resolver: next run is always 5 minutes after `from`. */
+const resolveNextRun = (_schedule: string, from: Date) => new Date(from.getTime() + 5 * 60_000);
+
+function cron(overrides: Partial<SessionCronSummary> = {}): SessionCronSummary {
+  return { id: "c1", schedule: "35 13 * * *", recurring: false, prompt: "WAKE", ...overrides };
+}
+
+function entry(overrides: Partial<SessionWakeEntry> = {}): SessionWakeEntry {
+  return {
+    id: "c1",
+    agent: "team/agent",
+    sessionId: "sess-1",
+    schedule: "35 13 * * *",
+    recurring: false,
+    prompt: "WAKE",
+    nextRunAt: new Date(NOW.getTime() + 60_000).toISOString(),
+    createdAt: NOW.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("reconcileSessionWakes", () => {
+  it("captures a new cron with a resolved absolute nextRunAt", () => {
+    const result = reconcileSessionWakes({
+      existing: [],
+      agent: "team/agent",
+      sessionId: "sess-1",
+      sessionCrons: [cron()],
+      now: NOW,
+      resolveNextRun,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "c1",
+      agent: "team/agent",
+      sessionId: "sess-1",
+      recurring: false,
+      prompt: "WAKE",
+      nextRunAt: new Date(NOW.getTime() + 5 * 60_000).toISOString(),
+      createdAt: NOW.toISOString(),
+    });
+  });
+
+  it("keeps a known id unchanged (does not reset the cycle)", () => {
+    const existing = [entry({ id: "c1", nextRunAt: "2026-07-09T13:35:00.000Z" })];
+    const result = reconcileSessionWakes({
+      existing,
+      agent: "team/agent",
+      sessionId: "sess-1",
+      sessionCrons: [cron({ id: "c1", prompt: "changed" })],
+      now: NOW,
+      resolveNextRun,
+    });
+    expect(result).toHaveLength(1);
+    // Preserved verbatim — including the original prompt and nextRunAt.
+    expect(result[0]).toEqual(existing[0]);
+  });
+
+  it("drops a one-shot that is no longer reported (fired or cancelled)", () => {
+    const existing = [entry({ id: "one", recurring: false })];
+    const result = reconcileSessionWakes({
+      existing,
+      agent: "team/agent",
+      sessionId: "sess-1",
+      sessionCrons: [],
+      now: NOW,
+      resolveNextRun,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("keeps a recurring wake even when a resumed turn reports it empty (gap 4)", () => {
+    const existing = [entry({ id: "rec", recurring: true })];
+    const result = reconcileSessionWakes({
+      existing,
+      agent: "team/agent",
+      sessionId: "sess-1",
+      sessionCrons: [],
+      now: NOW,
+      resolveNextRun,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("rec");
+  });
+
+  it("leaves other sessions' wakes untouched", () => {
+    const mine = entry({ id: "mine", sessionId: "sess-1", recurring: false });
+    const other = entry({ id: "other", sessionId: "sess-2", recurring: false });
+    const result = reconcileSessionWakes({
+      existing: [mine, other],
+      agent: "team/agent",
+      sessionId: "sess-1",
+      sessionCrons: [],
+      now: NOW,
+      resolveNextRun,
+    });
+    expect(result.map((e) => e.id)).toEqual(["other"]);
+  });
+
+  it("adds new and drops stale one-shots in one pass", () => {
+    const stale = entry({ id: "stale", recurring: false });
+    const result = reconcileSessionWakes({
+      existing: [stale],
+      agent: "team/agent",
+      sessionId: "sess-1",
+      sessionCrons: [cron({ id: "fresh" })],
+      now: NOW,
+      resolveNextRun,
+    });
+    expect(result.map((e) => e.id).sort()).toEqual(["fresh"]);
+  });
+});
+
+describe("advanceWake", () => {
+  it("returns null for a one-shot (fire once)", () => {
+    expect(advanceWake(entry({ recurring: false }), NOW, resolveNextRun)).toBeNull();
+  });
+
+  it("advances a recurring wake to its next fire time", () => {
+    const advanced = advanceWake(entry({ recurring: true }), NOW, resolveNextRun);
+    expect(advanced?.nextRunAt).toBe(new Date(NOW.getTime() + 5 * 60_000).toISOString());
+  });
+
+  it("returns null for a recurring wake past its 7-day lifetime", () => {
+    const old = entry({
+      recurring: true,
+      createdAt: new Date(NOW.getTime() - RECURRING_WAKE_MAX_AGE_MS - 1000).toISOString(),
+    });
+    expect(advanceWake(old, NOW, resolveNextRun)).toBeNull();
+  });
+});
+
+describe("isExpired / pruneExpiredWakes", () => {
+  it("one-shots never expire on age", () => {
+    const old = entry({
+      recurring: false,
+      createdAt: new Date(NOW.getTime() - RECURRING_WAKE_MAX_AGE_MS * 2).toISOString(),
+    });
+    expect(isExpired(old, NOW)).toBe(false);
+  });
+
+  it("prunes only aged recurring wakes", () => {
+    const fresh = entry({ id: "fresh", recurring: true, createdAt: NOW.toISOString() });
+    const aged = entry({
+      id: "aged",
+      recurring: true,
+      createdAt: new Date(NOW.getTime() - RECURRING_WAKE_MAX_AGE_MS - 1).toISOString(),
+    });
+    const result = pruneExpiredWakes([fresh, aged], NOW);
+    expect(result.map((e) => e.id)).toEqual(["fresh"]);
+  });
+});
+
+describe("removeWake / removeSessionWakes / findDueWakes", () => {
+  it("removes a wake by id", () => {
+    expect(removeWake([entry({ id: "a" }), entry({ id: "b" })], "a").map((e) => e.id)).toEqual([
+      "b",
+    ]);
+  });
+
+  it("removes all wakes for a session", () => {
+    const a = entry({ id: "a", sessionId: "sess-1" });
+    const b = entry({ id: "b", sessionId: "sess-2" });
+    expect(removeSessionWakes([a, b], "sess-1").map((e) => e.id)).toEqual(["b"]);
+  });
+
+  it("finds wakes due at or before now", () => {
+    const due = entry({ id: "due", nextRunAt: new Date(NOW.getTime() - 1).toISOString() });
+    const exact = entry({ id: "exact", nextRunAt: NOW.toISOString() });
+    const future = entry({ id: "future", nextRunAt: new Date(NOW.getTime() + 1).toISOString() });
+    expect(
+      findDueWakes([due, exact, future], NOW)
+        .map((e) => e.id)
+        .sort(),
+    ).toEqual(["due", "exact"]);
+  });
+});

--- a/packages/core/src/session/fleet-state-wake-persistence.ts
+++ b/packages/core/src/session/fleet-state-wake-persistence.ts
@@ -1,0 +1,46 @@
+/**
+ * {@link WakePersistence} backed by the fleet state file (`.herdctl/state.yaml`).
+ *
+ * Session wakes live under the top-level `session_wakes` record, keyed by SDK
+ * cron id. Reads/writes go through the same atomic `readFleetState` /
+ * `writeFleetState` helpers the scheduler uses, so wakes are durable across a
+ * fleet restart alongside the rest of fleet state.
+ */
+
+import { join } from "node:path";
+import { readFleetState, writeFleetState } from "../state/fleet-state.js";
+import { STATE_FILE_NAME } from "../state/types.js";
+import type { SessionWakeEntry } from "./types.js";
+import type { WakePersistence } from "./wake-registry.js";
+
+export interface FleetStateWakePersistenceOptions {
+  /** The state directory (`.herdctl`); the state file is `<stateDir>/state.yaml`. */
+  stateDir: string;
+}
+
+/**
+ * Persist the session-wake set inside the fleet state file. The registry's
+ * async lock serializes calls, so read-modify-write here is race-free within the
+ * fleet process.
+ */
+export class FleetStateWakePersistence implements WakePersistence {
+  private readonly stateFilePath: string;
+
+  constructor(options: FleetStateWakePersistenceOptions) {
+    this.stateFilePath = join(options.stateDir, STATE_FILE_NAME);
+  }
+
+  async load(): Promise<SessionWakeEntry[]> {
+    const state = await readFleetState(this.stateFilePath);
+    return Object.values(state.session_wakes ?? {});
+  }
+
+  async save(entries: SessionWakeEntry[]): Promise<void> {
+    const state = await readFleetState(this.stateFilePath);
+    const session_wakes: Record<string, SessionWakeEntry> = {};
+    for (const entry of entries) {
+      session_wakes[entry.id] = entry;
+    }
+    await writeFleetState(this.stateFilePath, { ...state, session_wakes });
+  }
+}

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Streaming-session lifecycle management: reap idle sessions and re-trigger the
+ * timer-class wakeups they leave behind. See edspencer/herdctl#307.
+ */
+
+export * from "./fleet-state-wake-persistence.js";
+export * from "./reaper-policy.js";
+export * from "./session-hooks.js";
+export * from "./session-reaper.js";
+export * from "./types.js";
+export * from "./wake-registry.js";
+export * from "./wake-store.js";

--- a/packages/core/src/session/reaper-policy.ts
+++ b/packages/core/src/session/reaper-policy.ts
@@ -1,0 +1,44 @@
+/**
+ * The reaper decision — one rule, no timers.
+ *
+ * Reaping a streaming session is cheap and lossless (measured on SDK 0.3.205):
+ * resume recovers the full conversation, cold respawn → `init` ≈ 0.5 s, and the
+ * Anthropic prompt cache is server-side so it survives the reap. Keeping an idle
+ * session warm therefore buys ~1 s and costs ~300 MB — a false economy. So the
+ * only reason to keep a session alive is *live background work* that reaping
+ * would kill. Everything else is reaped the instant it goes idle. No idle timer,
+ * no max-lifetime backstop, no idle-concurrency cap. See edspencer/herdctl#307.
+ */
+
+import type { SessionLifecycleSignal } from "./types.js";
+
+/**
+ * What to do with a session that has just gone idle.
+ *
+ * - `reap`: no continuous-class work is running — close the process now (after
+ *   sweeping any `sessionCrons` into the scheduler).
+ * - `keepAlive`: continuous-class background work is in flight; closing would
+ *   kill it. Hold the process open and re-evaluate when the task set changes.
+ */
+export type ReapDecision =
+  | { action: "reap" }
+  | {
+      action: "keepAlive";
+      reason: "background_tasks";
+      tasks: SessionLifecycleSignal["backgroundTasks"];
+    };
+
+/**
+ * Decide whether an idle session should be reaped.
+ *
+ * The rule is deliberately total and stateless: keep the session alive **iff**
+ * it holds live background work; otherwise reap. Timer-class `sessionCrons` do
+ * **not** keep a session alive — they are captured and re-triggered by the
+ * scheduler, so a session with only pending wakeups is still reaped.
+ */
+export function decideReap(signal: SessionLifecycleSignal): ReapDecision {
+  if (signal.backgroundTasks.length > 0) {
+    return { action: "keepAlive", reason: "background_tasks", tasks: signal.backgroundTasks };
+  }
+  return { action: "reap" };
+}

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -21,10 +21,26 @@ import type {
   SubagentStopHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKMessage } from "../runner/types.js";
+import { createLogger } from "../utils/logger.js";
 import type { SessionLifecycleSignal } from "./types.js";
+
+const logger = createLogger("session-hooks");
 
 /** Receiver for lifecycle signals (the session-reaper's `handleSignal`). */
 export type LifecycleSignalSink = (signal: SessionLifecycleSignal) => void | Promise<void>;
+
+/**
+ * Deliver a signal to the sink without blocking the caller, observing (and
+ * logging) any rejection so a failing sink can't surface as an unhandled promise
+ * rejection (which crashes Node 15+).
+ */
+function emit(sink: LifecycleSignalSink, signal: SessionLifecycleSignal): void {
+  void Promise.resolve()
+    .then(() => sink(signal))
+    .catch((error: unknown) => {
+      logger.warn(`Lifecycle signal sink threw (${signal.kind}): ${(error as Error).message}`);
+    });
+}
 
 function isStopLike(input: HookInput): input is StopHookInput | SubagentStopHookInput {
   return input.hook_event_name === "Stop" || input.hook_event_name === "SubagentStop";
@@ -40,12 +56,9 @@ export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"]
     if (isStopLike(input)) {
       const sessionCrons: SessionCronSummary[] = input.session_crons ?? [];
       const backgroundTasks: BackgroundTaskSummary[] = input.background_tasks ?? [];
-      await sink({
-        kind: "turn_end",
-        sessionId: input.session_id,
-        sessionCrons,
-        backgroundTasks,
-      });
+      // Never let a sink failure reject the hook (which would disrupt turn flow);
+      // log and continue. `emit` observes the async rejection off the hot path.
+      emit(sink, { kind: "turn_end", sessionId: input.session_id, sessionCrons, backgroundTasks });
     }
     return { continue: true };
   };
@@ -97,7 +110,7 @@ export async function* tapLifecycleStream(
   for await (const message of source) {
     if (message.type === "system" && message.subtype === "background_tasks_changed") {
       const rawTasks = (message.tasks as BackgroundTasksChangedEntry[] | undefined) ?? [];
-      void sink({
+      emit(sink, {
         kind: "background_tasks_changed",
         sessionId: message.session_id ?? "",
         sessionCrons: [],
@@ -106,7 +119,7 @@ export async function* tapLifecycleStream(
     } else if (message.type === "assistant") {
       if (!activityForwarded) {
         activityForwarded = true;
-        void sink({
+        emit(sink, {
           kind: "activity",
           sessionId: message.session_id ?? "",
           sessionCrons: [],

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -1,0 +1,122 @@
+/**
+ * Translate SDK lifecycle events into herdctl {@link SessionLifecycleSignal}s.
+ *
+ * Two surfaces feed the session-reaper:
+ * - {@link buildLifecycleHooks} — `Stop`/`SubagentStop` hooks that carry the
+ *   authoritative turn-boundary snapshot (`session_crons` + `background_tasks`).
+ * - {@link tapLifecycleStream} — a pass-through over the session's message
+ *   stream that surfaces mid-turn `background_tasks_changed` events and a single
+ *   "a new turn started" activity marker per turn.
+ *
+ * Kept separate from the SDK runtime so the mapping is unit-testable without a
+ * live `claude` process. See edspencer/herdctl#307.
+ */
+
+import type {
+  BackgroundTaskSummary,
+  HookInput,
+  Options,
+  SessionCronSummary,
+  StopHookInput,
+  SubagentStopHookInput,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { SDKMessage } from "../runner/types.js";
+import type { SessionLifecycleSignal } from "./types.js";
+
+/** Receiver for lifecycle signals (the session-reaper's `handleSignal`). */
+export type LifecycleSignalSink = (signal: SessionLifecycleSignal) => void | Promise<void>;
+
+function isStopLike(input: HookInput): input is StopHookInput | SubagentStopHookInput {
+  return input.hook_event_name === "Stop" || input.hook_event_name === "SubagentStop";
+}
+
+/**
+ * Build the `Stop`/`SubagentStop` hooks that forward each turn-boundary snapshot
+ * to `sink`. The hook awaits the sink so cron capture completes before the turn
+ * unwinds, then returns `{ continue: true }` to leave turn flow untouched.
+ */
+export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"] {
+  const callback = async (input: HookInput) => {
+    if (isStopLike(input)) {
+      const sessionCrons: SessionCronSummary[] = input.session_crons ?? [];
+      const backgroundTasks: BackgroundTaskSummary[] = input.background_tasks ?? [];
+      await sink({
+        kind: "turn_end",
+        sessionId: input.session_id,
+        sessionCrons,
+        backgroundTasks,
+      });
+    }
+    return { continue: true };
+  };
+
+  return {
+    Stop: [{ hooks: [callback] }],
+    SubagentStop: [{ hooks: [callback] }],
+  };
+}
+
+/** Shape of the `background_tasks_changed` system message's `tasks` entries. */
+interface BackgroundTasksChangedEntry {
+  task_id: string;
+  task_type: string;
+  description: string;
+}
+
+/**
+ * Map the lean `background_tasks_changed` task entries onto the richer
+ * {@link BackgroundTaskSummary} the reaper consumes. Only the fields the reap
+ * decision needs are populated; the rest are left undefined.
+ */
+function toBackgroundTaskSummaries(tasks: BackgroundTasksChangedEntry[]): BackgroundTaskSummary[] {
+  return tasks.map((t) => ({
+    id: t.task_id,
+    type: t.task_type,
+    status: "running",
+    description: t.description,
+  }));
+}
+
+/**
+ * Wrap a session's message stream, yielding every message through unchanged
+ * while emitting lifecycle signals as a side effect:
+ * - `background_tasks_changed` system messages → a `background_tasks_changed`
+ *   signal (fresh task set; no crons).
+ * - the first `assistant` message after a turn boundary → one `activity` signal
+ *   (a new turn is underway), reset on each `result` message.
+ *
+ * Signals are fire-and-forget; the reaper serializes them internally, preserving
+ * stream order, so yielding to the consumer is never blocked.
+ */
+export async function* tapLifecycleStream(
+  source: AsyncIterable<SDKMessage>,
+  sink: LifecycleSignalSink,
+): AsyncGenerator<SDKMessage> {
+  let activityForwarded = false;
+
+  for await (const message of source) {
+    if (message.type === "system" && message.subtype === "background_tasks_changed") {
+      const rawTasks = (message.tasks as BackgroundTasksChangedEntry[] | undefined) ?? [];
+      void sink({
+        kind: "background_tasks_changed",
+        sessionId: message.session_id ?? "",
+        sessionCrons: [],
+        backgroundTasks: toBackgroundTaskSummaries(rawTasks),
+      });
+    } else if (message.type === "assistant") {
+      if (!activityForwarded) {
+        activityForwarded = true;
+        void sink({
+          kind: "activity",
+          sessionId: message.session_id ?? "",
+          sessionCrons: [],
+          backgroundTasks: [],
+        });
+      }
+    } else if (message.type === "result") {
+      activityForwarded = false;
+    }
+
+    yield message;
+  }
+}

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -1,0 +1,222 @@
+/**
+ * Ties a live streaming session to the reap decision.
+ *
+ * A managed session forwards its turn-boundary {@link SessionLifecycleSignal}s
+ * here (via `RuntimeExecuteOptions.onLifecycleSignal`, wired in the SDK runtime).
+ * On each signal the reaper (1) reconciles the session's pending crons into the
+ * {@link WakeRegistry} so they survive the reap, then (2) applies the one-rule
+ * {@link decideReap} policy: keep the process alive while continuous-class
+ * background work runs, otherwise close it immediately.
+ *
+ * The reaper also answers "is this session live?" for the registry, so a due
+ * wake never spawns a second process for a session that is still open (gap 6).
+ *
+ * See edspencer/herdctl#307.
+ */
+
+import type { RuntimeSession } from "../runner/runtime/interface.js";
+import { createLogger } from "../utils/logger.js";
+import { decideReap } from "./reaper-policy.js";
+import type { BackgroundTaskSummary, SessionLifecycleSignal } from "./types.js";
+import type { WakeRegistry } from "./wake-registry.js";
+
+type Logger = ReturnType<typeof createLogger>;
+
+export interface SessionReaperOptions {
+  /** Durable wake store the reaper reconciles captured crons into. */
+  registry: WakeRegistry;
+  logger?: Logger;
+  /** Notified when a managed session is reaped (idle, no background work). */
+  onReap?: (info: { agent: string; sessionId: string }) => void;
+  /** Notified when a session is held open because background work is running. */
+  onKeepAlive?: (info: {
+    agent: string;
+    sessionId: string;
+    tasks: BackgroundTaskSummary[];
+  }) => void;
+}
+
+/** A handle to a session the reaper is managing. */
+export interface ManagedSession {
+  /**
+   * Feed a turn-boundary signal to the reaper. Wire into
+   * `RuntimeExecuteOptions.onLifecycleSignal`. Returns a promise the caller may
+   * await (the Stop hook does) so reconciliation completes before the turn fully
+   * unwinds; the actual `close()` is deferred so it never re-enters the hook.
+   */
+  handleSignal(signal: SessionLifecycleSignal): Promise<void>;
+  /** True until the session has been reaped or detached. */
+  isLive(): boolean;
+  /** The resolved session id, once learned from the first signal (else undefined). */
+  sessionId(): string | undefined;
+  /** Stop managing without reaping — the consumer closed the session itself. */
+  detach(): void;
+}
+
+/**
+ * Owns the reap policy across every managed streaming session in a fleet.
+ *
+ * One reaper is shared by all sessions; {@link manage} returns a per-session
+ * {@link ManagedSession} handle. {@link isSessionLive} is passed to the
+ * {@link WakeRegistry} so it can defer wakes for still-open sessions.
+ */
+export class SessionReaper {
+  private readonly registry: WakeRegistry;
+  private readonly logger: Logger;
+  private readonly onReap?: SessionReaperOptions["onReap"];
+  private readonly onKeepAlive?: SessionReaperOptions["onKeepAlive"];
+
+  /** Live managed sessions by resolved session id. */
+  private readonly liveById = new Map<string, ManagedSessionImpl>();
+
+  constructor(options: SessionReaperOptions) {
+    this.registry = options.registry;
+    this.logger = options.logger ?? createLogger("session-reaper");
+    this.onReap = options.onReap;
+    this.onKeepAlive = options.onKeepAlive;
+  }
+
+  /** Begin managing a session's lifecycle. */
+  manage(session: RuntimeSession, agent: string): ManagedSession {
+    const managed = new ManagedSessionImpl(session, agent, this);
+    return managed;
+  }
+
+  /** True while any managed session with this id is open. Used by the registry. */
+  isSessionLive(sessionId: string): boolean {
+    return this.liveById.has(sessionId);
+  }
+
+  // --- internal, called by ManagedSessionImpl ---
+
+  registerLive(sessionId: string, managed: ManagedSessionImpl): void {
+    this.liveById.set(sessionId, managed);
+  }
+
+  unregisterLive(sessionId: string): void {
+    this.liveById.delete(sessionId);
+  }
+
+  async processSignal(managed: ManagedSessionImpl, signal: SessionLifecycleSignal): Promise<void> {
+    // A new turn is producing output — the session is no longer idle-waiting, so
+    // a later background_tasks_changed must not reap it out from under a live turn.
+    if (signal.kind === "activity") {
+      managed.setAwaitingTasks(false);
+      return;
+    }
+
+    // Mid-session task-set change: only meaningful while the session is idle and
+    // was being kept alive purely for background work. Do NOT reconcile crons —
+    // this event doesn't report session_crons (dropping stale ones would delete
+    // the pending wakeups).
+    if (signal.kind === "background_tasks_changed") {
+      if (managed.isAwaitingTasks() && signal.backgroundTasks.length === 0) {
+        this.reap(managed, signal.sessionId);
+      }
+      return;
+    }
+
+    // turn_end: authoritative snapshot. Capture pending crons first so they
+    // survive whatever we decide next.
+    await this.registry.reconcile(managed.agent, signal.sessionId, signal.sessionCrons);
+
+    const decision = decideReap(signal);
+    if (decision.action === "keepAlive") {
+      this.logger.debug(
+        `Keeping session ${signal.sessionId} (${managed.agent}) alive: ${decision.tasks.length} background task(s)`,
+      );
+      managed.setAwaitingTasks(true);
+      this.onKeepAlive?.({
+        agent: managed.agent,
+        sessionId: signal.sessionId,
+        tasks: decision.tasks,
+      });
+      return;
+    }
+
+    this.reap(managed, signal.sessionId);
+  }
+
+  private reap(managed: ManagedSessionImpl, sessionId: string): void {
+    if (!managed.isLive()) return;
+    this.logger.info(`Reaping idle session ${sessionId} (${managed.agent})`);
+    this.onReap?.({ agent: managed.agent, sessionId });
+    managed.scheduleClose();
+  }
+}
+
+/**
+ * Per-session state. Serializes signals through a promise chain so a
+ * `background_tasks_changed` re-check can't interleave with a Stop reconcile,
+ * and defers `close()` out of the hook that requested it.
+ */
+class ManagedSessionImpl implements ManagedSession {
+  readonly agent: string;
+  private readonly session: RuntimeSession;
+  private readonly reaper: SessionReaper;
+  private resolvedSessionId: string | undefined;
+  private live = true;
+  private closing = false;
+  private awaitingTasks = false;
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(session: RuntimeSession, agent: string, reaper: SessionReaper) {
+    this.session = session;
+    this.agent = agent;
+    this.reaper = reaper;
+  }
+
+  handleSignal(signal: SessionLifecycleSignal): Promise<void> {
+    if (!this.live) return Promise.resolve();
+
+    // Learn the session id from the first signal that carries one.
+    if (signal.sessionId && this.resolvedSessionId !== signal.sessionId) {
+      if (this.resolvedSessionId) this.reaper.unregisterLive(this.resolvedSessionId);
+      this.resolvedSessionId = signal.sessionId;
+      this.reaper.registerLive(signal.sessionId, this);
+    }
+
+    this.queue = this.queue.then(() => this.reaper.processSignal(this, signal));
+    return this.queue;
+  }
+
+  isLive(): boolean {
+    return this.live;
+  }
+
+  sessionId(): string | undefined {
+    return this.resolvedSessionId;
+  }
+
+  /** True while the session is idle and held open solely for background work. */
+  isAwaitingTasks(): boolean {
+    return this.awaitingTasks;
+  }
+
+  setAwaitingTasks(value: boolean): void {
+    this.awaitingTasks = value;
+  }
+
+  detach(): void {
+    this.markDone();
+  }
+
+  /** Reap: mark not-live and close the session after the current hook unwinds. */
+  scheduleClose(): void {
+    if (this.closing) return;
+    this.closing = true;
+    this.markDone();
+    // Defer so close()'s q.return() never runs inside the Stop hook that asked
+    // for it (re-entering the SDK generator mid-hook can wedge teardown).
+    setTimeout(() => {
+      void this.session.close().catch(() => {
+        // Already closed / never started — nothing to clean up.
+      });
+    }, 0);
+  }
+
+  private markDone(): void {
+    this.live = false;
+    if (this.resolvedSessionId) this.reaper.unregisterLive(this.resolvedSessionId);
+  }
+}

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -40,9 +40,10 @@ export interface SessionReaperOptions {
 export interface ManagedSession {
   /**
    * Feed a turn-boundary signal to the reaper. Wire into
-   * `RuntimeExecuteOptions.onLifecycleSignal`. Returns a promise the caller may
-   * await (the Stop hook does) so reconciliation completes before the turn fully
-   * unwinds; the actual `close()` is deferred so it never re-enters the hook.
+   * `RuntimeExecuteOptions.onLifecycleSignal`. Signals are serialized internally
+   * (reconcile → decision → close, in order), so callers may fire-and-forget; the
+   * returned promise settles when this signal has been processed. The actual
+   * `close()` is deferred so it never re-enters the hook that triggered it.
    */
   handleSignal(signal: SessionLifecycleSignal): Promise<void>;
   /** True until the session has been reaped or detached. */
@@ -117,8 +118,16 @@ export class SessionReaper {
     }
 
     // turn_end: authoritative snapshot. Capture pending crons first so they
-    // survive whatever we decide next.
-    await this.registry.reconcile(managed.agent, signal.sessionId, signal.sessionCrons);
+    // survive whatever we decide next. A reconcile I/O failure loses that turn's
+    // capture but must NOT block the reap — leaving the session alive is the leak
+    // this module exists to prevent — so log and press on with the decision.
+    try {
+      await this.registry.reconcile(managed.agent, signal.sessionId, signal.sessionCrons);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to reconcile wakes for session ${signal.sessionId} (${managed.agent}): ${(error as Error).message}`,
+      );
+    }
 
     const decision = decideReap(signal);
     if (decision.action === "keepAlive") {
@@ -126,11 +135,13 @@ export class SessionReaper {
         `Keeping session ${signal.sessionId} (${managed.agent}) alive: ${decision.tasks.length} background task(s)`,
       );
       managed.setAwaitingTasks(true);
-      this.onKeepAlive?.({
-        agent: managed.agent,
-        sessionId: signal.sessionId,
-        tasks: decision.tasks,
-      });
+      this.notify(() =>
+        this.onKeepAlive?.({
+          agent: managed.agent,
+          sessionId: signal.sessionId,
+          tasks: decision.tasks,
+        }),
+      );
       return;
     }
 
@@ -140,8 +151,19 @@ export class SessionReaper {
   private reap(managed: ManagedSessionImpl, sessionId: string): void {
     if (!managed.isLive()) return;
     this.logger.info(`Reaping idle session ${sessionId} (${managed.agent})`);
-    this.onReap?.({ agent: managed.agent, sessionId });
+    // Notify before closing, but never let a throwing consumer callback skip the
+    // close() — that would leak the very session we decided to reap.
+    this.notify(() => this.onReap?.({ agent: managed.agent, sessionId }));
     managed.scheduleClose();
+  }
+
+  /** Run a consumer callback, swallowing (and logging) any throw. */
+  private notify(fn: () => void): void {
+    try {
+      fn();
+    } catch (error) {
+      this.logger.warn(`Session lifecycle callback threw: ${(error as Error).message}`);
+    }
   }
 }
 
@@ -176,8 +198,13 @@ class ManagedSessionImpl implements ManagedSession {
       this.reaper.registerLive(signal.sessionId, this);
     }
 
-    this.queue = this.queue.then(() => this.reaper.processSignal(this, signal));
-    return this.queue;
+    const result = this.queue.then(() => this.reaper.processSignal(this, signal));
+    // Keep the internal queue always-resolving: a single rejected signal must
+    // never poison the chain (which would skip every future signal and strand
+    // the session unreaped). processSignal already swallows its own errors; this
+    // is belt-and-suspenders against an unexpected throw.
+    this.queue = result.then(undefined, () => undefined);
+    return result;
   }
 
   isLive(): boolean {

--- a/packages/core/src/session/types.ts
+++ b/packages/core/src/session/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Types for streaming-session lifecycle management (reaper + wake re-trigger).
+ *
+ * A long-lived chat session (`FleetManager.openChatSession` /
+ * `SDKRuntime.openSession`) keeps a native `claude` process warm at ~300 MB RSS.
+ * These types back the machinery that reaps such a process the instant it goes
+ * idle and re-triggers any scheduled wakeups it left behind — see the `session/`
+ * module docs and edspencer/herdctl#307.
+ */
+
+import type { BackgroundTaskSummary, SessionCronSummary } from "@anthropic-ai/claude-agent-sdk";
+
+// Re-export the SDK's summary shapes so consumers of `@herdctl/core` can type
+// lifecycle signals without importing the SDK directly (mirrors how
+// `interface.ts` re-exports `SlashCommand`).
+export type { BackgroundTaskSummary, SessionCronSummary };
+
+/**
+ * A snapshot of a session's pending background work, captured at a turn
+ * boundary (the SDK `Stop`/`SubagentStop` hook) or when the live background-task
+ * set changes (`background_tasks_changed`).
+ *
+ * `sessionCrons` are the timer-class wakeups (`ScheduleWakeup`, `CronCreate`,
+ * `/loop`) that want to re-run the session later; `backgroundTasks` are the
+ * continuous-class work (a dev/web server, a `Monitor`, a detached subagent)
+ * that must keep the process alive while running.
+ */
+export interface SessionLifecycleSignal {
+  /**
+   * What produced the signal:
+   * - `turn_end` — a `Stop`/`SubagentStop` hook fired; `sessionCrons` and
+   *   `backgroundTasks` are the authoritative turn-boundary snapshot.
+   * - `background_tasks_changed` — the live background-task set changed
+   *   mid-session; `backgroundTasks` is fresh, `sessionCrons` is not reported
+   *   (empty) and must not be reconciled.
+   * - `activity` — the session started producing output again (a new turn is
+   *   underway); carries no snapshot, only clears the idle-waiting state.
+   */
+  kind: "turn_end" | "background_tasks_changed" | "activity";
+  /** The resolved session id the wakeups/tasks belong to. */
+  sessionId: string;
+  /** Pending timer-class wakeups. Empty when none are scheduled. */
+  sessionCrons: SessionCronSummary[];
+  /** In-flight continuous-class background work. Empty when the session is idle. */
+  backgroundTasks: BackgroundTaskSummary[];
+}
+
+/**
+ * A herdctl-owned wake, captured from a `SessionCronSummary` and persisted so
+ * the fleet's own scheduler can re-trigger it after the session is reaped.
+ *
+ * The SDK's session-only cron dies with the `claude` process (durable crons are
+ * silently downgraded in the headless SDK context), so herdctl becomes the
+ * persistence layer: it stores the resolved absolute `nextRunAt` and, on due,
+ * resumes the session and injects `prompt`.
+ */
+export interface SessionWakeEntry {
+  /** The SDK cron id — the reconciliation key across turns. */
+  id: string;
+  /** Qualified agent name that owns the session. */
+  agent: string;
+  /** Session id to resume when the wake fires. */
+  sessionId: string;
+  /** Cron expression. For a one-shot `ScheduleWakeup` it encodes a single fire time. */
+  schedule: string;
+  /** `false` for one-shot wakeups; `true` for crons that re-fire on every match. */
+  recurring: boolean;
+  /** Prompt injected into the resumed session when the wake fires. */
+  prompt: string;
+  /** Resolved absolute next fire time (ISO). Stored so an overdue fleet fires immediately. */
+  nextRunAt: string;
+  /** ISO timestamp the wake was first captured — anchors the recurring-cron expiry. */
+  createdAt: string;
+}

--- a/packages/core/src/session/wake-registry.ts
+++ b/packages/core/src/session/wake-registry.ts
@@ -1,0 +1,200 @@
+/**
+ * The stateful coordinator over herdctl-owned session wakes.
+ *
+ * Wraps the pure {@link ./wake-store.js} reconciliation with persistence, a
+ * cron resolver, and a concurrency-limited firing path. All mutations funnel
+ * through a single async lock so a turn-end reconcile can't race the scheduler's
+ * due-check. Firing happens **outside** the lock — a fired wake resumes the
+ * session, whose own Stop hook re-enters {@link reconcile}, so holding the lock
+ * across a fire would deadlock.
+ *
+ * See edspencer/herdctl#307 gap 2 (fire-time concurrency) and gap 6 (wake-vs-live
+ * collision).
+ */
+
+import { createLogger } from "../utils/logger.js";
+import type { SessionCronSummary, SessionWakeEntry } from "./types.js";
+
+/** The structural logger returned by {@link createLogger}. */
+type Logger = ReturnType<typeof createLogger>;
+
+import {
+  advanceWake,
+  findDueWakes,
+  type NextRunResolver,
+  pruneExpiredWakes,
+  RECURRING_WAKE_MAX_AGE_MS,
+  reconcileSessionWakes,
+  removeSessionWakes,
+  removeWake,
+} from "./wake-store.js";
+
+/** Where the wake set is read from / written to (fleet state in production). */
+export interface WakePersistence {
+  load(): Promise<SessionWakeEntry[]>;
+  save(entries: SessionWakeEntry[]): Promise<void>;
+}
+
+export interface WakeRegistryOptions {
+  /** Durable store for the wake set. */
+  persistence: WakePersistence;
+  /** Resolves a cron expression to its next absolute fire time. */
+  resolveNextRun: NextRunResolver;
+  /**
+   * Fires a due wake: resume its session and inject its prompt. Called outside
+   * the registry lock; a throw is logged and the wake is not retried (recurring
+   * wakes simply fire next cycle).
+   */
+  fire: (entry: SessionWakeEntry) => Promise<void>;
+  /**
+   * True while `sessionId` has a live, herdctl-managed session open. A wake for a
+   * live session is skipped at due time — that session's own next turn re-captures
+   * it — rather than spawning a second process for the same session (gap 6).
+   */
+  isSessionLive?: (sessionId: string) => boolean;
+  /** Max concurrent fires at one due tick (gap 2). Default 4. */
+  concurrency?: number;
+  /** Recurring-wake lifetime; defaults to the 7-day harness parity. */
+  maxAgeMs?: number;
+  logger?: Logger;
+}
+
+const DEFAULT_CONCURRENCY = 4;
+
+export class WakeRegistry {
+  private readonly persistence: WakePersistence;
+  private readonly resolveNextRun: NextRunResolver;
+  private readonly fire: (entry: SessionWakeEntry) => Promise<void>;
+  private readonly isSessionLive: (sessionId: string) => boolean;
+  private readonly concurrency: number;
+  private readonly maxAgeMs: number;
+  private readonly logger: Logger;
+
+  /** Serializes all persisted-state mutations (reconcile + due bookkeeping). */
+  private lock: Promise<void> = Promise.resolve();
+
+  constructor(options: WakeRegistryOptions) {
+    this.persistence = options.persistence;
+    this.resolveNextRun = options.resolveNextRun;
+    this.fire = options.fire;
+    this.isSessionLive = options.isSessionLive ?? (() => false);
+    this.concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY);
+    this.maxAgeMs = options.maxAgeMs ?? RECURRING_WAKE_MAX_AGE_MS;
+    this.logger = options.logger ?? createLogger("wake-registry");
+  }
+
+  /** Run `fn` with exclusive access to the persisted wake set. */
+  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.lock.then(fn, fn);
+    // Keep the chain alive but swallow errors so one failure can't wedge the lock.
+    this.lock = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  /**
+   * Reconcile a session's pending crons (from its Stop hook) into the durable
+   * wake set. Call at every turn boundary, before reaping.
+   */
+  async reconcile(
+    agent: string,
+    sessionId: string,
+    sessionCrons: SessionCronSummary[],
+    now: Date = new Date(),
+  ): Promise<void> {
+    await this.withLock(async () => {
+      const existing = await this.persistence.load();
+      const reconciled = reconcileSessionWakes({
+        existing,
+        agent,
+        sessionId,
+        sessionCrons,
+        now,
+        resolveNextRun: this.resolveNextRun,
+      });
+      const pruned = pruneExpiredWakes(reconciled, now, this.maxAgeMs);
+      await this.persistence.save(pruned);
+    });
+  }
+
+  /** Remove a single wake by id (an explicitly detected `CronDelete`; gap 4b). */
+  async remove(id: string): Promise<void> {
+    await this.withLock(async () => {
+      const existing = await this.persistence.load();
+      await this.persistence.save(removeWake(existing, id));
+    });
+  }
+
+  /** Drop all wakes for a session (e.g. it was permanently closed by the user). */
+  async forgetSession(sessionId: string): Promise<void> {
+    await this.withLock(async () => {
+      const existing = await this.persistence.load();
+      await this.persistence.save(removeSessionWakes(existing, sessionId));
+    });
+  }
+
+  /**
+   * Fire every wake now due, honoring the concurrency limit and skipping wakes
+   * whose session is currently live. Bookkeeping (advance recurring / drop
+   * one-shot) is persisted *before* firing so a slow or failed fire can't
+   * double-trigger; the fires then run outside the lock.
+   *
+   * @returns the wakes that were dispatched this tick.
+   */
+  async dispatchDue(now: Date = new Date()): Promise<SessionWakeEntry[]> {
+    const due = await this.withLock(async () => {
+      const existing = pruneExpiredWakes(await this.persistence.load(), now, this.maxAgeMs);
+      const dueNow = findDueWakes(existing, now).filter((e) => !this.isSessionLive(e.sessionId));
+      if (dueNow.length === 0) {
+        await this.persistence.save(existing);
+        return [];
+      }
+      // Pre-compute the post-fire set: advance recurring, drop one-shots.
+      const dueIds = new Set(dueNow.map((e) => e.id));
+      const next: SessionWakeEntry[] = [];
+      for (const entry of existing) {
+        if (!dueIds.has(entry.id)) {
+          next.push(entry);
+          continue;
+        }
+        const advanced = advanceWake(entry, now, this.resolveNextRun, this.maxAgeMs);
+        if (advanced) next.push(advanced);
+      }
+      await this.persistence.save(next);
+      return dueNow;
+    });
+
+    if (due.length > 0) {
+      await this.runLimited(due, (entry) => this.fireOne(entry));
+    }
+    return due;
+  }
+
+  private async fireOne(entry: SessionWakeEntry): Promise<void> {
+    try {
+      this.logger.debug(`Firing session wake ${entry.id} for ${entry.agent} (${entry.sessionId})`);
+      await this.fire(entry);
+    } catch (error) {
+      this.logger.warn(
+        `Session wake ${entry.id} for ${entry.agent} failed to fire: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  /** Run `task` over `items` with at most `this.concurrency` in flight. */
+  private async runLimited<T>(items: T[], task: (item: T) => Promise<void>): Promise<void> {
+    let cursor = 0;
+    const worker = async (): Promise<void> => {
+      while (cursor < items.length) {
+        const item = items[cursor++];
+        await task(item);
+      }
+    };
+    const workers = Array.from({ length: Math.min(this.concurrency, items.length) }, () =>
+      worker(),
+    );
+    await Promise.all(workers);
+  }
+}

--- a/packages/core/src/session/wake-store.ts
+++ b/packages/core/src/session/wake-store.ts
@@ -1,0 +1,145 @@
+/**
+ * Reconcile session-only crons into herdctl-owned wake entries.
+ *
+ * At each turn boundary the SDK reports the session's pending `session_crons`.
+ * herdctl reconciles that authoritative set (by `id`) against what it already
+ * holds, then persists the result so its own scheduler can re-trigger the wakes
+ * after the session is reaped. These functions are pure — persistence and cron
+ * math are injected — so the reconciliation rules are unit-testable in isolation.
+ *
+ * See edspencer/herdctl#307 (§"Re-trigger timer-class work") and its gap-4 note
+ * on recurring-cron ownership.
+ */
+
+import type { SessionCronSummary, SessionWakeEntry } from "./types.js";
+
+/** Recurring session-only crons auto-expire after 7 days (mirrors the harness). */
+export const RECURRING_WAKE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Injected cron resolver — decouples reconciliation from `scheduler/cron.ts`. */
+export type NextRunResolver = (schedule: string, from: Date) => Date;
+
+export interface ReconcileParams {
+  /** All wake entries herdctl currently holds (across every session). */
+  existing: SessionWakeEntry[];
+  /** Qualified agent name that owns the session being reconciled. */
+  agent: string;
+  /** The session id these crons belong to. */
+  sessionId: string;
+  /** The authoritative pending set reported by this turn's Stop hook. */
+  sessionCrons: SessionCronSummary[];
+  /** Current time — the anchor for new `nextRunAt` / `createdAt` values. */
+  now: Date;
+  /** Resolves a cron expression to its next absolute fire time. */
+  resolveNextRun: NextRunResolver;
+}
+
+/**
+ * Reconcile one session's pending crons into the full wake set.
+ *
+ * Rules (see #307 gap 4):
+ * - **New id** (in `sessionCrons`, not stored) → capture it, resolving an
+ *   absolute `nextRunAt` now so an overdue fleet can fire it immediately.
+ * - **Known id** (in both) → keep the stored entry unchanged; herdctl already
+ *   owns its schedule and must not reset the cycle just because it was re-reported.
+ * - **Dropped id** (stored for this session, absent from `sessionCrons`):
+ *   - one-shot (`recurring:false`) → remove (it fired, or the agent cancelled it).
+ *   - recurring (`recurring:true`) → **keep**. A herdctl-fired *resumed* turn does
+ *     not re-arm the session-only cron, so it legitimately reports empty; dropping
+ *     on absence would delete every recurring wake on its first re-trigger.
+ *     Recurring wakes are instead retired by {@link pruneExpiredWakes} (7-day) or
+ *     an explicit {@link removeWake} (a detected `CronDelete`).
+ *
+ * Entries for *other* sessions pass through untouched.
+ */
+export function reconcileSessionWakes(params: ReconcileParams): SessionWakeEntry[] {
+  const { existing, agent, sessionId, sessionCrons, now, resolveNextRun } = params;
+
+  const others = existing.filter((e) => e.sessionId !== sessionId);
+  const mine = existing.filter((e) => e.sessionId === sessionId);
+  const byId = new Map(mine.map((e) => [e.id, e]));
+  const reportedIds = new Set(sessionCrons.map((c) => c.id));
+
+  const result: SessionWakeEntry[] = [];
+
+  // Known + new ids from the authoritative reported set.
+  for (const cron of sessionCrons) {
+    const known = byId.get(cron.id);
+    if (known) {
+      result.push(known);
+      continue;
+    }
+    result.push({
+      id: cron.id,
+      agent,
+      sessionId,
+      schedule: cron.schedule,
+      recurring: cron.recurring,
+      prompt: cron.prompt,
+      nextRunAt: resolveNextRun(cron.schedule, now).toISOString(),
+      createdAt: now.toISOString(),
+    });
+  }
+
+  // Dropped ids: keep recurring (herdctl-owned), discard stale one-shots.
+  for (const entry of mine) {
+    if (reportedIds.has(entry.id)) continue;
+    if (entry.recurring) result.push(entry);
+  }
+
+  return [...others, ...result];
+}
+
+/**
+ * Advance a recurring wake to its next fire time after it has fired; one-shots
+ * return `null` (fire once, then drop). Recurring wakes past the 7-day lifetime
+ * also return `null`.
+ */
+export function advanceWake(
+  entry: SessionWakeEntry,
+  now: Date,
+  resolveNextRun: NextRunResolver,
+  maxAgeMs: number = RECURRING_WAKE_MAX_AGE_MS,
+): SessionWakeEntry | null {
+  if (!entry.recurring) return null;
+  if (isExpired(entry, now, maxAgeMs)) return null;
+  return { ...entry, nextRunAt: resolveNextRun(entry.schedule, now).toISOString() };
+}
+
+/** A recurring wake is expired once it has outlived `maxAgeMs` since capture. */
+export function isExpired(
+  entry: SessionWakeEntry,
+  now: Date,
+  maxAgeMs: number = RECURRING_WAKE_MAX_AGE_MS,
+): boolean {
+  if (!entry.recurring) return false;
+  return now.getTime() - new Date(entry.createdAt).getTime() > maxAgeMs;
+}
+
+/** Drop recurring wakes that have passed the 7-day lifetime. */
+export function pruneExpiredWakes(
+  entries: SessionWakeEntry[],
+  now: Date,
+  maxAgeMs: number = RECURRING_WAKE_MAX_AGE_MS,
+): SessionWakeEntry[] {
+  return entries.filter((e) => !isExpired(e, now, maxAgeMs));
+}
+
+/** Remove a wake by id (e.g. an explicitly detected `CronDelete`). */
+export function removeWake(entries: SessionWakeEntry[], id: string): SessionWakeEntry[] {
+  return entries.filter((e) => e.id !== id);
+}
+
+/** Remove every wake bound to a session (e.g. the session was permanently closed). */
+export function removeSessionWakes(
+  entries: SessionWakeEntry[],
+  sessionId: string,
+): SessionWakeEntry[] {
+  return entries.filter((e) => e.sessionId !== sessionId);
+}
+
+/** Wakes whose `nextRunAt` is at or before `now` — the due set to fire. */
+export function findDueWakes(entries: SessionWakeEntry[], now: Date): SessionWakeEntry[] {
+  const t = now.getTime();
+  return entries.filter((e) => new Date(e.nextRunAt).getTime() <= t);
+}

--- a/packages/core/src/state/schemas/fleet-state.ts
+++ b/packages/core/src/state/schemas/fleet-state.ts
@@ -61,6 +61,34 @@ export const AgentStateSchema = z.object({
 });
 
 // =============================================================================
+// Session Wake Schemas
+// =============================================================================
+
+/**
+ * A herdctl-owned wake captured from a streaming session's `session_crons`, so
+ * the fleet scheduler can re-trigger it after the session is reaped
+ * (edspencer/herdctl#307). Keyed by the SDK cron `id` at the top level of state.
+ */
+export const SessionWakeSchema = z.object({
+  /** SDK cron id — the reconciliation key across turns. */
+  id: z.string(),
+  /** Qualified agent name that owns the session. */
+  agent: z.string(),
+  /** Session id to resume when the wake fires. */
+  sessionId: z.string(),
+  /** Cron expression (a one-shot wakeup encodes a single fire time). */
+  schedule: z.string(),
+  /** `false` for one-shot wakeups; `true` for recurring crons. */
+  recurring: z.boolean(),
+  /** Prompt injected into the resumed session. */
+  prompt: z.string(),
+  /** Resolved absolute next fire time (ISO). */
+  nextRunAt: z.string(),
+  /** ISO capture time — anchors the 7-day recurring expiry. */
+  createdAt: z.string(),
+});
+
+// =============================================================================
 // Fleet State Schemas
 // =============================================================================
 
@@ -80,6 +108,8 @@ export const FleetStateSchema = z.object({
   fleet: FleetMetadataSchema.optional().default({}),
   /** Map of agent names to their current state */
   agents: z.record(z.string(), AgentStateSchema).optional().default({}),
+  /** Captured session wakes keyed by SDK cron id (see {@link SessionWakeSchema}). */
+  session_wakes: z.record(z.string(), SessionWakeSchema).optional(),
 });
 
 // =============================================================================
@@ -88,6 +118,7 @@ export const FleetStateSchema = z.object({
 
 export type ScheduleStatus = z.infer<typeof ScheduleStatusSchema>;
 export type ScheduleState = z.infer<typeof ScheduleStateSchema>;
+export type SessionWake = z.infer<typeof SessionWakeSchema>;
 export type AgentStatus = z.infer<typeof AgentStatusSchema>;
 export type AgentState = z.infer<typeof AgentStateSchema>;
 export type FleetMetadata = z.infer<typeof FleetMetadataSchema>;


### PR DESCRIPTION
Implements the core of #307 — **reap idle streaming sessions the instant they go idle, and re-trigger the timer-class wakeups they leave behind through herdctl's own scheduler**. This is **part 1**: the complete, tested core mechanism + integration seams. Part 2 (the `FleetManager.openChatSession` opt-in + consumer delivery surface, coupled to edspencer/paddock#111) follows.

## Why
Today `openChatSession` opens an `SDKRuntime` streaming session (~300 MB RSS native `claude` process) with **zero lifecycle management** — nothing reaps it. A consumer driving every chat as a long-lived session (paddock#111) accumulates warm processes. Reaping is cheap and lossless (resume recovers full conversation; the Anthropic prompt cache is server-side and survives the reap), so the right policy is: **reap the moment a session goes idle, unless it holds live background work.** No idle timers, no backstops, no concurrency cap — memory self-bounds to *actively-working* sessions.

## What's in this PR (`packages/core/src/session/`)
- **`reaper-policy`** — `decideReap`: keep alive iff continuous-class `background_tasks` are running; otherwise reap. Timer-class `session_crons` never pin a session.
- **`wake-store`** — pure reconcile-by-id of SDK `session_crons` into herdctl-owned wake entries: absolute `nextRunAt` (via an injected cron resolver), one-shot vs recurring, **7-day recurring expiry**, and the **gap-4 recurring-ownership rule** (a herdctl-fired resumed turn doesn't re-arm a session-only cron, so recurring wakes are *not* dropped on absence — only on expiry or an explicit `CronDelete`).
- **`wake-registry`** — stateful coordinator: async-locked reconcile + **concurrency-limited (gap 2)**, deadlock-free `dispatchDue` that pre-persists post-fire state and **skips still-live sessions (gap 6)**.
- **`session-reaper`** — ties a live session to the policy; consumes `turn_end` / `background_tasks_changed` / `activity` signals; defers `close()` so it never re-enters the Stop hook; re-reaps a kept-alive session once its background work ends (and won't reap mid-turn).
- **`session-hooks`** — `buildLifecycleHooks` (`Stop`/`SubagentStop`) + `tapLifecycleStream` mapping SDK events → lifecycle signals.
- **`fleet-state-wake-persistence`** — durable `session_wakes` slice in fleet state.

### Integration seams
- `SDKRuntime.openSession` installs the lifecycle hooks + stream tap when a new `onLifecycleSignal` execute-option is set, and **threads an `AbortController`** (acceptance criterion).
- `Scheduler` gains an **`onTick`** option so wake firing reuses the existing loop (no second timer).

## Testing
- 47 new unit tests across the `session/` module + `Scheduler.onTick`.
- Core coverage **80%+** (all thresholds green); `src/session` ≈ 97%.
- `pnpm --filter @herdctl/core typecheck` + `build` green.
- Full suite green except the pre-existing **root-only** `directory.test.ts` (root bypasses the unwritable-dir check; unrelated).

## Not in this PR (part 2)
- `FleetManager` constructs the `WakeRegistry` (`resolveNextRun` via `cron.ts`, `fire` = `openChatSession({resume}) + inject`, `isSessionLive` from the reaper) and passes `onTick: () => registry.dispatchDue()` to the `Scheduler`.
- `ChatSessionOptions.manageLifecycle` opt-in in `JobControl.openChatSession` (wire `onLifecycleSignal` → `reaper.manage(session)`).
- Consumer surface for delivering the re-triggered turn onto the hub/attribution path (paddock#111 gap 3), and the targeted `CronDelete` watch (gap 4b).

Kept separate because it touches the large `FleetManager` and is coupled to the Paddock consumer surface — same rationale as splitting #304/#305.

Refs #307, edspencer/paddock#111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for long-lived session lifecycle handling, including automatic wake tracking and re-triggering.
  * Sessions can now report lifecycle events during streaming, enabling better background-work awareness.
  * Scheduler ticks can now run additional time-based work alongside existing schedule checks.

* **Bug Fixes**
  * Improved session teardown so open sessions close more reliably.
  * Preserved unrelated fleet state while updating session wake data.
  * Added safeguards so scheduler hook errors do not stop the main loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->