### PR TITLE
fix(core): resolve session wakes in host-local tz, not UTC (#311)

### DIFF
--- a/.changeset/session-wake-local-tz.md
+++ b/.changeset/session-wake-local-tz.md
@@ -1,0 +1,9 @@
+---
+"@herdctl/core": patch
+---
+
+Fix session `ScheduleWakeup` resolving ~24h late when the host timezone is behind UTC (edspencer/herdctl#311).
+
+The SDK/native harness serializes a relative one-shot `ScheduleWakeup` (and `CronCreate` schedules) as a wall-clock cron expression in the **host's local timezone** — e.g. a "+60s" wake at 19:08 local becomes `"10 19 * * *"`. The session reaper's default wake resolver, however, resolved that cron in **UTC**. On a host behind UTC, the local wall-clock minute/hour has often already passed in UTC, so `nextRunAt` rolled to *tomorrow* and the wake sat idle for ~24h instead of firing in a minute.
+
+`SessionLifecycleManager`'s default `resolveNextRun` now resolves session-cron schedules in the host's system timezone (via `calculateNextCronTrigger`), matching both the timezone the harness serialized them in and how the rest of the scheduler (`scheduler.ts`, `schedule-runner.ts`) already resolves fleet crons. Consumers that inject a custom `resolveNextRun` are unaffected.

--- a/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
+++ b/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeSession } from "../../runner/runtime/interface.js";
 import { FleetStateWakePersistence } from "../fleet-state-wake-persistence.js";
 import {
+  defaultResolveNextRun,
   SessionLifecycleManager,
   type SessionWakeChatOptions,
 } from "../session-lifecycle-manager.js";
@@ -124,5 +125,45 @@ describe("SessionLifecycleManager", () => {
     const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
     expect(await slm.dispatchDue(NOW)).toEqual([]);
     expect(openChatSession).not.toHaveBeenCalled();
+  });
+});
+
+// Regression: edspencer/herdctl#311 — the harness serializes a relative one-shot
+// ScheduleWakeup as a wall-clock cron in the host's LOCAL timezone, so the wake
+// must be resolved in that same timezone. Resolving it as UTC on a host behind
+// UTC rolls the next fire time to tomorrow, so a "+60s" wake never fires today.
+describe("defaultResolveNextRun (session wake tz)", () => {
+  const originalTZ = process.env.TZ;
+
+  afterEach(() => {
+    if (originalTZ === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTZ;
+  });
+
+  it("resolves a local-time one-shot cron to ~1 minute out, not ~24h, when host tz is behind UTC", () => {
+    // Host tz America/New_York (UTC-4 in July). Real wall-clock 19:08 EDT ==
+    // 23:08 UTC. A "+60s" ScheduleWakeup is serialized by the harness as the
+    // local target minute/hour: "10 19 * * *" (19:10 EDT).
+    process.env.TZ = "America/New_York";
+    const now = new Date("2026-07-09T23:08:46.380Z"); // 19:08:46 EDT
+    const schedule = "10 19 * * *"; // 19:10 local == 23:10 UTC
+
+    const next = defaultResolveNextRun(schedule, now);
+
+    // Correct: next fire is 19:10 EDT today == 23:10 UTC, ~74s out.
+    expect(next.toISOString()).toBe("2026-07-09T23:10:00.000Z");
+    const deltaMs = next.getTime() - now.getTime();
+    expect(deltaMs).toBeGreaterThan(0);
+    expect(deltaMs).toBeLessThan(5 * 60_000); // minutes out, not ~20h
+  });
+
+  it("resolves the same cron in UTC to ~24h out (documents the pre-fix behavior)", async () => {
+    // Guard against a regression to UTC resolution: the old resolver treated the
+    // local cron as UTC, so "10 19 * * *" from 23:08 UTC rolled to tomorrow.
+    process.env.TZ = "UTC";
+    const { getNextCronTrigger } = await import("../../scheduler/cron.js");
+    const now = new Date("2026-07-09T23:08:46.380Z");
+    const utcNext = getNextCronTrigger("10 19 * * *", now);
+    expect(utcNext.toISOString()).toBe("2026-07-10T19:10:00.000Z"); // ~20h late — the bug
   });
 });

--- a/packages/core/src/session/session-lifecycle-manager.ts
+++ b/packages/core/src/session/session-lifecycle-manager.ts
@@ -10,7 +10,7 @@
  */
 
 import type { RuntimeSession } from "../runner/runtime/interface.js";
-import { getNextCronTrigger } from "../scheduler/cron.js";
+import { calculateNextCronTrigger } from "../scheduler/cron.js";
 import { createLogger } from "../utils/logger.js";
 import { FleetStateWakePersistence } from "./fleet-state-wake-persistence.js";
 import { type ManagedSession, SessionReaper } from "./session-reaper.js";
@@ -48,7 +48,7 @@ export interface SessionLifecycleManagerOptions {
   openChatSession: (agent: string, options: SessionWakeChatOptions) => Promise<RuntimeSession>;
   /** Max concurrent wake fires per tick (gap 2). */
   concurrency?: number;
-  /** Override the cron resolver (defaults to `scheduler/cron.ts`, UTC). */
+  /** Override the cron resolver (defaults to `scheduler/cron.ts`, host-local tz). */
   resolveNextRun?: NextRunResolver;
   /** Consumer hook for delivering the woken turn (attribution/hub path). */
   sessionWakeHandler?: SessionWakeHandler;
@@ -61,9 +61,23 @@ export interface SessionLifecycleManagerOptions {
   }) => void;
 }
 
