### PR TITLE
feat(core): wire session reaper into FleetManager + openChatSession (#307, part 2)

### DIFF
--- a/.changeset/session-reaper-fleet-wiring.md
+++ b/.changeset/session-reaper-fleet-wiring.md
@@ -1,0 +1,13 @@
+---
+"@herdctl/core": minor
+---
+
+Wire the session reaper + wake registry into the fleet end-to-end (part 2 of edspencer/herdctl#307).
+
+Builds on the `session/` mechanism to make idle-session reaping and wake re-triggering actually run inside a `FleetManager`:
+
+- **`SessionLifecycleManager`** — assembles the `WakeRegistry` + `SessionReaper` + persistence + cron resolution + the resume-and-inject fire path into one facade. Firing a due wake resumes its session via `openChatSession({ resume, prompt, manageLifecycle: true })` and either hands the live session to a registered consumer or drains it headlessly so recurring wakeups keep firing.
+- **`FleetManager`** now constructs a `SessionLifecycleManager` and passes `onTick: () => dispatchDue()` to the `Scheduler`, so due wakes fire on the existing scheduler loop. New surface: `getSessionLifecycle()` and `setSessionWakeHandler()` (the consumer hook for delivering woken turns onto a hub/attribution path).
+- **`ChatSessionOptions.manageLifecycle`** — opt a streaming session into herdctl-managed lifecycle. `JobControl.openChatSession` wires the session's `onLifecycleSignal` to the reaper (`manage()`), so the session is reaped when it goes idle and its `session_crons` are captured for re-triggering.
+
+Behavior is unchanged unless a caller opts in via `manageLifecycle` (or a consumer registers a wake handler): existing `openChatSession` callers keep owning `close()`.

--- a/packages/core/src/fleet-manager/context.ts
+++ b/packages/core/src/fleet-manager/context.ts
@@ -11,6 +11,7 @@
 import type { EventEmitter } from "node:events";
 import type { ResolvedConfig } from "../config/index.js";
 import type { Scheduler } from "../scheduler/index.js";
+import type { SessionLifecycleManager } from "../session/index.js";
 import type { StateDirectory } from "../state/index.js";
 import type { IChatManager } from "./chat-manager-interface.js";
 import type {
@@ -52,6 +53,13 @@ export interface FleetManagerContext {
    * Get the scheduler instance (null if not initialized)
    */
   getScheduler(): Scheduler | null;
+
+  /**
+   * Get the session-lifecycle manager (reaper + wake registry), or null if the
+   * fleet is not initialized. Used by `openChatSession` to opt a session into
+   * lifecycle management (edspencer/herdctl#307).
+   */
+  getSessionLifecycle?(): SessionLifecycleManager | null;
 
   /**
    * Get the current fleet manager status

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -26,6 +26,7 @@ import {
 import type { RuntimeSession, SlashCommand } from "../runner/index.js";
 import { getCliSessionFile, getDockerSessionFile } from "../runner/runtime/cli-session-path.js";
 import { Scheduler, type TriggerInfo } from "../scheduler/index.js";
+import { SessionLifecycleManager, type SessionWakeHandler } from "../session/index.js";
 import {
   type ChatMessage,
   type DiscoveredSession,
@@ -101,6 +102,8 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   private config: ResolvedConfig | null = null;
   private stateDirInfo: StateDirectory | null = null;
   private scheduler: Scheduler | null = null;
+  private sessionLifecycle: SessionLifecycleManager | null = null;
+  private sessionWakeHandler?: SessionWakeHandler;
 
   // Timing info
   private initializedAt: string | null = null;
@@ -159,6 +162,9 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   }
   getScheduler(): Scheduler | null {
     return this.scheduler;
+  }
+  getSessionLifecycle(): SessionLifecycleManager | null {
+    return this.sessionLifecycle;
   }
   getStatus(): FleetManagerStatus {
     return this.status;
@@ -270,11 +276,16 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
       this.stateDirInfo = await this.initializeStateDir();
       this.logger.debug("State directory initialized");
 
+      this.sessionLifecycle = this.createSessionLifecycle();
       this.scheduler = new Scheduler({
         stateDir: this.stateDir,
         checkInterval: this.checkInterval,
         logger: this.logger,
         onTrigger: (info) => this.handleScheduleTrigger(info),
+        // Reuse the scheduler loop to fire due session wakes (#307).
+        onTick: async () => {
+          await this.sessionLifecycle?.dispatchDue();
+        },
       });
 
       // Initialize chat managers (web will be picked up since config.fleet.web.enabled = true)
@@ -324,11 +335,16 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
       this.stateDirInfo = await this.initializeStateDir();
       this.logger.debug("State directory initialized");
 
+      this.sessionLifecycle = this.createSessionLifecycle();
       this.scheduler = new Scheduler({
         stateDir: this.stateDir,
         checkInterval: this.checkInterval,
         logger: this.logger,
         onTrigger: (info) => this.handleScheduleTrigger(info),
+        // Reuse the scheduler loop to fire due session wakes (#307).
+        onTick: async () => {
+          await this.sessionLifecycle?.dispatchDue();
+        },
       });
 
       // Dynamically import and create chat managers for configured platforms
@@ -867,6 +883,34 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
 
     // Chat managers are created during initialize() via dynamic imports
     // to avoid hard dependencies on platform packages.
+  }
+
+  /**
+   * Build the session-lifecycle manager (reaper + wake registry) for #307.
+   *
+   * The registry fires due wakes by resuming the session and injecting the
+   * stored prompt through {@link openChatSession} (with `manageLifecycle` so the
+   * resumed turn is itself reaped and re-captured). Any consumer-registered
+   * {@link SessionWakeHandler} drives the woken turn; otherwise it runs headless.
+   */
+  private createSessionLifecycle(): SessionLifecycleManager {
+    return new SessionLifecycleManager({
+      stateDir: this.stateDir,
+      openChatSession: (agent, opts) => this.openChatSession(agent, opts),
+      sessionWakeHandler: this.sessionWakeHandler,
+    });
+  }
+
+  /**
+   * Register (or clear) the consumer that drives herdctl-fired session wakes.
+   *
+   * A consumer (e.g. Paddock) sets this to receive the resumed, already-managed
+   * session on its hub/attribution path; without it, woken turns run headless so
+   * recurring wakeups still fire. Safe to call before or after initialize().
+   */
+  setSessionWakeHandler(handler: SessionWakeHandler | undefined): void {
+    this.sessionWakeHandler = handler;
+    this.sessionLifecycle?.setSessionWakeHandler(handler);
   }
 
   /**

--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -18,6 +18,7 @@ import {
   SDKRuntime,
   type SlashCommand,
 } from "../runner/index.js";
+import type { ManagedSession, SessionLifecycleSignal } from "../session/index.js";
 import { createJob, getJob, getSessionInfo, readJobOutputAll, updateJob } from "../state/index.js";
 import type { JobMetadata } from "../state/schemas/job-metadata.js";
 import type { FleetManagerContext } from "./context.js";
@@ -387,13 +388,32 @@ export class JobControl {
 
     const runtime = new SDKRuntime();
     logger.info(`Opening streaming chat session for ${agentName} (sdk runtime)`);
-    return runtime.openSession({
+
+    // Opt in to herdctl-managed lifecycle (reap-on-idle + wake re-trigger, #307)
+    // when requested and a lifecycle manager exists. The managed handle is
+    // created after the session (it needs the session to close it), so signals
+    // are forwarded through a late-bound reference — safe because the first
+    // signal only arrives at the first turn's end, well after `manage()` runs.
+    const lifecycle = options?.manageLifecycle ? this.ctx.getSessionLifecycle?.() : undefined;
+    let managed: ManagedSession | undefined;
+    const onLifecycleSignal = lifecycle
+      ? (signal: SessionLifecycleSignal) => managed?.handleSignal(signal)
+      : undefined;
+
+    const session = runtime.openSession({
       agent: effectiveAgent,
       prompt: options?.prompt ?? "",
       resume: sessionId,
       injectedMcpServers: options?.injectedMcpServers,
       systemPromptAppend: options?.systemPromptAppend,
+      onLifecycleSignal,
     });
+
+    if (lifecycle) {
+      managed = lifecycle.manage(session, agentName);
+    }
+
+    return session;
   }
 
   /**

--- a/packages/core/src/fleet-manager/types.ts
+++ b/packages/core/src/fleet-manager/types.ts
@@ -695,6 +695,18 @@ export interface ChatSessionOptions {
 
   /** Text to append to the agent's system prompt for this session. */
   systemPromptAppend?: string;
+
+  /**
+   * Opt in to herdctl-managed session lifecycle (edspencer/herdctl#307).
+   *
+   * When `true` and the fleet has a session-lifecycle manager, the session is
+   * reaped the instant it goes idle (unless it holds live background work), and
+   * its timer-class wakeups are captured and re-triggered through the scheduler.
+   * The caller should treat the message stream ending as a reap and re-open
+   * (resume) later if it wants to keep driving the conversation. Defaults to the
+   * legacy behavior (no lifecycle management — the caller owns `close()`).
+   */
+  manageLifecycle?: boolean;
 }
 
 /**

--- a/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
+++ b/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeSession } from "../../runner/runtime/interface.js";
+import { FleetStateWakePersistence } from "../fleet-state-wake-persistence.js";
+import {
+  SessionLifecycleManager,
+  type SessionWakeChatOptions,
+} from "../session-lifecycle-manager.js";
+import type { SessionLifecycleSignal, SessionWakeEntry } from "../types.js";
+
+const NOW = new Date("2026-07-09T12:00:00.000Z");
+const resolveNextRun = (_s: string, from: Date) => new Date(from.getTime() + 5 * 60_000);
+
+function fakeSession(): RuntimeSession {
+  async function* empty(): AsyncGenerator<never> {}
+  return {
+    messages: empty(),
+    send: vi.fn().mockResolvedValue(undefined),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    listCommands: vi.fn().mockResolvedValue([]),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function dueWake(overrides: Partial<SessionWakeEntry> = {}): SessionWakeEntry {
+  return {
+    id: "w1",
+    agent: "team/agent",
+    sessionId: "sess-1",
+    schedule: "*/5 * * * *",
+    recurring: false,
+    prompt: "WAKE-CONTINUE",
+    nextRunAt: new Date(NOW.getTime() - 1000).toISOString(),
+    createdAt: NOW.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("SessionLifecycleManager", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(join(tmpdir(), "herdctl-slm-"));
+  });
+
+  afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("manage() returns a live managed handle tracked by the reaper", async () => {
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession: vi.fn(),
+      resolveNextRun,
+    });
+    const managed = slm.manage(fakeSession(), "team/agent");
+    expect(managed.isLive()).toBe(true);
+    await managed.handleSignal({
+      kind: "activity",
+      sessionId: "sess-1",
+      sessionCrons: [],
+      backgroundTasks: [],
+    } satisfies SessionLifecycleSignal);
+    expect(slm.reaper.isSessionLive("sess-1")).toBe(true);
+  });
+
+  it("fires a due wake by resuming-and-injecting through openChatSession", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([dueWake()]);
+    const calls: Array<[string, SessionWakeChatOptions]> = [];
+    const openChatSession = vi.fn(async (agent: string, opts: SessionWakeChatOptions) => {
+      calls.push([agent, opts]);
+      return fakeSession();
+    });
+
+    const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
+    const dispatched = await slm.dispatchDue(NOW);
+
+    expect(dispatched.map((e) => e.id)).toEqual(["w1"]);
+    expect(calls).toEqual([
+      ["team/agent", { resume: "sess-1", prompt: "WAKE-CONTINUE", manageLifecycle: true }],
+    ]);
+    // One-shot fired → removed from the durable set.
+    expect(await new FleetStateWakePersistence({ stateDir }).load()).toEqual([]);
+  });
+
+  it("delegates the woken turn to a registered sessionWakeHandler", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([dueWake({ id: "w2" })]);
+    const session = fakeSession();
+    const openChatSession = vi.fn().mockResolvedValue(session);
+    const handler = vi.fn().mockResolvedValue(undefined);
+
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession,
+      resolveNextRun,
+      sessionWakeHandler: handler,
+    });
+    await slm.dispatchDue(NOW);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toBe(session);
+    expect(handler.mock.calls[0][1]).toMatchObject({ id: "w2" });
+  });
+
+  it("setSessionWakeHandler swaps the consumer at runtime", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([dueWake({ id: "w3" })]);
+    const openChatSession = vi.fn().mockResolvedValue(fakeSession());
+    const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
+
+    const handler = vi.fn().mockResolvedValue(undefined);
+    slm.setSessionWakeHandler(handler);
+    await slm.dispatchDue(NOW);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire wakes that are not yet due", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([
+      dueWake({ id: "future", nextRunAt: new Date(NOW.getTime() + 60_000).toISOString() }),
+    ]);
+    const openChatSession = vi.fn();
+    const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
+    expect(await slm.dispatchDue(NOW)).toEqual([]);
+    expect(openChatSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -6,6 +6,7 @@
 export * from "./fleet-state-wake-persistence.js";
 export * from "./reaper-policy.js";
 export * from "./session-hooks.js";
+export * from "./session-lifecycle-manager.js";
 export * from "./session-reaper.js";
 export * from "./types.js";
 export * from "./wake-registry.js";

--- a/packages/core/src/session/session-lifecycle-manager.ts
+++ b/packages/core/src/session/session-lifecycle-manager.ts
@@ -1,0 +1,142 @@
+/**
+ * The integration facade that wires the session reaper + wake registry to a
+ * fleet's `openChatSession` and scheduler loop.
+ *
+ * FleetManager constructs one of these, passes `dispatchDue` as the scheduler's
+ * `onTick`, and lets `JobControl.openChatSession` register managed sessions via
+ * {@link manage}. All the moving parts (persistence, cron resolution, the
+ * resume-and-inject fire path) are assembled here so FleetManager only holds a
+ * single reference. See edspencer/herdctl#307 (part 2).
+ */
+
+import type { RuntimeSession } from "../runner/runtime/interface.js";
+import { getNextCronTrigger } from "../scheduler/cron.js";
+import { createLogger } from "../utils/logger.js";
+import { FleetStateWakePersistence } from "./fleet-state-wake-persistence.js";
+import { type ManagedSession, SessionReaper } from "./session-reaper.js";
+import type { BackgroundTaskSummary, SessionWakeEntry } from "./types.js";
+import { WakeRegistry } from "./wake-registry.js";
+import type { NextRunResolver } from "./wake-store.js";
+
+type Logger = ReturnType<typeof createLogger>;
+
+/** Options a fired wake passes to `openChatSession` to resume-and-inject. */
+export interface SessionWakeChatOptions {
+  resume: string;
+  prompt: string;
+  manageLifecycle: true;
+}
+
+/**
+ * Drives the woken turn. If a consumer (e.g. Paddock) registers one, it receives
+ * the resumed, already-managed session and is responsible for consuming it;
+ * otherwise the manager drains it headlessly so recurring wakes keep firing.
+ */
+export type SessionWakeHandler = (
+  session: RuntimeSession,
+  entry: SessionWakeEntry,
+) => void | Promise<void>;
+
+export interface SessionLifecycleManagerOptions {
+  /** State directory (`.herdctl`) backing the durable wake set. */
+  stateDir: string;
+  /**
+   * Opens (resumes) a managed chat session and injects the wake's prompt. Wired
+   * to `FleetManager.openChatSession`; must set `manageLifecycle: true` so the
+   * resumed turn is itself reaped and its crons re-captured.
+   */
+  openChatSession: (agent: string, options: SessionWakeChatOptions) => Promise<RuntimeSession>;
+  /** Max concurrent wake fires per tick (gap 2). */
+  concurrency?: number;
+  /** Override the cron resolver (defaults to `scheduler/cron.ts`, UTC). */
+  resolveNextRun?: NextRunResolver;
+  /** Consumer hook for delivering the woken turn (attribution/hub path). */
+  sessionWakeHandler?: SessionWakeHandler;
+  logger?: Logger;
+  onReap?: (info: { agent: string; sessionId: string }) => void;
+  onKeepAlive?: (info: {
+    agent: string;
+    sessionId: string;
+    tasks: BackgroundTaskSummary[];
+  }) => void;
+}
+
+/** Default cron resolver — herdctl's own parser, matching the SDK's UTC crons. */
+function defaultResolveNextRun(schedule: string, from: Date): Date {
+  return getNextCronTrigger(schedule, from);
+}
+
+export class SessionLifecycleManager {
+  readonly registry: WakeRegistry;
+  readonly reaper: SessionReaper;
+
+  private readonly openChatSession: (
+    agent: string,
+    options: SessionWakeChatOptions,
+  ) => Promise<RuntimeSession>;
+  private readonly logger: Logger;
+  private sessionWakeHandler?: SessionWakeHandler;
+
+  constructor(options: SessionLifecycleManagerOptions) {
+    this.openChatSession = options.openChatSession;
+    this.logger = options.logger ?? createLogger("session-lifecycle");
+    this.sessionWakeHandler = options.sessionWakeHandler;
+
+    // The registry needs `isSessionLive` from the reaper, and the reaper needs
+    // the registry — build the registry first with a late-bound reference.
+    this.registry = new WakeRegistry({
+      persistence: new FleetStateWakePersistence({ stateDir: options.stateDir }),
+      resolveNextRun: options.resolveNextRun ?? defaultResolveNextRun,
+      fire: (entry) => this.fire(entry),
+      isSessionLive: (id) => this.reaper.isSessionLive(id),
+      concurrency: options.concurrency,
+      logger: this.logger,
+    });
+    this.reaper = new SessionReaper({
+      registry: this.registry,
+      logger: this.logger,
+      onReap: options.onReap,
+      onKeepAlive: options.onKeepAlive,
+    });
+  }
+
+  /** Begin managing a freshly-opened streaming session's lifecycle. */
+  manage(session: RuntimeSession, agent: string): ManagedSession {
+    return this.reaper.manage(session, agent);
+  }
+
+  /** Fire every wake now due. Wire as the scheduler's `onTick`. */
+  dispatchDue(now: Date = new Date()): Promise<SessionWakeEntry[]> {
+    return this.registry.dispatchDue(now);
+  }
+
+  /** Register the consumer that drives woken turns (else they run headless). */
+  setSessionWakeHandler(handler: SessionWakeHandler | undefined): void {
+    this.sessionWakeHandler = handler;
+  }
+
+  /**
+   * Resume the wake's session and inject its prompt, then either hand the live
+   * session to the registered consumer or drain it to completion. The resumed
+   * session is opened with `manageLifecycle`, so its own Stop hook re-captures
+   * any new wakeups and reaps it when idle.
+   */
+  private async fire(entry: SessionWakeEntry): Promise<void> {
+    const session = await this.openChatSession(entry.agent, {
+      resume: entry.sessionId,
+      prompt: entry.prompt,
+      manageLifecycle: true,
+    });
+
+    if (this.sessionWakeHandler) {
+      await this.sessionWakeHandler(session, entry);
+      return;
+    }
+
+    // Headless: consume the stream so the turn actually runs. The reaper closes
+    // the session when the turn goes idle, which ends this iteration.
+    for await (const _message of session.messages) {
+      // Drain — output delivery is the consumer's job when a handler is set.
+    }
+  }
+}


### PR DESCRIPTION
**Stacked on #308** (`feat/session-reaper`). Part 2 of #307 — makes the reaper + wake registry from #308 actually run inside a `FleetManager`, so a consumer (edspencer/paddock#111) gets reap-on-idle + cross-turn wake re-triggering end-to-end.

## What this adds
- **`SessionLifecycleManager`** (`session/session-lifecycle-manager.ts`) — one facade assembling `WakeRegistry` + `SessionReaper` + `FleetStateWakePersistence` + the cron resolver (`scheduler/cron.ts`) + the **resume-and-inject** fire path. Firing a due wake calls `openChatSession({ resume, prompt, manageLifecycle: true })`, then either hands the live (already-managed) session to a registered consumer or **drains it headlessly** so recurring wakeups keep firing with no consumer attached.
- **`FleetManager`** constructs one `SessionLifecycleManager` (both init paths) and passes **`onTick: () => dispatchDue()`** to the `Scheduler` — due wakes fire on the existing loop, no second timer. New public surface: `getSessionLifecycle()` and **`setSessionWakeHandler(handler)`** (the consumer hook for delivering woken turns onto a hub/attribution path — paddock#111 gap 3).
- **`ChatSessionOptions.manageLifecycle`** — opt a streaming session into managed lifecycle. `JobControl.openChatSession` wires the session's `onLifecycleSignal` to `reaper.manage(session)` via a late-bound handle (the managed handle needs the session to close it; the first signal only arrives at the first turn's end, well after `manage()` runs).
- **`FleetManagerContext.getSessionLifecycle()`**.

## Safety / compatibility
No behavior change unless a caller opts in via `manageLifecycle` (or registers a wake handler). Existing `openChatSession` callers keep owning `close()`.

## Testing
- 5 new unit tests for `SessionLifecycleManager` (manage-tracks-liveness, resume-and-inject fire, consumer-handler delegation, runtime handler swap, not-yet-due).
- `typecheck` + `build` green; full suite **3204 passing** (only the pre-existing root-only `directory.test.ts` skipped), core coverage **80%** (all thresholds green).

## CI note
This PR's base is the feature branch `feat/session-reaper`, not `main`, so the repo workflows (Lint/Typecheck/Unit/Web-UI/Build) **won't run until it retargets to `main`** (auto-happens when #308 merges + its branch is deleted). Gates were run locally and are green. Merge #308 first, then this retargets to `main` and picks up CI (close/reopen to force the run if needed).

## Still open after this (tracked, not in scope)
- The `CronDelete` targeted watch (gap 4b) — recurring wakes currently retire on 7-day expiry or an explicit `registry.remove(id)`.
- The Paddock-side consumer that calls `setSessionWakeHandler` and threads retention config (paddock#111).

Refs #307, edspencer/paddock#111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in session lifecycle management for fleet chats, including wake handling, automatic re-triggering of due sessions, and idle session reaping.
  * Fleet now exposes controls to access lifecycle management and register a wake handler.
* **Bug Fixes**
  * Due session wakes are now processed on the existing scheduler loop, improving reliability of recurring wakeups.
  * Future wakes are left untouched until their scheduled time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->