### PR TITLE
docs: auto-update documentation (2026-07-10)

### DIFF
--- a/agents/docs/state.md
+++ b/agents/docs/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 9c7ac85
-last_run: "2026-06-30T03:08:55Z"
-docs_gaps_found: 3
-branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13", "docs/auto-update-2026-06-30"]
+last_checked_commit: eed88a1
+last_run: "2026-07-10T23:17:20Z"
+docs_gaps_found: 7
+branches_created: ["docs/auto-update-2026-02-21", "docs/auto-update-2026-03-01", "docs/auto-update-2026-03-05", "docs/auto-update-2026-03-07", "docs/auto-update-2026-03-13", "docs/auto-update-2026-06-30", "docs/auto-update-2026-07-10"]
 status: completed
 ---
 
 # Documentation Audit State
 
-**Last Updated:** 2026-06-30
+**Last Updated:** 2026-07-10
 
 This document tracks the state of the documentation audit agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 9c7ac85 | ci: run the @herdctl/web Playwright integration suite in CI |
-| Last run | 2026-06-30T03:08:55Z | Manual invocation |
-| Gaps found (last run) | 3 | Programmatic agent management API, SDK message translator, session cache improvements |
-| Branches created | docs/auto-update-2026-06-30 | Added FleetManager API docs, @herdctl/chat translator, session methods |
+| Last checked commit | eed88a1 | chore: version packages (#318) |
+| Last run | 2026-07-10T23:17:20Z | Manual invocation |
+| Gaps found (last run) | 7 | openChatSession, session reaper + wakes, trigger fork, cancelJob interrupt, translator attribution, ChatMessage.uuid, stale What's New |
+| Branches created | docs/auto-update-2026-07-10 | Streaming sessions + reaper/wake docs, fork/cancelJob/uuid reference updates, What's New refresh |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Gaps Found | Action | Branch |
 |------|-----------------|------------|--------|--------|
+| 2026-07-10 | 51 | 7 | created-branch | docs/auto-update-2026-07-10 |
 | 2026-06-30 | 20 | 3 | created-branch | docs/auto-update-2026-06-30 |
 | 2026-03-13 | 3 | 5 | created-branch | docs/auto-update-2026-03-13 |
 | 2026-03-07 | 4 | 1 | created-branch | docs/auto-update-2026-03-07 |

--- a/docs/src/content/docs/architecture/chat-infrastructure.md
+++ b/docs/src/content/docs/architecture/chat-infrastructure.md
@@ -166,9 +166,9 @@ import { createSDKMessageHandler } from '@herdctl/chat';
 
 // Create a message handler
 const onMessage = createSDKMessageHandler({
-  onText: (text) => stream(text),
+  onText: (text, attribution) => stream(text, attribution),
   onToolCall: (call) => renderTool(call),
-  onBoundary: () => startNewBubble(),
+  onBoundary: (attribution) => startNewBubble(attribution),
 });
 
 // Use it with trigger
@@ -179,6 +179,27 @@ await fleet.trigger('agent', undefined, {
 ```
 
 The translator tracks pending `tool_use` blocks so they can be paired with their `tool_result` when it arrives later in the stream. It also detects when a new assistant turn begins after a previous one produced text, so transports can split message bubbles appropriately.
+
+### Agent Attribution
+
+Every emitted event carries **agent attribution** identifying which agent produced it — the main agent or a `Task`-spawned subagent. The Claude Agent SDK sets `parent_tool_use_id` on every `assistant`/`user` message: `null` (or absent) for the main agent, or the `Task` tool_use ID of the subagent that produced it. The translator surfaces this so consumers can group events into per-agent lanes:
+
+- `onText(text, attribution)` and `onBoundary(attribution)` receive an `AgentAttribution` as their attribution argument.
+- `TranslatedToolCall` includes a `parentToolUseId` field, attributed to the agent that *issued* the `tool_use` (a tracked main-agent tool call keeps its `null` even when its result arrives on a subagent-attributed message; only a truly untracked result falls back to the result message's attribution).
+
+```typescript
+import { getAgentAttribution, type AgentAttribution } from '@herdctl/chat';
+
+interface AgentAttribution {
+  // null for the main agent, else the spawning Task tool_use id
+  parentToolUseId: string | null;
+}
+
+// Read attribution off a raw SDK message directly
+const attribution = getAgentAttribution(message);
+```
+
+The `Task` tool_use ID seen on the main stream correlates with the subagent's `parent_tool_use_id`, so a UI can nest a subagent's text and tool calls under the `Task` call that spawned it. The change is additive — handlers that ignore the attribution argument keep working unchanged.
 
 For reusable instances (e.g., a long-lived WebSocket connection), create the translator directly and call `handle()` per message:
 

--- a/docs/src/content/docs/architecture/scheduler.md
+++ b/docs/src/content/docs/architecture/scheduler.md
@@ -53,6 +53,7 @@ const scheduler = new Scheduler({
 | `stateDir` | string | required | Path to `.herdctl` state directory |
 | `logger` | SchedulerLogger | console | Logger instance with debug/info/warn/error |
 | `onTrigger` | callback | undefined | Called when a schedule triggers |
+| `onTick` | `() => Promise<void> \| void` | undefined | Called once per tick, after config schedules are checked (see [Tick Hook](#tick-hook-ontick)) |
 
 ### Lifecycle Methods
 
@@ -101,6 +102,24 @@ private async runLoop(): Promise<void> {
   }
 }
 ```
+
+### Tick Hook (onTick)
+
+The `onTick` option is a seam for time-based work that isn't a config schedule. It is invoked once per tick, after `checkAllSchedules()` and before the sleep. A throw is logged and swallowed so a misbehaving hook cannot wedge the loop:
+
+```typescript
+if (this.onTick) {
+  try {
+    await this.onTick();
+  } catch (error) {
+    this.logger.error(`Error during scheduler tick hook: ...`);
+  }
+}
+```
+
+Its primary consumer is the **session-wake registry**: `FleetManager` wires `onTick: () => sessionLifecycle.dispatchDue()`, so durable session wakes (captured `ScheduleWakeup`/`CronCreate` timers from reaped chat sessions) fire on the existing scheduler loop instead of a second timer. Each dispatch prunes expired wakes, finds entries whose `nextRunAt` has passed (skipping sessions that are still live), and resumes each due session with its wake prompt — at most 4 concurrent fires per tick. Like fleet cron schedules, wake cron expressions are resolved in the host's local timezone.
+
+See [Sessions: Managed Session Lifecycle](/concepts/sessions/#managed-session-lifecycle-reaping-and-wakes) and [State Persistence: Session Wakes](/architecture/state-management/#session-wakes).
 
 ### Abort Handling
 

--- a/docs/src/content/docs/architecture/session-discovery.md
+++ b/docs/src/content/docs/architecture/session-discovery.md
@@ -48,7 +48,7 @@ If the file does not exist or cannot be opened, the reader returns `null` and th
 
 | Function | Purpose |
 |----------|---------|
-| `parseSessionMessages(filePath, options?)` | Parse a full session into `ChatMessage[]` with tool call/result pairing |
+| `parseSessionMessages(filePath, options?)` | Parse a full session into `ChatMessage[]` with tool call/result pairing. Each message carries the stable `uuid` of its source JSONL entry (see below) |
 | `extractSessionMetadata(filePath)` | Extract summary metadata (timestamps, message count, git branch, preview, sidechain status) |
 | `extractSessionUsage(filePath)` | Extract token usage data (input tokens, turn count) |
 | `isSidechainSession(filePath)` | O(1) check -- reads only the first JSONL line to detect sub-agent sessions |
@@ -71,6 +71,16 @@ if (messageId) {
 ### Tool Call/Result Pairing
 
 Assistant messages contain `tool_use` content blocks; the subsequent user message contains the matching `tool_result` blocks. The parser maintains a `Map<string, PendingToolUse>` keyed by tool use ID. When a tool_use block is encountered, it is stored as pending. When the matching tool_result arrives, the parser pairs them to produce a `ChatMessage` with role `"tool"` that includes both the tool name, input summary, output, error status, and duration.
+
+### Stable Message IDs
+
+Each JSONL transcript entry carries a stable `uuid` — assigned when the line is written, append-only, and preserved across reloads and session forks. `parseSessionMessages` surfaces it as an optional `uuid` field on each `ChatMessage`:
+
+- User and assistant messages take their own line's `uuid`.
+- A paired tool message takes the **originating `tool_use` entry's** `uuid`, so the ID stays deterministic even when several `tool_result`s share a single user line. An orphan tool_result with no matching tool_use falls back to its own line's uuid.
+- `uuid` is `undefined` when the source line carries none, so existing consumers are unaffected.
+
+This gives UIs a reload-stable identifier for keying per-message state (React list keys, collapse/pin state, deep links) instead of falling back to array indexes.
 
 ### SessionMetadata Type
 

--- a/docs/src/content/docs/architecture/state-management.md
+++ b/docs/src/content/docs/architecture/state-management.md
@@ -91,6 +91,17 @@ agents:
     next_schedule: null
     next_trigger_at: null
     container_id: "def456"
+
+session_wakes:                # Captured session wakes, keyed by SDK cron ID
+  cron-abc123:
+    id: cron-abc123
+    agent: bragdoc-coder
+    sessionId: claude-session-xyz789
+    schedule: "10 19 * * *"
+    recurring: false
+    prompt: "Check whether the CI run finished."
+    nextRunAt: "2026-07-09T23:10:00.000Z"
+    createdAt: "2026-07-09T23:08:46.380Z"
 ```
 
 ### Zod Schema
@@ -103,10 +114,11 @@ const FleetStateSchema = z.object({
     started_at: z.string().optional(),
   }).optional().default({}),
   agents: z.record(z.string(), AgentStateSchema).optional().default({}),
+  session_wakes: z.record(z.string(), SessionWakeSchema).optional(),
 });
 ```
 
-When `state.yaml` is missing or empty, the schema defaults produce a valid empty state (`{ fleet: {}, agents: {} }`).
+When `state.yaml` is missing or empty, the schema defaults produce a valid empty state (`{ fleet: {}, agents: {} }`). The `session_wakes` slice is optional with no default — it only appears once a lifecycle-managed session has scheduled a wake.
 
 ### Agent State Fields
 
@@ -421,6 +433,48 @@ The `createDefaultScheduleState()` factory function initializes a new schedule w
 
 For more details on schedule state, see [Scheduler Architecture](/architecture/scheduler/).
 
+## Session Wakes
+
+The optional top-level `session_wakes` slice of `state.yaml` stores durable **wake entries** captured from lifecycle-managed streaming chat sessions (see [Sessions: Managed Session Lifecycle](/concepts/sessions/#managed-session-lifecycle-reaping-and-wakes)). When an agent schedules a timer-class wakeup in-session (`ScheduleWakeup` or `CronCreate`), the SDK reports the session's pending crons at turn end; herdctl reconciles them into this slice so they survive both the session reap and fleet restarts. The scheduler fires due wakes on its polling loop, resuming the session with the wake's prompt.
+
+```yaml
+session_wakes:
+  <sdk-cron-id>:
+    id: <sdk-cron-id>           # SDK cron ID — reconciliation key across turns
+    agent: bragdoc-coder        # Qualified agent name that owns the session
+    sessionId: claude-session-xyz789  # Session resumed when the wake fires
+    schedule: "10 19 * * *"     # Cron expression (one-shot wakes encode a single fire time)
+    recurring: false            # false = one-shot; true = re-fires on every match
+    prompt: "Check whether the CI run finished."
+    nextRunAt: "2026-07-09T23:10:00.000Z"  # Resolved absolute next fire time
+    createdAt: "2026-07-09T23:08:46.380Z"  # Capture time — anchors recurring expiry
+```
+
+### Session Wake Fields
+
+Entries are validated against `SessionWakeSchema` (in `packages/core/src/state/schemas/fleet-state.ts`). All fields are required within an entry:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | SDK cron ID — the reconciliation key across turns |
+| `agent` | `string` | Qualified agent name that owns the session |
+| `sessionId` | `string` | Session ID resumed when the wake fires |
+| `schedule` | `string` | Cron expression; a one-shot `ScheduleWakeup` encodes a single fire time |
+| `recurring` | `boolean` | `false` for one-shot wakeups; `true` for crons that re-fire on every match |
+| `prompt` | `string` | Prompt injected into the resumed session when the wake fires |
+| `nextRunAt` | `string` (ISO) | Resolved absolute next fire time — stored so an overdue fleet fires immediately on startup |
+| `createdAt` | `string` (ISO) | When the wake was first captured — anchors the 7-day recurring-wake expiry |
+
+### Wake Reconciliation Rules
+
+The wake registry reconciles the SDK's reported crons against the stored set on every turn end:
+
+- **New ID** (reported but not stored) — captured, with `nextRunAt` resolved immediately. Cron expressions are resolved in the **host's local timezone**, matching how Claude Code serializes them.
+- **Known ID** (both) — the stored entry is kept unchanged, so re-reporting doesn't reset a recurring cycle.
+- **Dropped ID** (stored but no longer reported) — a one-shot is removed (it fired or was cancelled); a recurring wake is *kept*, because a herdctl-fired resumed turn legitimately reports empty. Recurring wakes are retired only by the 7-day expiry (`RECURRING_WAKE_MAX_AGE_MS`) or explicit removal.
+
+Reads and writes go through the same atomic `readFleetState()`/`writeFleetState()` helpers as the rest of `state.yaml`, via the `FleetStateWakePersistence` adapter.
+
 ## Atomic Write Pattern
 
 All state file writes (YAML and JSON) use atomic writes to prevent corruption. This is implemented in `packages/core/src/state/utils/atomic.ts`.
@@ -607,7 +661,7 @@ packages/core/src/state/
 ├── index.ts              # Public exports
 ├── schemas/
 │   ├── index.ts          # Schema exports
-│   ├── fleet-state.ts    # FleetStateSchema, AgentStateSchema, ScheduleStateSchema
+│   ├── fleet-state.ts    # FleetStateSchema, AgentStateSchema, ScheduleStateSchema, SessionWakeSchema
 │   ├── job-metadata.ts   # JobMetadataSchema, TriggerTypeSchema, ExitReasonSchema
 │   ├── job-output.ts     # JobOutputMessageSchema (discriminated union)
 │   └── session-info.ts   # SessionInfoSchema, SessionModeSchema

--- a/docs/src/content/docs/concepts/sessions.md
+++ b/docs/src/content/docs/concepts/sessions.md
@@ -238,6 +238,20 @@ herdctl session fork <session-id> --run --prompt "Try a different approach"
 herdctl session fork <session-id> --at-message 5
 ```
 
+### Forking from the Library
+
+Programmatically, pass `fork` to `FleetManager.trigger()`. The run resumes the source session's transcript as context but writes all new turns to a **brand-new session ID** (via Claude Code's `--fork-session`), leaving the source session untouched:
+
+```typescript
+const job = await manager.trigger('my-agent', undefined, {
+  fork: 'source-session-id',        // Mutually exclusive with `resume`
+  forkedFrom: 'job-2026-07-01-abc123', // Optional lineage metadata
+  prompt: 'Try a different approach from here',
+});
+```
+
+The child session ID is reported the same way a fresh session's is — on the `system`/`init` message and on the final result. `fork` and `resume` are mutually exclusive; when both are set, `fork` takes precedence. See the [trigger() reference](/library-reference/fleet-manager/#triggeragentname-schedulename-options) for details.
+
 ### Fork Use Cases
 
 1. **Experimentation**: Try different solutions without losing progress
@@ -250,6 +264,35 @@ Original Session:
                  ↓
 Forked Session:  M4' → M5' (different approach)
 ```
+
+## Streaming Chat Sessions
+
+Beyond one-shot job triggers, herdctl can hold a **live, multi-turn streaming session** with an agent. `FleetManager.openChatSession()` returns a `RuntimeSession` handle that supports sending follow-up turns (`send()`), interrupting a runaway turn without losing the session (`interrupt()`), discovering the available slash commands (`listCommands()`), and switching models mid-conversation (`setModel()`). Slash commands are just user messages — sending `"/compact"` runs the command in-session.
+
+Streaming sessions always run on the SDK runtime, even for `runtime: cli` agents (they share the same auth and on-disk session store); only Docker-wrapped agents are unsupported. This is the primitive behind interactive chat UIs like the web dashboard.
+
+See [openChatSession() in the FleetManager reference](/library-reference/fleet-manager/#openchatsessionagentname-options) for the full API.
+
+## Managed Session Lifecycle (Reaping and Wakes)
+
+A live streaming session keeps a warm `claude` process around (~300 MB each). Sessions opened with `manageLifecycle: true` opt in to herdctl-managed lifecycle:
+
+- **Reap on idle** — the session is closed the instant its turn ends, *unless* it holds live background work (running shells, subagents, monitors). Resuming later recovers the full conversation, and Claude's prompt cache is server-side and survives the reap, so closing an idle session costs only ~0.5s of respawn time.
+- **Durable wakes** — timer-class wakeups the agent scheduled in-session (`ScheduleWakeup` one-shots, `CronCreate` recurring crons) would normally die with the `claude` process. Instead, herdctl captures them as durable wake entries in `state.yaml` (`session_wakes`) and re-fires them from its own scheduler loop, resuming the session with the wake's prompt.
+
+Wake semantics:
+
+| Behavior | Rule |
+|----------|------|
+| One-shot wakes | Fire once, then removed |
+| Recurring wakes | Re-arm after each fire; auto-expire **7 days** after capture |
+| Timezone | Cron expressions resolve in the **host's local timezone**, not UTC (matching how Claude Code serializes them) |
+| Live sessions | A due wake is skipped while its session is still open — the session's own next turn re-captures it |
+| Persistence | Wake entries survive fleet restarts (stored in `state.yaml`) |
+
+Consumers that want to deliver woken turns somewhere (e.g. a chat UI) register a handler via `FleetManager.setSessionWakeHandler()`; without one, herdctl drains the woken turn headlessly so recurring wakes keep firing.
+
+See [Session Lifecycle Methods](/library-reference/fleet-manager/#session-lifecycle-methods) for the API and [State Persistence](/architecture/state-management/#session-wakes) for the on-disk format.
 
 ## Example Configurations
 
@@ -504,4 +547,5 @@ Auto-generated names are cached in the `SessionMetadataStore` so that session li
 - [Jobs](/concepts/jobs/) - Individual executions that use sessions
 - [Agents](/concepts/agents/) - Configure session behavior per agent
 - [State Management](/architecture/state-management/) - Session persistence details
+- [FleetManager API](/library-reference/fleet-manager/#session-management-methods) - Programmatic session management, streaming chat sessions, and forking
 - [CLI Reference: sessions](/cli-reference/#sessions) - Full command options for session management

--- a/docs/src/content/docs/guides/recipes.mdx
+++ b/docs/src/content/docs/guides/recipes.mdx
@@ -729,7 +729,7 @@ my-fleet/
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@herdctl/core": "^0.1.0"
+    "@herdctl/core": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
@@ -896,7 +896,7 @@ packages:
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@herdctl/core": "^0.1.0",
+    "@herdctl/core": "^5.0.0",
     "@repo/shared": "workspace:*",
     "@repo/agent-prompts": "workspace:*"
   }

--- a/docs/src/content/docs/library-reference/error-handling.mdx
+++ b/docs/src/content/docs/library-reference/error-handling.mdx
@@ -361,6 +361,42 @@ try {
 
 ---
 
+### StreamingSessionUnsupportedError
+
+Thrown when an agent cannot open a streaming chat session.
+
+```typescript
+class StreamingSessionUnsupportedError extends FleetManagerError {
+  runtime?: string; // The runtime type that does not support streaming sessions
+}
+```
+
+**Common Causes:**
+- The agent is Docker-wrapped (`docker.enabled: true`) — streaming sessions require the SDK runtime, which cannot drive a containerized agent
+
+Thrown by `openChatSession()` and, transitively, by `listAgentCommands()`. Note that `runtime: cli` agents do *not* trigger this error — streaming sessions always run on the SDK runtime regardless of the agent's configured runtime.
+
+**Example:**
+
+```typescript
+import { StreamingSessionUnsupportedError } from '@herdctl/core';
+
+try {
+  const session = await manager.openChatSession('docker-agent');
+} catch (error) {
+  if (error instanceof StreamingSessionUnsupportedError) {
+    console.error(`Streaming not supported: ${error.message}`);
+    if (error.runtime) {
+      console.error(`Runtime: ${error.runtime}`); // e.g. "docker"
+    }
+    // Fall back to one-shot triggers
+    await manager.trigger('docker-agent', undefined, { prompt });
+  }
+}
+```
+
+---
+
 ### FleetManagerShutdownError
 
 Thrown when fleet shutdown fails.
@@ -885,6 +921,9 @@ const FleetManagerErrorCode = {
   // Job Control
   JOB_CANCEL_ERROR: 'JOB_CANCEL_ERROR',
   JOB_FORK_ERROR: 'JOB_FORK_ERROR',
+
+  // Streaming Sessions
+  STREAMING_SESSION_UNSUPPORTED: 'STREAMING_SESSION_UNSUPPORTED',
 } as const;
 ```
 

--- a/docs/src/content/docs/library-reference/fleet-manager.mdx
+++ b/docs/src/content/docs/library-reference/fleet-manager.mdx
@@ -752,12 +752,15 @@ await manager.getAgentSessionMessages(
 
 ```typescript
 interface ChatMessage {
-  role: 'user' | 'assistant';
+  role: 'user' | 'assistant' | 'tool';
   content: string;
-  timestamp?: string;
-  // ... (additional fields)
+  timestamp: string;             // ISO 8601
+  toolCall?: ChatToolCall;       // Present for role: 'tool' (paired tool_use/tool_result)
+  uuid?: string;                 // Stable id from the source transcript entry
 }
 ```
+
+The `uuid` field is the stable ID of the message's source JSONL transcript entry. It is assigned when the line is written, is append-only, and remains stable across reloads and session forks — making it suitable for keying per-message UI state (e.g. React list keys, collapse state, deep links). For a paired tool message, it is the originating `tool_use` entry's uuid, so the ID is deterministic even when several tool results share one user line. It is `undefined` when the source line carried no uuid.
 
 #### Throws
 
@@ -963,6 +966,116 @@ const sessions = await manager.getAgentSessions('my-agent');
 
 ---
 
+### `openChatSession(agentName, options?)`
+
+Opens a long-lived, multi-turn streaming chat session with an agent and returns a live `RuntimeSession` handle.
+
+```typescript
+await manager.openChatSession(
+  agentName: string,
+  options?: ChatSessionOptions
+): Promise<RuntimeSession>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agentName` | `string` | **Yes** | Agent qualified name or local name |
+| `options.prompt` | `string` | No | Optional initial user turn to send when the session opens. When omitted, the session opens idle and the first turn is sent via `session.send(...)` |
+| `options.resume` | `string \| null` | No | Session ID to resume. `string` resumes that session; `null` explicitly starts fresh (skips agent-level fallback); `undefined` falls back to the agent's stored session |
+| `options.workingDirectory` | `string` | No | Override the agent's configured working directory for this session only |
+| `options.injectedMcpServers` | `Record<string, InjectedMcpServerDef>` | No | MCP servers to inject at runtime (in-process SDK servers) |
+| `options.systemPromptAppend` | `string` | No | Text to append to the agent's system prompt for this session |
+| `options.manageLifecycle` | `boolean` | No | Opt in to herdctl-managed session lifecycle (reap-on-idle + durable wakes). See [Session Lifecycle Methods](#session-lifecycle-methods). Default: `false` (caller owns `close()`) |
+
+#### Returns
+
+A live `RuntimeSession`:
+
+```typescript
+interface RuntimeSession {
+  // The live SDK message stream for the session. Iterate to receive output.
+  readonly messages: AsyncIterable<SDKMessage>;
+
+  // Send a user turn. A leading-slash string (e.g. "/compact", "/clear") is
+  // dispatched by Claude Code as a slash command — commands are just user
+  // messages whose text is the command.
+  send(text: string): Promise<void>;
+
+  // Interrupt the current turn without closing the session.
+  // Further send() calls remain valid.
+  interrupt(): Promise<void>;
+
+  // List the slash commands available in this session
+  // (name, description, argument hint). Does not run anything.
+  listCommands(): Promise<SlashCommand[]>;
+
+  // Change the model used for subsequent turns in this session.
+  setModel(model?: string): Promise<void>;
+
+  // Close the session, ending the input stream and shutting down the query.
+  close(): Promise<void>;
+}
+```
+
+#### Description
+
+Unlike `trigger()`, `openChatSession()` does **not** create a job record and does not drain the run to completion — the caller drives the session across turns and must call `session.close()` when finished. This is the primitive behind interactive chat UIs: multi-turn streaming input, mid-turn `interrupt()`, and slash-command discovery via `listCommands()`.
+
+The session **always runs on the SDK runtime**, regardless of the agent's configured `runtime`. This is safe for `cli`-configured agents (same `CLAUDE_CODE_OAUTH_TOKEN` auth, shared on-disk session store) and is what unlocks the SDK control requests (interrupt, listCommands, streaming send), which require streaming input/output mode.
+
+Session resume follows the same precedence as `trigger()`: an explicit `options.resume` string wins; `null` forces a fresh session; `undefined` falls back to the agent's stored session.
+
+The session ID is not a property of the handle — it arrives inside the message stream, on the `system`/`init` message.
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `InvalidStateError` | Fleet manager not initialized |
+| `AgentNotFoundError` | Agent doesn't exist |
+| `StreamingSessionUnsupportedError` | Agent is Docker-wrapped (`docker.enabled: true`) — streaming sessions require the SDK runtime |
+
+#### Example
+
+```typescript
+const session = await manager.openChatSession('my-agent', {
+  prompt: 'Summarize the open PRs',
+});
+
+// Consume the output stream
+const reader = (async () => {
+  for await (const message of session.messages) {
+    if (message.type === 'system' && message.subtype === 'init') {
+      console.log(`Session started: ${message.session_id}`);
+    }
+    // ... render assistant text, tool calls, results
+  }
+})();
+
+// Send follow-up turns — slash commands are just user messages
+await session.send('Now focus on the oldest one');
+await session.send('/compact');
+
+// Stop a runaway turn without losing the session
+await session.interrupt();
+await session.send('Never mind, try a shorter answer');
+
+// Discover available slash commands
+const commands = await session.listCommands();
+
+// Always close when done
+await session.close();
+await reader;
+```
+
+<Aside type="caution">
+A `RuntimeSession` holds a live `claude` query for as long as it is open. Always call `close()` (e.g. in a `finally` block), or opt in to `manageLifecycle: true` to let herdctl reap idle sessions automatically.
+</Aside>
+
+---
+
 ### `listAgentCommands(agentName, options?)`
 
 Lists the slash commands available to an agent — for populating a command palette or autocomplete — in a single call.
@@ -1023,6 +1136,108 @@ for (const cmd of commands) {
 
 ---
 
+## Session Lifecycle Methods
+
+When a streaming chat session is opened with `manageLifecycle: true`, herdctl manages its lifecycle: the session is **reaped** (closed) the instant it goes idle — instead of accumulating warm `claude` processes at roughly 300 MB each — and any timer-class wakeups the agent scheduled in-session (`ScheduleWakeup`, `CronCreate`) are captured as durable **wake entries** and re-fired through the fleet's scheduler, resuming the session with the wake's prompt. Wake entries persist in `state.yaml` under `session_wakes`, so they survive fleet restarts. See [State Persistence](/architecture/state-management/#session-wakes) for the on-disk format and [Sessions](/concepts/sessions/#managed-session-lifecycle-reaping-and-wakes) for the concept.
+
+### `getSessionLifecycle()`
+
+Returns the fleet's session-lifecycle manager, or `null` before `initialize()`.
+
+```typescript
+manager.getSessionLifecycle(): SessionLifecycleManager | null
+```
+
+#### Description
+
+The `SessionLifecycleManager` is the facade over the session reaper and wake registry. It is constructed during `initialize()` and wired into the scheduler loop (due wakes are dispatched once per scheduler tick). Most applications only need `setSessionWakeHandler()`, but the manager is exposed for advanced use:
+
+```typescript
+class SessionLifecycleManager {
+  readonly registry: WakeRegistry;   // Durable wake entries (reconcile/remove/dispatchDue)
+  readonly reaper: SessionReaper;    // Reap-on-idle policy over managed sessions
+
+  manage(session: RuntimeSession, agent: string): ManagedSession;
+  dispatchDue(now?: Date): Promise<SessionWakeEntry[]>;
+  setSessionWakeHandler(handler: SessionWakeHandler | undefined): void;
+}
+```
+
+The reap policy is a single rule: a session is kept alive **if and only if it holds live background work** (running shells, subagents, monitors); otherwise it is reaped as soon as its turn ends. Pending wakeups do *not* keep a session alive — they are captured durably and re-triggered later. Resuming recovers the full conversation, and Claude's prompt cache is server-side, so a reap costs only about half a second of respawn time on the next wake.
+
+#### Example
+
+```typescript
+const lifecycle = manager.getSessionLifecycle();
+if (lifecycle) {
+  // Inspect or force-dispatch due wakes (normally done by the scheduler tick)
+  const fired = await lifecycle.dispatchDue();
+  console.log(`Fired ${fired.length} due wakes`);
+}
+```
+
+---
+
+### `setSessionWakeHandler(handler)`
+
+Registers the consumer hook that receives sessions resumed by a fired wake.
+
+```typescript
+manager.setSessionWakeHandler(
+  handler: SessionWakeHandler | undefined
+): void
+
+type SessionWakeHandler = (
+  session: RuntimeSession,
+  entry: SessionWakeEntry,
+) => void | Promise<void>;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `handler` | `SessionWakeHandler \| undefined` | **Yes** | Called with the already-resumed, lifecycle-managed session and the wake entry that fired. Pass `undefined` to clear |
+
+#### Description
+
+When a wake fires, herdctl resumes the session via `openChatSession({ resume, prompt, manageLifecycle: true })` — the wake's prompt is already injected. If a handler is registered, it receives the live `RuntimeSession` and is responsible for consuming its message stream (e.g. delivering the woken turn to a chat UI). If no handler is registered, the manager drains the stream headlessly so recurring wakes keep firing.
+
+Because the resumed session is itself lifecycle-managed, the reaper closes it again when the woken turn goes idle, so the handler should treat the message stream ending as normal. Safe to call before or after `initialize()`.
+
+The `SessionWakeEntry` describes the wake that fired:
+
+```typescript
+interface SessionWakeEntry {
+  id: string;          // SDK cron id — the reconciliation key across turns
+  agent: string;       // Qualified agent name that owns the session
+  sessionId: string;   // Session resumed when the wake fired
+  schedule: string;    // Cron expression (a one-shot wakeup encodes a single fire time)
+  recurring: boolean;  // false = one-shot; true = re-fires on every match
+  prompt: string;      // Prompt injected into the resumed session
+  nextRunAt: string;   // Resolved absolute next fire time (ISO)
+  createdAt: string;   // ISO capture time — anchors the 7-day recurring expiry
+}
+```
+
+#### Example
+
+```typescript
+manager.setSessionWakeHandler(async (session, entry) => {
+  console.log(`Wake ${entry.id} fired for ${entry.agent} (${entry.sessionId})`);
+  // Deliver the woken turn to your UI
+  for await (const message of session.messages) {
+    renderMessage(message);
+  }
+});
+```
+
+<Aside type="note">
+Cron expressions in session wakes are resolved in the **host's local timezone**, not UTC — matching how Claude Code serializes `ScheduleWakeup`/`CronCreate` schedules and how the scheduler resolves fleet crons. One-shot wakes are removed after firing; recurring wakes re-arm on each fire and auto-expire 7 days after capture.
+</Aside>
+
+---
+
 ## Action Methods
 
 ### `trigger(agentName, scheduleName?, options?)`
@@ -1044,9 +1259,14 @@ await manager.trigger(
 | `agentName` | `string` | **Yes** | Name of the agent to trigger |
 | `scheduleName` | `string` | No | Schedule to use for configuration (prompt, work source) |
 | `options.prompt` | `string` | No | Override the prompt for this trigger |
+| `options.resume` | `string \| null` | No | Session ID to resume for conversation continuity. `string` resumes that session; `null` explicitly starts fresh (skips agent-level fallback); `undefined` uses the agent-level session fallback |
+| `options.fork` | `string` | No | Session ID to **fork**: the run resumes this session's transcript as context but writes all new turns to a brand-new session ID (Claude Code `--fork-session`), leaving the source session untouched. Mutually exclusive with `resume` — when both are set, `fork` takes precedence |
+| `options.forkedFrom` | `string` | No | Parent job ID recorded as the new job's `forked_from` lineage. Only meaningful alongside `fork`; purely informational |
 | `options.workItems` | `WorkItem[]` | No | Custom work items instead of fetching from work source |
 | `options.bypassConcurrencyLimit` | `boolean` | No | Force trigger even if agent is at capacity (default: `false`) |
 | `options.workingDirectory` | `string` | No | Override the agent's configured working directory for this trigger only |
+| `options.onMessage` | `(message: SDKMessage) => void \| Promise<void>` | No | Callback invoked for each SDK message during execution, for real-time streaming of output |
+| `options.onJobCreated` | `(jobId: string) => void \| Promise<void>` | No | Callback invoked as soon as the job ID is created — useful for immediate job control (e.g. enabling cancel while output streams) |
 
 #### Returns
 
@@ -1094,10 +1314,20 @@ const job = await manager.trigger('my-agent', undefined, {
   workingDirectory: '/path/to/specific/project',
   prompt: 'Analyze this project',
 });
+
+// Fork an existing session into an independent child conversation
+const job = await manager.trigger('my-agent', undefined, {
+  fork: 'session-abc123',
+  prompt: 'Try a different approach from here',
+});
 ```
 
 <Aside type="tip">
 Prompt priority: `options.prompt` > schedule prompt > undefined. If you specify a prompt in options, it overrides the schedule's configured prompt.
+</Aside>
+
+<Aside type="note">
+**Forking vs resuming:** `resume` continues writing to the *same* session; `fork` branches it — the new run starts with the source session's full transcript as context but all new turns go to a brand-new session ID, so the source is never modified. The child session ID is reported the same way a fresh session's is (on the `system`/`init` message and the final result). This lets you explore several directions from a shared context without exhausting one context window. See [Sessions: Fork Capability](/concepts/sessions/#fork-capability).
 </Aside>
 
 <Aside type="note">
@@ -1137,7 +1367,14 @@ interface CancelJobResult {
 
 #### Description
 
-Cancels a running job by first sending SIGTERM to allow graceful shutdown. If the job doesn't terminate within the timeout, it will be forcefully killed with SIGKILL.
+Cancels a running job by aborting its in-flight execution and marking the job record `cancelled`. The fleet manager keeps an `AbortController` registered for every job it is currently running; `cancelJob()` fires that controller's abort signal, which genuinely interrupts the run:
+
+- **CLI runtime** — the `claude` subprocess is killed.
+- **SDK runtime** — the in-flight SDK query is aborted.
+
+The aborted run is finalized with `status: cancelled` and `exit_reason: cancelled` (not `failed`), and a `job:cancelled` event is emitted.
+
+If the job is already finished, the call returns early with `terminationType: 'already_stopped'`. If the job was started by a *different* process (the registry is per-process), only the job's status file is updated — the cancellation is best-effort in that case.
 
 #### Throws
 
@@ -1620,6 +1857,7 @@ FleetManagerError (base)
 ├── ConcurrencyLimitError     // Agent at max capacity
 ├── JobCancelError            // Job cancellation failed
 ├── JobForkError              // Job fork failed
+├── StreamingSessionUnsupportedError // Agent runtime can't open streaming sessions
 ├── FleetManagerConfigError   // Legacy config error
 ├── FleetManagerStateError    // Legacy state error
 ├── FleetManagerStateDirError // State directory init failed
@@ -1642,6 +1880,7 @@ const FleetManagerErrorCode = {
   SHUTDOWN_ERROR: 'SHUTDOWN_ERROR',
   JOB_CANCEL_ERROR: 'JOB_CANCEL_ERROR',
   JOB_FORK_ERROR: 'JOB_FORK_ERROR',
+  STREAMING_SESSION_UNSUPPORTED: 'STREAMING_SESSION_UNSUPPORTED',
 };
 ```
 
@@ -1709,6 +1948,13 @@ class InvalidStateError extends FleetManagerError {
   operation: string;              // The attempted operation
   currentState: string;           // Current fleet state
   expectedState: string | string[]; // Required state(s)
+}
+```
+  </TabItem>
+  <TabItem label="StreamingSessionUnsupportedError">
+```typescript
+class StreamingSessionUnsupportedError extends FleetManagerError {
+  runtime?: string;               // Runtime that can't stream (e.g. "docker")
 }
 ```
   </TabItem>

--- a/docs/src/content/docs/library-reference/fleet-manager.mdx
+++ b/docs/src/content/docs/library-reference/fleet-manager.mdx
@@ -184,7 +184,7 @@ await manager.stop(options?: FleetManagerStopOptions): Promise<void>
 | `options.waitForJobs` | `boolean` | No | `true` | Wait for running jobs to complete before stopping |
 | `options.timeout` | `number` | No | `30000` | Maximum time in ms to wait for jobs to complete |
 | `options.cancelOnTimeout` | `boolean` | No | `false` | Cancel jobs that don't complete within timeout |
-| `options.cancelTimeout` | `number` | No | `10000` | Time in ms for each job to respond to SIGTERM before SIGKILL |
+| `options.cancelTimeout` | `number` | No | `10000` | Passed through to each job's `cancelJob()` call; currently unused — cancellation aborts runs immediately |
 
 #### Description
 
@@ -1265,6 +1265,9 @@ await manager.trigger(
 | `options.workItems` | `WorkItem[]` | No | Custom work items instead of fetching from work source |
 | `options.bypassConcurrencyLimit` | `boolean` | No | Force trigger even if agent is at capacity (default: `false`) |
 | `options.workingDirectory` | `string` | No | Override the agent's configured working directory for this trigger only |
+| `options.triggerType` | `string` | No | How the trigger was initiated (`"discord"`, `"slack"`, `"web"`, `"manual"`, ...) — connectors set this to identify the source platform (default: `"manual"`) |
+| `options.systemPromptAppend` | `string` | No | Text appended to the agent's system prompt for this trigger only |
+| `options.injectedMcpServers` | `Record<string, InjectedMcpServerDef>` | No | MCP servers merged with the agent's config-declared servers at execution time, for runtime tool injection |
 | `options.onMessage` | `(message: SDKMessage) => void \| Promise<void>` | No | Callback invoked for each SDK message during execution, for real-time streaming of output |
 | `options.onJobCreated` | `(jobId: string) => void \| Promise<void>` | No | Callback invoked as soon as the job ID is created — useful for immediate job control (e.g. enabling cancel while output streams) |
 
@@ -1352,7 +1355,7 @@ await manager.cancelJob(
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `jobId` | `string` | **Yes** | — | ID of the job to cancel |
-| `options.timeout` | `number` | No | `10000` | Time in ms to wait for graceful shutdown before SIGKILL |
+| `options.timeout` | `number` | No | `10000` | Accepted for backwards compatibility but currently unused — cancellation aborts the run immediately (see Description) |
 
 #### Returns
 

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,90 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Published Package Deduplication Fix
+**July 10, 2026** · `@herdctl/core@5.18.2` · `herdctl@1.5.26` · `@herdctl/chat@0.5.5`
+
+Internal `@herdctl/*` dependencies are now published as caret ranges (`workspace:^`) instead of exact pins. Previously, published packages pinned their herdctl siblings to a single exact version, so downstream projects that installed two herdctl packages cut at different times got duplicate nested copies of `@herdctl/core` that `npm dedupe` could not collapse. Depending on `@herdctl/core` alongside any other herdctl package now resolves to a single copy. No API changes. [#317](https://github.com/edspencer/herdctl/pull/317)
+
+---
+
+### Session Wake Timezone Fix
+**July 10, 2026** · `@herdctl/core@5.18.2`
+
+Fixed session `ScheduleWakeup` timers resolving up to ~24 hours late on hosts behind UTC. Claude Code serializes a relative one-shot wakeup (and `CronCreate` schedules) as a wall-clock cron expression in the host's local timezone, but the wake registry resolved it in UTC — so a "wake me in 60 seconds" could roll over to tomorrow. Session wakes now resolve in the host's system timezone, matching both how the harness serialized them and how the scheduler already resolves fleet crons. [#316](https://github.com/edspencer/herdctl/pull/316)
+
+---
+
+### Stable Per-Message IDs in Session History
+**July 10, 2026** · `@herdctl/core@5.18.1`
+
+`parseSessionMessages` (and therefore `FleetManager.getAgentSessionMessages()`) now surfaces each transcript entry's stable `uuid` on `ChatMessage`. The ID is assigned when the line is written, append-only, and survives reloads and session forks — so UIs can finally key per-message state (React list keys, collapse/pin state, deep links) on something better than an array index. Paired tool messages use the originating `tool_use` entry's uuid so the ID stays deterministic. Additive and optional, so existing consumers are unaffected. [#313](https://github.com/edspencer/herdctl/pull/313)
+
+---
+
+### Session Reaper and Durable Wakes
+**July 9, 2026** · `@herdctl/core@5.18.0`
+
+Streaming chat sessions can now opt in to herdctl-managed lifecycle with `openChatSession({ manageLifecycle: true })`. Managed sessions are reaped the instant they go idle — instead of accumulating warm `claude` processes at ~300 MB each — unless they hold live background work (running shells, subagents, monitors). Timer-class wakeups the agent scheduled in-session (`ScheduleWakeup`, `CronCreate`) are captured as durable wake entries in `state.yaml` and re-fired through the fleet's own scheduler, resuming the session with the wake's prompt; one-shot wakes fire once, recurring wakes re-arm and expire after 7 days. New `FleetManager` surface: `getSessionLifecycle()` and `setSessionWakeHandler()` for delivering woken turns to a consumer. This gives agents real cross-turn autonomy: an agent can say "wake me in 10 minutes" and actually be re-invoked, even though its process was reclaimed in between. [#308](https://github.com/edspencer/herdctl/pull/308), [#309](https://github.com/edspencer/herdctl/pull/309)
+
+---
+
+### Claude Agent SDK 0.3 and Zod 4 Upgrade
+**July 9, 2026** · `@herdctl/core@5.17.0` · `@herdctl/chat@0.5.2`
+
+Upgraded `@anthropic-ai/claude-agent-sdk` from the stale 0.1 line to 0.3, which runs the native Claude Code binary and carries the current agentic toolset (`ScheduleWakeup`, `ToolSearch`, `Cron*`, `Monitor`, ...) — the prerequisite for the session reaper's cross-turn autonomy. Core and chat also moved from `zod@^3` to `zod@^4` to match the SDK's peer dependency, with behavior-preserving fixes for zod 4's changed `.default()` semantics. No `@herdctl/core` public API changes; consumers that compose the exported Zod schema objects with their own Zod instance need to be on `zod@^4`.
+
+---
+
+### Slash Command Discovery
+**July 8, 2026** · `@herdctl/core@5.16.0`
+
+New `FleetManager.listAgentCommands(agentName, options?)` returns the slash commands available to an agent — built-ins, project `.claude/commands`, and MCP-provided commands — in one call, for populating a command palette or autocomplete. It opens a streaming session, reads the command list, and always closes the session, so callers never manage the underlying `claude` subprocess. Works for `cli`-runtime agents too, and re-exports the `SlashCommand` type from `@herdctl/core`.
+
+---
+
+### Agent Attribution in Chat Streams
+**July 7, 2026** · `@herdctl/chat@0.5.0`
+
+The SDK message translator now preserves agent attribution, so chat UIs can separate the main agent from `Task`-spawned subagents into per-agent lanes. `onText` and `onBoundary` receive an `AgentAttribution` argument, and `TranslatedToolCall` gains a `parentToolUseId` field (`null` for the main agent, else the spawning `Task` tool_use ID). New `AgentAttribution` type and `getAgentAttribution()` helper are exported from `@herdctl/chat`. Fully additive — existing handlers keep working unchanged. [#298](https://github.com/edspencer/herdctl/pull/298)
+
+---
+
+### Session Forking via trigger()
+**July 7, 2026** · `@herdctl/core@5.15.0`
+
+`TriggerOptions` gains a `fork` option: `trigger('agent', undefined, { fork: sessionId })` runs a turn that resumes the source session's transcript as context but writes all new turns to a brand-new session ID (Claude Code's `--fork-session`), leaving the source untouched — branch an existing conversation into independent children without exhausting one context window. Also fixed the CLI runtime's fork handling, which previously reported the parent's session ID and missed the child's turns. An optional `forkedFrom` records job lineage. [#291](https://github.com/edspencer/herdctl/pull/291)
+
+---
+
+### Cleaner Chat History
+**July 7, 2026** · `@herdctl/core@5.15.2` · `@herdctl/chat@0.4.8`
+
+Two history-rendering fixes. Session parsing and metadata extraction now skip Claude Code's injected `isMeta: true` user lines (a skill's SKILL.md, slash-command output, hook output), which previously rendered as giant out-of-order user bubbles and skewed message counts and previews. And the CLI's synthetic placeholder assistant turns (model `"<synthetic>"`, e.g. "No response requested." after a `/compact`) are filtered from both live translation and reloaded history.
+
+---
+
+### Real Job Cancellation
+**July 6, 2026** · `@herdctl/core@5.14.1`
+
+`cancelJob()` now actually interrupts a running job. Previously it only rewrote the job's status file to `cancelled` while the agent process kept running to completion. `trigger()` now registers an `AbortController` per run; cancelling aborts it — killing the CLI subprocess or aborting the SDK query — and the aborted run is finalized as `cancelled` rather than `failed`. [#289](https://github.com/edspencer/herdctl/pull/289)
+
+---
+
+### Streaming Chat Sessions
+**July 5, 2026** · `@herdctl/core@5.14.0`
+
+New `FleetManager.openChatSession(agentName, options?)` opens a live, multi-turn streaming session with an agent and returns a `RuntimeSession` handle: `send(text)` for follow-up turns (slash commands like `/compact` are just user messages), `interrupt()` to stop the current turn without losing the session, `listCommands()` for command-palette discovery, `setModel()` to switch models mid-session, and `close()`. Sessions always run on the SDK runtime, so `cli`-runtime agents work too; only Docker-wrapped agents are unsupported (new `StreamingSessionUnsupportedError`). This is the primitive behind interactive chat UIs. [#286](https://github.com/edspencer/herdctl/pull/286)
+
+---
+
+### Session Usage API and Thinking-Turn Fix
+**June 21, 2026** · `@herdctl/core@5.13.0`
+
+New `FleetManager.getAgentSessionUsage(name, sessionId)` returns a session's most recent context-window fill level (last assistant turn's input + cache tokens) and turn count, so a UI can show "context used" for a chat opened from history before any new turn streams fresh usage. Also fixed dropped assistant answers when reloading a chat: extended-thinking turns span multiple JSONL lines sharing one message ID, and the old dedup discarded the actual answer text as a duplicate of the thinking line.
+
+---
+
 ### Discord File Attachment Support
 **March 10, 2026** · `@herdctl/discord@1.2.0` · `@herdctl/core@5.10.0`
 

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -8,9 +8,9 @@ A summary of notable changes across the herdctl packages. For the full technical
 ---
 
 ### Published Package Deduplication Fix
-**July 10, 2026** · `@herdctl/core@5.18.2` · `herdctl@1.5.26` · `@herdctl/chat@0.5.5`
+**July 10, 2026** · `herdctl@1.5.26` · `@herdctl/chat@0.5.5` (and the other packages that declare internal deps)
 
-Internal `@herdctl/*` dependencies are now published as caret ranges (`workspace:^`) instead of exact pins. Previously, published packages pinned their herdctl siblings to a single exact version, so downstream projects that installed two herdctl packages cut at different times got duplicate nested copies of `@herdctl/core` that `npm dedupe` could not collapse. Depending on `@herdctl/core` alongside any other herdctl package now resolves to a single copy. No API changes. [#317](https://github.com/edspencer/herdctl/pull/317)
+Internal `@herdctl/*` dependencies are now published as caret ranges (`workspace:^`) instead of exact pins. Previously, published packages pinned their herdctl siblings to a single exact version, so downstream projects that installed two herdctl packages cut at different times got duplicate nested copies of `@herdctl/core` that `npm dedupe` could not collapse. Depending on `@herdctl/core` alongside any other herdctl package now resolves to a single copy. `@herdctl/core` itself is unchanged (it has no internal dependencies); this patch republished the packages that declare internal deps. No API changes. [#317](https://github.com/edspencer/herdctl/pull/317)
 
 ---
 
@@ -38,14 +38,14 @@ Streaming chat sessions can now opt in to herdctl-managed lifecycle with `openCh
 ### Claude Agent SDK 0.3 and Zod 4 Upgrade
 **July 9, 2026** · `@herdctl/core@5.17.0` · `@herdctl/chat@0.5.2`
 
-Upgraded `@anthropic-ai/claude-agent-sdk` from the stale 0.1 line to 0.3, which runs the native Claude Code binary and carries the current agentic toolset (`ScheduleWakeup`, `ToolSearch`, `Cron*`, `Monitor`, ...) — the prerequisite for the session reaper's cross-turn autonomy. Core and chat also moved from `zod@^3` to `zod@^4` to match the SDK's peer dependency, with behavior-preserving fixes for zod 4's changed `.default()` semantics. No `@herdctl/core` public API changes; consumers that compose the exported Zod schema objects with their own Zod instance need to be on `zod@^4`.
+Upgraded `@anthropic-ai/claude-agent-sdk` from the stale 0.1 line to 0.3, which runs the native Claude Code binary and carries the current agentic toolset (`ScheduleWakeup`, `ToolSearch`, `Cron*`, `Monitor`, ...) — the prerequisite for the session reaper's cross-turn autonomy. Core and chat also moved from `zod@^3` to `zod@^4` to match the SDK's peer dependency, with behavior-preserving fixes for zod 4's changed `.default()` semantics. No `@herdctl/core` public API changes; consumers that compose the exported Zod schema objects with their own Zod instance need to be on `zod@^4`. [#304](https://github.com/edspencer/herdctl/pull/304), [#305](https://github.com/edspencer/herdctl/pull/305)
 
 ---
 
 ### Slash Command Discovery
 **July 8, 2026** · `@herdctl/core@5.16.0`
 
-New `FleetManager.listAgentCommands(agentName, options?)` returns the slash commands available to an agent — built-ins, project `.claude/commands`, and MCP-provided commands — in one call, for populating a command palette or autocomplete. It opens a streaming session, reads the command list, and always closes the session, so callers never manage the underlying `claude` subprocess. Works for `cli`-runtime agents too, and re-exports the `SlashCommand` type from `@herdctl/core`.
+New `FleetManager.listAgentCommands(agentName, options?)` returns the slash commands available to an agent — built-ins, project `.claude/commands`, and MCP-provided commands — in one call, for populating a command palette or autocomplete. It opens a streaming session, reads the command list, and always closes the session, so callers never manage the underlying `claude` subprocess. Works for `cli`-runtime agents too, and re-exports the `SlashCommand` type from `@herdctl/core`. [#301](https://github.com/edspencer/herdctl/pull/301)
 
 ---
 
@@ -56,17 +56,17 @@ The SDK message translator now preserves agent attribution, so chat UIs can sepa
 
 ---
 
+### Cleaner Chat History
+**July 4–7, 2026** · `@herdctl/core@5.13.2` / `@herdctl/core@5.15.2` · `@herdctl/chat@0.4.8`
+
+Two history-rendering fixes. Session parsing (core 5.13.2, July 4) and metadata extraction (core 5.15.2, July 7) now skip Claude Code's injected `isMeta: true` user lines (a skill's SKILL.md, slash-command output, hook output), which previously rendered as giant out-of-order user bubbles and skewed message counts and previews. And the CLI's synthetic placeholder assistant turns (model `"<synthetic>"`, e.g. "No response requested." after a `/compact`) are filtered from both live translation and reloaded history (chat 0.4.8, July 7).
+
+---
+
 ### Session Forking via trigger()
 **July 7, 2026** · `@herdctl/core@5.15.0`
 
 `TriggerOptions` gains a `fork` option: `trigger('agent', undefined, { fork: sessionId })` runs a turn that resumes the source session's transcript as context but writes all new turns to a brand-new session ID (Claude Code's `--fork-session`), leaving the source untouched — branch an existing conversation into independent children without exhausting one context window. Also fixed the CLI runtime's fork handling, which previously reported the parent's session ID and missed the child's turns. An optional `forkedFrom` records job lineage. [#291](https://github.com/edspencer/herdctl/pull/291)
-
----
-
-### Cleaner Chat History
-**July 7, 2026** · `@herdctl/core@5.15.2` · `@herdctl/chat@0.4.8`
-
-Two history-rendering fixes. Session parsing and metadata extraction now skip Claude Code's injected `isMeta: true` user lines (a skill's SKILL.md, slash-command output, hook output), which previously rendered as giant out-of-order user bubbles and skewed message counts and previews. And the CLI's synthetic placeholder assistant turns (model `"<synthetic>"`, e.g. "No response requested." after a `/compact`) are filtered from both live translation and reloaded history.
 
 ---
 
@@ -87,7 +87,7 @@ New `FleetManager.openChatSession(agentName, options?)` opens a live, multi-turn
 ### Session Usage API and Thinking-Turn Fix
 **June 21, 2026** · `@herdctl/core@5.13.0`
 
-New `FleetManager.getAgentSessionUsage(name, sessionId)` returns a session's most recent context-window fill level (last assistant turn's input + cache tokens) and turn count, so a UI can show "context used" for a chat opened from history before any new turn streams fresh usage. Also fixed dropped assistant answers when reloading a chat: extended-thinking turns span multiple JSONL lines sharing one message ID, and the old dedup discarded the actual answer text as a duplicate of the thinking line.
+New `FleetManager.getAgentSessionUsage(name, sessionId)` returns a session's most recent context-window fill level (last assistant turn's input + cache tokens) and turn count, so a UI can show "context used" for a chat opened from history before any new turn streams fresh usage. Also fixed dropped assistant answers when reloading a chat: extended-thinking turns span multiple JSONL lines sharing one message ID, and the old dedup discarded the actual answer text as a duplicate of the thinking line. [#261](https://github.com/edspencer/herdctl/pull/261)
 
 ---
 

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -29,7 +29,7 @@ npm install @herdctl/chat
 
 ### SDK Message Translation
 
-`SDKMessageTranslator` provides transport-agnostic translation from Claude SDK message streams to chat-UI events. It extracts assistant text deltas, tracks turn boundaries, and pairs tool calls with their results (enriched with input summaries and durations). This eliminates the need to reimplement message processing logic in each chat connector or downstream application.
+`SDKMessageTranslator` provides transport-agnostic translation from Claude SDK message streams to chat-UI events. It extracts assistant text deltas, tracks turn boundaries, and pairs tool calls with their results (enriched with input summaries and durations). Every event carries agent attribution (`AgentAttribution`): `onText` and `onBoundary` receive it as an argument and `TranslatedToolCall` includes a `parentToolUseId` (`null` for the main agent, else the spawning `Task` tool_use ID), so consumers can separate the main agent from `Task`-spawned subagents into per-agent lanes. This eliminates the need to reimplement message processing logic in each chat connector or downstream application. See the [Shared Chat Layer docs](https://herdctl.dev/architecture/chat-infrastructure/) for details.
 
 ### Streaming Responses
 


### PR DESCRIPTION
Automated documentation audit found 7 gap(s) across 51 commits (9c7ac85..eed88a1).

## Gaps Addressed
1. **openChatSession() streaming chat sessions** (#286) — new `openChatSession` section in the FleetManager reference with `ChatSessionOptions` + `RuntimeSession`; `StreamingSessionUnsupportedError` added to the error hierarchy and error-handling reference; streaming-sessions section in the sessions concept page.
2. **Session-lifecycle reaper + wake registry** (#307–#309, #316) — new Session Lifecycle Methods section (`getSessionLifecycle`, `setSessionWakeHandler`, `manageLifecycle`), `session_wakes` slice documented in state-management, scheduler `onTick` hook, wake semantics (one-shot vs recurring, 7-day expiry, host-local timezone) in concepts/sessions.
3. **trigger({ fork })** (#291) — `fork`/`forkedFrom`/`resume` added to the `trigger()` options table; library fork path added to the sessions concept page.
4. **cancelJob() real interruption** (#289) — description updated to the AbortController registry behavior (CLI subprocess kill / SDK query abort).
5. **Translator agent attribution** (#298) — chat-infrastructure callback signatures updated (`onText(text, attribution)`, `onBoundary(attribution)`), new Agent Attribution subsection, chat README note.
6. **ChatMessage.uuid** (#313) — stable per-message uuid documented in the FleetManager reference and session-discovery architecture page.
7. **What's New refresh** — 12 entries covering the June 21 → July 10 releases (core 5.13 → 5.18 era); the page had been stale since 2026-03-13.

Docs site builds cleanly (`astro build`).

Generated by docs-audit-daily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for streaming chat sessions, session forking, lifecycle management, durable wake scheduling, and session reaping.
  * Documented new FleetManager capabilities, including chat sessions, lifecycle controls, agent command discovery, callbacks, and cancellation behavior.
  * Clarified stable message identifiers, tool messages, agent attribution, scheduler hooks, and session wake handling.
  * Added documentation for streaming-session limitations, related error codes, and fallback behavior.
  * Updated the “What’s New” release history with recent platform improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->