-/** Default cron resolver — herdctl's own parser, matching the SDK's UTC crons. */
-function defaultResolveNextRun(schedule: string, from: Date): Date {
-  return getNextCronTrigger(schedule, from);
+/**
+ * Default cron resolver for session-only wakes.
+ *
+ * The SDK/native harness serializes a relative one-shot `ScheduleWakeup` (and
+ * `CronCreate` schedules) as a wall-clock cron expression in the **host's local
+ * timezone** — e.g. a "+60s" wake at 19:08 local becomes `"10 19 * * *"`. So the
+ * cron must be resolved back in that same local timezone, not UTC: resolving
+ * `"10 19 * * *"` as UTC while the host is behind UTC rolls `nextRunAt` to
+ * tomorrow, and the wake silently sits idle for ~24h (edspencer/herdctl#311).
+ *
+ * `calculateNextCronTrigger` resolves in the host's system timezone
+ * (`Intl.DateTimeFormat().resolvedOptions().timeZone`), which is exactly the
+ * timezone the harness serialized the cron in — and matches how the rest of the
+ * scheduler (`scheduler.ts`, `schedule-runner.ts`) resolves fleet crons.
+ */
+export function defaultResolveNextRun(schedule: string, from: Date): Date {
+  return calculateNextCronTrigger(schedule, from);
 }
 
 export class SessionLifecycleManager {


### PR DESCRIPTION
Fixes #311.

## Problem

A session-only `ScheduleWakeup` (a *relative* "wake me in N seconds/minutes") resolved its next-run time **~24h in the future** whenever the host timezone is behind UTC.

The SDK/native harness serializes a relative one-shot `ScheduleWakeup` (and `CronCreate` schedules) as a wall-clock cron expression in the **host's local timezone** — e.g. a "+60s" wake at `19:08` local becomes `"10 19 * * *"`. But `SessionLifecycleManager`'s default `resolveNextRun` resolved that cron in **UTC** (`getNextCronTrigger`). On a host behind UTC, the local wall-clock minute/hour has usually already passed in UTC today, so `nextRunAt` rolled to *tomorrow* — a "1 minute from now" wake effectively never fired until the next day.

`SessionCronSummary` only exposes the cron `schedule` string (no absolute fire instant or original delay), so the issue's "preferred" fix — carrying the absolute instant — isn't reachable from the SDK type. The correct fix is the fallback: resolve the cron in the same timezone the harness serialized it in (host-local).

## Fix

`SessionLifecycleManager`'s default `resolveNextRun` now resolves session-cron schedules in the host's **system timezone** via `calculateNextCronTrigger` instead of UTC via `getNextCronTrigger`. This matches:

- the timezone the harness serialized the cron in, and
- how the rest of the scheduler (`scheduler.ts`, `schedule-runner.ts`) already resolves fleet crons (they were the only consistent-with-local path; the session default was the lone UTC outlier).

Consumers that inject a custom `resolveNextRun` are unaffected. No public API change.

## Test

Adds a deterministic, machine-independent regression test under a non-UTC `TZ` (`America/New_York`):

- proves a "+60s" wake (`"10 19 * * *"` serialized at `23:08 UTC` / `19:08 EDT`) resolves to `23:10 UTC` — ~74s out, not tomorrow.
- a companion assertion documents the pre-fix UTC behavior (`2026-07-10T19:10Z`, ~20h late) to guard against a regression back to UTC resolution.

## Verification

- `vitest run src/session src/scheduler` — 326 passed
- `tsc --noEmit` (core) — clean
- `pnpm --filter @herdctl/core build` — clean

Refs #307, edspencer/paddock#111.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session wakeups scheduled with relative one-shot schedules being delayed by approximately 24 hours on hosts behind UTC.
  * Session wake times now correctly follow the host’s local timezone, matching schedule behavior across the platform.

* **Tests**
  * Added regression coverage for timezone-sensitive session scheduling in both local and UTC environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->