### PR TITLE
perf(state): cache derived per-session facts (isSidechain, usage) in the metadata store

### DIFF
--- a/.changeset/cache-session-facts.md
+++ b/.changeset/cache-session-facts.md
@@ -1,0 +1,24 @@
+---
+"@herdctl/core": minor
+---
+
+perf(state): cache derived per-session facts (isSidechain, usage) in the session metadata store
+
+Session discovery re-derived two facts from every transcript on each listing: the
+sidechain flag (`getAgentSessions` opened the first JSONL line of **every**
+session, every call) and the context-window usage (`getSessionUsage` streamed the
+whole transcript). Both are now memoized in `SessionMetadataStore` keyed on the
+transcript's mtime — the same mtime-invalidated pattern already used for
+`preview`/`autoName` — so an unchanged session is never re-read.
+
+- New `SessionMetadataEntry` fields: `isSidechain`/`isSidechainMtime` and
+  `usage`/`usageMtime`, with `getSidechain`/`batchSetSidechains` and
+  `getUsage`/`setUsage` on the store.
+- `getSessionUsage` gains optional `agentName` (enables the persistent cache) and
+  `mtime` (skips a `stat` when the caller already knows it). `FleetManager.getAgentSessionUsage`
+  passes the agent name, so callers get durable, restart-surviving usage caching
+  for free.
+
+Measured on a real 289-transcript project (after a simulated restart): bulk usage
+reads dropped from ~600 ms to ~2 ms, and `getAgentSessions` from ~1.29 s to ~0.91 s
+(the remainder is the attribution-index rebuild, addressed separately).

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -662,6 +662,9 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
     }
     return this.getSessionDiscovery().getSessionUsage(workingDirectory, sessionId, {
       dockerEnabled,
+      // Enables the persistent, mtime-keyed usage cache so a chat list doesn't
+      // re-stream every transcript on each read.
+      agentName: name,
     });
   }
 

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -28,6 +28,10 @@ const mockGetAutoName = vi.fn().mockResolvedValue(undefined);
 const mockBatchSetAutoNames = vi.fn().mockResolvedValue(undefined);
 const mockGetPreview = vi.fn().mockResolvedValue(undefined);
 const mockBatchSetPreviews = vi.fn().mockResolvedValue(undefined);
+const mockGetSidechain = vi.fn().mockResolvedValue(undefined);
+const mockBatchSetSidechains = vi.fn().mockResolvedValue(undefined);
+const mockGetUsage = vi.fn().mockResolvedValue(undefined);
+const mockSetUsage = vi.fn().mockResolvedValue(undefined);
 vi.mock("../session-metadata.js", () => {
   return {
     SessionMetadataStore: class MockSessionMetadataStore {
@@ -36,6 +40,10 @@ vi.mock("../session-metadata.js", () => {
       batchSetAutoNames = mockBatchSetAutoNames;
       getPreview = mockGetPreview;
       batchSetPreviews = mockBatchSetPreviews;
+      getSidechain = mockGetSidechain;
+      batchSetSidechains = mockBatchSetSidechains;
+      getUsage = mockGetUsage;
+      setUsage = mockSetUsage;
     },
   };
 });
@@ -135,12 +143,24 @@ describe("SessionDiscoveryService", () => {
     mockGetPreview.mockResolvedValue(undefined);
     mockBatchSetPreviews.mockReset();
     mockBatchSetPreviews.mockResolvedValue(undefined);
+    mockGetSidechain.mockReset();
+    mockGetSidechain.mockResolvedValue(undefined);
+    mockBatchSetSidechains.mockReset();
+    mockBatchSetSidechains.mockResolvedValue(undefined);
+    mockGetUsage.mockReset();
+    mockGetUsage.mockResolvedValue(undefined);
+    mockSetUsage.mockReset();
+    mockSetUsage.mockResolvedValue(undefined);
 
     // Reset JSONL parser mocks
     mockExtractLastSummary.mockReset();
     mockExtractLastSummary.mockResolvedValue(undefined);
     mockExtractFirstMessagePreview.mockReset();
     mockExtractFirstMessagePreview.mockResolvedValue(undefined);
+    mockIsSidechainSession.mockReset();
+    mockIsSidechainSession.mockResolvedValue(false);
+    mockExtractSessionUsage.mockReset();
+    mockExtractSessionUsage.mockResolvedValue({ inputTokens: 0, turnCount: 0, hasData: false });
   });
 
   afterEach(async () => {
@@ -924,6 +944,69 @@ describe("SessionDiscoveryService", () => {
       expect(result).toEqual(mockUsage);
       expect(mockExtractSessionUsage).toHaveBeenCalled();
     });
+
+    it("without agentName it does not touch the persistent cache", async () => {
+      mockExtractSessionUsage.mockResolvedValue({ inputTokens: 1, turnCount: 1, hasData: true });
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      await service.getSessionUsage("/Users/ed/Code/myproject", "session-abc");
+
+      expect(mockGetUsage).not.toHaveBeenCalled();
+      expect(mockSetUsage).not.toHaveBeenCalled();
+    });
+
+    it("with agentName + a cache miss, it parses and persists the usage", async () => {
+      mockGetUsage.mockResolvedValue(undefined); // cache miss
+      mockExtractSessionUsage.mockResolvedValue({
+        inputTokens: 250_000,
+        turnCount: 12,
+        hasData: true,
+      });
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      const result = await service.getSessionUsage("/Users/ed/Code/myproject", "session-abc", {
+        agentName: "my-agent",
+        mtime: "2024-01-15T10:00:00.000Z",
+      });
+
+      expect(result.inputTokens).toBe(250_000);
+      expect(mockExtractSessionUsage).toHaveBeenCalled();
+      expect(mockSetUsage).toHaveBeenCalledWith(
+        "my-agent",
+        "session-abc",
+        { inputTokens: 250_000, turnCount: 12, hasData: true },
+        "2024-01-15T10:00:00.000Z",
+      );
+    });
+
+    it("with agentName + a fresh cache hit, it serves the cache without re-parsing", async () => {
+      // Cache entry newer than the supplied mtime → valid hit.
+      mockGetUsage.mockResolvedValue({
+        usage: { inputTokens: 42, turnCount: 3, hasData: true },
+        usageMtime: "2099-01-01T00:00:00.000Z",
+      });
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      const result = await service.getSessionUsage("/Users/ed/Code/myproject", "session-abc", {
+        agentName: "my-agent",
+        mtime: "2024-01-15T10:00:00.000Z",
+      });
+
+      expect(result).toEqual({ inputTokens: 42, turnCount: 3, hasData: true });
+      expect(mockExtractSessionUsage).not.toHaveBeenCalled();
+      expect(mockSetUsage).not.toHaveBeenCalled();
+    });
   });
 
   // ===========================================================================
@@ -1601,6 +1684,90 @@ describe("SessionDiscoveryService", () => {
       expect(sessions[0].autoName).toBeUndefined();
       // Should not batch write when there's nothing to write
       expect(mockBatchSetAutoNames).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // Sidechain caching (issue: project switch re-reads every transcript)
+  // ===========================================================================
+
+  describe("sidechain caching", () => {
+    const workingDir = "/Users/ed/Code/myproject";
+    // tempClaudeHome is only assigned in beforeEach, so resolve the dir per-test.
+    const projectDirOf = () => join(tempClaudeHome, "projects", "-Users-ed-Code-myproject");
+
+    it("re-reads the transcript on a cache miss and batch-writes the flag", async () => {
+      const projectDir = projectDirOf();
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "session-1");
+
+      mockGetSidechain.mockResolvedValue(undefined); // miss
+      mockIsSidechainSession.mockResolvedValue(false);
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+
+      expect(sessions.map((s) => s.sessionId)).toContain("session-1");
+      expect(mockIsSidechainSession).toHaveBeenCalled();
+      expect(mockBatchSetSidechains).toHaveBeenCalledWith(
+        "my-agent",
+        expect.arrayContaining([
+          expect.objectContaining({ sessionId: "session-1", isSidechain: false }),
+        ]),
+      );
+    });
+
+    it("uses a fresh cache hit and does NOT re-open the transcript", async () => {
+      const projectDir = projectDirOf();
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "session-1");
+
+      // Cache newer than the file → valid.
+      mockGetSidechain.mockResolvedValue({
+        isSidechain: false,
+        isSidechainMtime: "2099-01-01T00:00:00.000Z",
+      });
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+
+      expect(sessions.map((s) => s.sessionId)).toContain("session-1");
+      expect(mockIsSidechainSession).not.toHaveBeenCalled();
+      expect(mockBatchSetSidechains).not.toHaveBeenCalled();
+    });
+
+    it("excludes a session cached as a sidechain, without reading it", async () => {
+      const projectDir = projectDirOf();
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "sidechain-1");
+      await createSessionFile(projectDir, "real-1");
+
+      mockGetSidechain.mockImplementation(async (_agent: string, sessionId: string) =>
+        sessionId === "sidechain-1"
+          ? { isSidechain: true, isSidechainMtime: "2099-01-01T00:00:00.000Z" }
+          : { isSidechain: false, isSidechainMtime: "2099-01-01T00:00:00.000Z" },
+      );
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      const ids = (await service.getAgentSessions("my-agent", workingDir, false)).map(
+        (s) => s.sessionId,
+      );
+
+      expect(ids).toContain("real-1");
+      expect(ids).not.toContain("sidechain-1");
+      expect(mockIsSidechainSession).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/state/__tests__/session-metadata.test.ts
+++ b/packages/core/src/state/__tests__/session-metadata.test.ts
@@ -646,4 +646,78 @@ describe("SessionMetadataStore", () => {
       expect(preview1!.preview).toBe("Question one");
     });
   });
+
+  describe("getSidechain / batchSetSidechains", () => {
+    it("returns undefined for a session with no sidechain flag", async () => {
+      const result = await store.getSidechain("test-agent", "session-999");
+      expect(result).toBeUndefined();
+    });
+
+    it("roundtrips isSidechain (including false) and isSidechainMtime", async () => {
+      await store.batchSetSidechains("test-agent", [
+        { sessionId: "session-1", isSidechain: true, mtime: "2024-01-15T10:00:00.000Z" },
+        { sessionId: "session-2", isSidechain: false, mtime: "2024-01-15T11:00:00.000Z" },
+      ]);
+
+      const s1 = await store.getSidechain("test-agent", "session-1");
+      expect(s1!.isSidechain).toBe(true);
+      expect(s1!.isSidechainMtime).toBe("2024-01-15T10:00:00.000Z");
+
+      // `false` must roundtrip (not be conflated with "not cached").
+      const s2 = await store.getSidechain("test-agent", "session-2");
+      expect(s2!.isSidechain).toBe(false);
+      expect(s2!.isSidechainMtime).toBe("2024-01-15T11:00:00.000Z");
+    });
+
+    it("does nothing when entries array is empty", async () => {
+      await store.batchSetSidechains("test-agent", []);
+      expect(await store.getAgentMetadata("test-agent")).toBeNull();
+    });
+
+    it("preserves existing preview/customName when setting the sidechain flag", async () => {
+      await store.setCustomName("test-agent", "session-1", "Custom One");
+      await store.setPreview("test-agent", "session-1", "Hi", "2024-01-15T10:00:00.000Z");
+
+      await store.batchSetSidechains("test-agent", [
+        { sessionId: "session-1", isSidechain: false, mtime: "2024-01-15T10:00:00.000Z" },
+      ]);
+
+      expect(await store.getCustomName("test-agent", "session-1")).toBe("Custom One");
+      expect((await store.getPreview("test-agent", "session-1"))!.preview).toBe("Hi");
+      expect((await store.getSidechain("test-agent", "session-1"))!.isSidechain).toBe(false);
+    });
+  });
+
+  describe("getUsage / setUsage", () => {
+    it("returns undefined for a session with no usage", async () => {
+      const result = await store.getUsage("test-agent", "session-999");
+      expect(result).toBeUndefined();
+    });
+
+    it("roundtrips usage and usageMtime", async () => {
+      await store.setUsage(
+        "test-agent",
+        "session-123",
+        { inputTokens: 250_000, turnCount: 12, hasData: true },
+        "2024-01-15T10:00:00.000Z",
+      );
+
+      const result = await store.getUsage("test-agent", "session-123");
+      expect(result!.usage).toEqual({ inputTokens: 250_000, turnCount: 12, hasData: true });
+      expect(result!.usageMtime).toBe("2024-01-15T10:00:00.000Z");
+    });
+
+    it("preserves existing preview when setting usage", async () => {
+      await store.setPreview("test-agent", "session-1", "Hi", "2024-01-15T10:00:00.000Z");
+      await store.setUsage(
+        "test-agent",
+        "session-1",
+        { inputTokens: 1, turnCount: 1, hasData: true },
+        "2024-01-15T10:00:00.000Z",
+      );
+
+      expect((await store.getPreview("test-agent", "session-1"))!.preview).toBe("Hi");
+      expect((await store.getUsage("test-agent", "session-1"))!.usage!.inputTokens).toBe(1);
+    });
+  });
 });

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -421,6 +421,47 @@ export class SessionDiscoveryService {
   }
 
   /**
+   * Resolve whether a session is a sidechain (Task sub-agent / --resume warmup),
+   * using the cache when valid. The flag is derived from the transcript's first
+   * JSONL line, so caching it (keyed on file mtime) lets a listing skip re-opening
+   * every transcript — the check runs once per session per content change instead
+   * of on every listing.
+   *
+   * @param agentName - The agent's qualified name (or "adhoc" for unattributed)
+   * @param sessionId - The session ID
+   * @param fileMtime - ISO 8601 timestamp of the session file's modification time
+   * @param workingDirectory - The session's working directory
+   * @returns Object with isSidechain and whether the cache needs an update
+   */
+  private async resolveSidechain(
+    agentName: string,
+    sessionId: string,
+    fileMtime: string,
+    workingDirectory: string,
+    dockerEnabled?: boolean,
+  ): Promise<{ isSidechain: boolean; needsUpdate: boolean }> {
+    // Check cache
+    const cached = await this.sessionMetadataStore.getSidechain(agentName, sessionId);
+
+    if (
+      cached?.isSidechain !== undefined &&
+      cached.isSidechainMtime &&
+      cached.isSidechainMtime >= fileMtime
+    ) {
+      // Cache is valid
+      return { isSidechain: cached.isSidechain, needsUpdate: false };
+    }
+
+    // Need to read the transcript's first line
+    const filePath = dockerEnabled
+      ? getDockerSessionFile(this.stateDir, sessionId)
+      : getCliSessionFile(workingDirectory, sessionId);
+    const isSidechain = await isSidechainSession(filePath);
+
+    return { isSidechain, needsUpdate: true };
+  }
+
+  /**
    * Get sessions for a specific agent.
    *
    * Returns sessions from the agent's working directory, attributed and
@@ -465,19 +506,28 @@ export class SessionDiscoveryService {
     const sessions: DiscoveredSession[] = [];
     const autoNameUpdates: Array<{ sessionId: string; autoName: string; mtime: string }> = [];
     const previewUpdates: Array<{ sessionId: string; preview: string; mtime: string }> = [];
+    const sidechainUpdates: Array<{ sessionId: string; isSidechain: boolean; mtime: string }> = [];
 
     for (const { sessionId, mtime } of filesToEnrich) {
-      // Get the actual file path based on storage location
-      const filePath = dockerEnabled
-        ? getDockerSessionFile(this.stateDir, sessionId)
-        : getCliSessionFile(workingDirectory, sessionId);
+      const mtimeStr = mtime.toISOString();
 
       // Filter out sidechain (sub-agent) sessions. Claude Code marks sessions
       // as sidechain when they're Task tool sub-agents or when --resume is used.
       // These are mostly prompt-cache warmup sessions ("Warmup" + single response)
-      // that clutter the UI with no useful content. We check only the first JSONL
-      // line so this is O(1) per file.
-      if (await isSidechainSession(filePath)) {
+      // that clutter the UI with no useful content. The flag comes from the first
+      // JSONL line and is cached (keyed on mtime) so we don't re-open every
+      // transcript on each listing.
+      const { isSidechain, needsUpdate: sidechainNeedsUpdate } = await this.resolveSidechain(
+        agentName,
+        sessionId,
+        mtimeStr,
+        workingDirectory,
+        dockerEnabled,
+      );
+      if (sidechainNeedsUpdate) {
+        sidechainUpdates.push({ sessionId, isSidechain, mtime: mtimeStr });
+      }
+      if (isSidechain) {
         continue;
       }
 
@@ -492,7 +542,6 @@ export class SessionDiscoveryService {
       }
 
       const customName = await this.sessionMetadataStore.getCustomName(agentName, sessionId);
-      const mtimeStr = mtime.toISOString();
 
       // Resolve autoName with caching — pass docker flag so it reads the right file
       const { autoName, needsUpdate } = await this.resolveAutoName(
@@ -539,6 +588,9 @@ export class SessionDiscoveryService {
     }
     if (previewUpdates.length > 0) {
       await this.sessionMetadataStore.batchSetPreviews(agentName, previewUpdates);
+    }
+    if (sidechainUpdates.length > 0) {
+      await this.sessionMetadataStore.batchSetSidechains(agentName, sidechainUpdates);
     }
 
     return sessions;
@@ -772,16 +824,26 @@ export class SessionDiscoveryService {
       const sessions: DiscoveredSession[] = [];
       const autoNameUpdates: Array<{ sessionId: string; autoName: string; mtime: string }> = [];
       const previewUpdates: Array<{ sessionId: string; preview: string; mtime: string }> = [];
+      const sidechainUpdates: Array<{ sessionId: string; isSidechain: boolean; mtime: string }> =
+        [];
       let visibleSessionCount = 0;
 
       for (const { sessionId, mtime } of dir.sessionFiles) {
-        // Get the actual file path based on storage location
-        const filePath = dir.dockerEnabled
-          ? getDockerSessionFile(this.stateDir, sessionId)
-          : getCliSessionFile(dir.decodedPath, sessionId);
+        const mtimeStr = mtime.toISOString();
 
-        // Filter out sidechain (sub-agent) sessions — see comment in getAgentSessions()
-        if (await isSidechainSession(filePath)) {
+        // Filter out sidechain (sub-agent) sessions — see comment in getAgentSessions().
+        // Cached (keyed on mtime) so we don't re-open every transcript per listing.
+        const { isSidechain, needsUpdate: sidechainNeedsUpdate } = await this.resolveSidechain(
+          dir.metadataKey,
+          sessionId,
+          mtimeStr,
+          dir.decodedPath,
+          dir.dockerEnabled,
+        );
+        if (sidechainNeedsUpdate) {
+          sidechainUpdates.push({ sessionId, isSidechain, mtime: mtimeStr });
+        }
+        if (isSidechain) {
           continue;
         }
 
@@ -817,8 +879,6 @@ export class SessionDiscoveryService {
         if (selectedSessionIds && !selectedSessionIds.has(sessionId)) {
           continue;
         }
-
-        const mtimeStr = mtime.toISOString();
 
         // Get custom name (works for both attributed and unattributed sessions)
         const customName = await this.sessionMetadataStore.getCustomName(
@@ -871,6 +931,9 @@ export class SessionDiscoveryService {
       }
       if (previewUpdates.length > 0) {
         await this.sessionMetadataStore.batchSetPreviews(dir.metadataKey, previewUpdates);
+      }
+      if (sidechainUpdates.length > 0) {
+        await this.sessionMetadataStore.batchSetSidechains(dir.metadataKey, sidechainUpdates);
       }
 
       if (sessions.length > 0) {
@@ -971,24 +1034,55 @@ export class SessionDiscoveryService {
   /**
    * Get usage data for a session.
    *
-   * Delegates to the JSONL parser.
+   * Delegates to the JSONL parser. When `agentName` is supplied, the result is
+   * memoized in the persistent SessionMetadataStore keyed on the transcript's
+   * mtime, so repeated reads (and reads after a restart) skip re-streaming the
+   * whole transcript unless a new turn has changed it.
    *
    * @param workingDirectory - The session's working directory
    * @param sessionId - The session ID
-   * @param options - Optional settings (dockerEnabled for Docker agent sessions)
+   * @param options - Optional settings (dockerEnabled for Docker agent sessions;
+   *   agentName to enable the persistent usage cache; mtime to key that cache
+   *   without a stat when the caller already knows the transcript's mtime)
    * @returns Session usage data
    */
   async getSessionUsage(
     workingDirectory: string,
     sessionId: string,
-    options?: { dockerEnabled?: boolean },
+    options?: { dockerEnabled?: boolean; agentName?: string; mtime?: string },
   ): Promise<SessionUsage> {
     const filePath = this.resolveSessionFilePath(
       workingDirectory,
       sessionId,
       options?.dockerEnabled,
     );
-    return extractSessionUsage(filePath);
+
+    const agentName = options?.agentName;
+    if (!agentName) {
+      return extractSessionUsage(filePath);
+    }
+
+    // Key the cache on the transcript's mtime. Prefer a caller-supplied mtime
+    // (session listings already have it); otherwise a cheap stat. If neither is
+    // available (file gone), fall back to a direct parse rather than caching a
+    // bogus entry.
+    let mtimeStr = options?.mtime;
+    if (!mtimeStr) {
+      try {
+        mtimeStr = (await stat(filePath)).mtime.toISOString();
+      } catch {
+        return extractSessionUsage(filePath);
+      }
+    }
+
+    const cached = await this.sessionMetadataStore.getUsage(agentName, sessionId);
+    if (cached?.usage && cached.usageMtime && cached.usageMtime >= mtimeStr) {
+      return cached.usage;
+    }
+
+    const usage = await extractSessionUsage(filePath);
+    await this.sessionMetadataStore.setUsage(agentName, sessionId, usage, mtimeStr);
+    return usage;
   }
 
   /**

--- a/packages/core/src/state/session-metadata.ts
+++ b/packages/core/src/state/session-metadata.ts
@@ -32,6 +32,28 @@ export const SessionMetadataEntrySchema = z.object({
   preview: z.string().optional(),
   /** ISO 8601 timestamp of when preview was extracted (for cache invalidation) */
   previewMtime: z.string().optional(),
+  /**
+   * Whether the session is a sidechain (Task sub-agent / --resume warmup). Derived
+   * from the transcript's first JSONL line; cached so session discovery doesn't
+   * re-open every transcript on each listing.
+   */
+  isSidechain: z.boolean().optional(),
+  /** ISO 8601 timestamp of when isSidechain was determined (for cache invalidation) */
+  isSidechainMtime: z.string().optional(),
+  /**
+   * Context-window usage as of the session's last completed turn, cached so the
+   * fill can be shown without re-streaming the whole transcript. `hasData:false`
+   * means the transcript carried no usage.
+   */
+  usage: z
+    .object({
+      inputTokens: z.number(),
+      turnCount: z.number(),
+      hasData: z.boolean(),
+    })
+    .optional(),
+  /** ISO 8601 timestamp of when usage was extracted (for cache invalidation) */
+  usageMtime: z.string().optional(),
   // Future: pinned, archived, tags
 });
 
@@ -463,6 +485,135 @@ export class SessionMetadataStore {
 
     logger.debug(`Batch set previews for ${entries.length} sessions`, {
       agentName,
+    });
+  }
+
+  /**
+   * Get cached sidechain flag and its mtime for a session
+   *
+   * @param agentName - The agent's qualified name (use "adhoc" for unattributed sessions)
+   * @param sessionId - The session ID
+   * @returns Object with isSidechain and isSidechainMtime, or undefined if not cached
+   */
+  async getSidechain(
+    agentName: string,
+    sessionId: string,
+  ): Promise<{ isSidechain?: boolean; isSidechainMtime?: string } | undefined> {
+    const metadata = await this.loadMetadata(agentName);
+    if (!metadata) {
+      return undefined;
+    }
+
+    const entry = metadata.sessions[sessionId];
+    if (!entry) {
+      return undefined;
+    }
+
+    return {
+      isSidechain: entry.isSidechain,
+      isSidechainMtime: entry.isSidechainMtime,
+    };
+  }
+
+  /**
+   * Batch set sidechain flags for multiple sessions
+   *
+   * More efficient than a per-session write since it performs a single file
+   * write for all updates.
+   *
+   * @param agentName - The agent's qualified name (use "adhoc" for unattributed sessions)
+   * @param entries - Array of { sessionId, isSidechain, mtime } objects
+   */
+  async batchSetSidechains(
+    agentName: string,
+    entries: Array<{ sessionId: string; isSidechain: boolean; mtime: string }>,
+  ): Promise<void> {
+    if (entries.length === 0) {
+      return;
+    }
+
+    let metadata = await this.loadMetadata(agentName);
+
+    if (!metadata) {
+      metadata = this.createEmptyMetadata(agentName);
+    }
+
+    for (const { sessionId, isSidechain, mtime } of entries) {
+      const sessionEntry = metadata.sessions[sessionId] ?? {};
+      metadata.sessions[sessionId] = {
+        ...sessionEntry,
+        isSidechain,
+        isSidechainMtime: mtime,
+      };
+    }
+
+    await this.saveMetadata(agentName, metadata);
+
+    logger.debug(`Batch set sidechain flags for ${entries.length} sessions`, {
+      agentName,
+    });
+  }
+
+  /**
+   * Get cached usage and its mtime for a session
+   *
+   * @param agentName - The agent's qualified name (use "adhoc" for unattributed sessions)
+   * @param sessionId - The session ID
+   * @returns Object with usage and usageMtime, or undefined if not cached
+   */
+  async getUsage(
+    agentName: string,
+    sessionId: string,
+  ): Promise<{ usage?: SessionMetadataEntry["usage"]; usageMtime?: string } | undefined> {
+    const metadata = await this.loadMetadata(agentName);
+    if (!metadata) {
+      return undefined;
+    }
+
+    const entry = metadata.sessions[sessionId];
+    if (!entry) {
+      return undefined;
+    }
+
+    return {
+      usage: entry.usage,
+      usageMtime: entry.usageMtime,
+    };
+  }
+
+  /**
+   * Set cached usage for a session
+   *
+   * @param agentName - The agent's qualified name (use "adhoc" for unattributed sessions)
+   * @param sessionId - The session ID
+   * @param usage - The extracted usage (inputTokens / turnCount / hasData)
+   * @param mtime - ISO 8601 timestamp of the session file when usage was extracted
+   */
+  async setUsage(
+    agentName: string,
+    sessionId: string,
+    usage: NonNullable<SessionMetadataEntry["usage"]>,
+    mtime: string,
+  ): Promise<void> {
+    let metadata = await this.loadMetadata(agentName);
+
+    if (!metadata) {
+      metadata = this.createEmptyMetadata(agentName);
+    }
+
+    const sessionEntry = metadata.sessions[sessionId] ?? {};
+
+    metadata.sessions[sessionId] = {
+      ...sessionEntry,
+      usage,
+      usageMtime: mtime,
+    };
+
+    await this.saveMetadata(agentName, metadata);
+
+    logger.debug(`Set usage for session ${sessionId}`, {
+      agentName,
+      inputTokens: usage.inputTokens,
     });
   }
 }


### PR DESCRIPTION
## Problem

Listing an agent's sessions re-derives two facts from **every** transcript on **every** call, uncached:

1. **Sidechain flag** — `getAgentSessions` (and the grouped `getAllSessions`) opens the first JSONL line of every session file each call to decide whether to hide it.
2. **Usage** — `getSessionUsage` streams and `JSON.parse`s the *entire* transcript to compute the context-window fill.

For a consumer that lists sessions and reads per-session usage on every UI navigation (e.g. Paddock's project switch), this is O(sessions × transcript size) of repeated disk work that scales with activity — the dominant cost once a project accumulates a few hundred chats.

`preview` and `autoName` already avoid this: they're memoized in `SessionMetadataStore` keyed on the transcript's mtime. This PR gives the same treatment to the two remaining hot facts.

## Change

- **Schema** (`SessionMetadataEntry`): add `isSidechain`/`isSidechainMtime` and `usage`/`usageMtime`.
- **Store**: `getSidechain`/`batchSetSidechains` and `getUsage`/`setUsage`, mirroring the preview/autoName accessors.
- **Discovery**: a `resolveSidechain()` helper (same shape as `resolvePreview`) used in both the `getAgentSessions` and `getAllSessions` loops; new flags are batch-written alongside previews/autoNames. On a cache hit the transcript is never opened.
- **Usage**: `getSessionUsage` gains optional `agentName` (opts into the persistent cache) and `mtime` (lets a caller that already knows the mtime skip a `stat`). `FleetManager.getAgentSessionUsage` passes the agent name, so **usage caching survives process restarts for free** for existing callers — no caller change required.

Invalidation is by mtime, identical to preview/autoName: a new turn rewrites the transcript, bumps its mtime, and the next read re-derives. `isSidechain` is immutable per transcript but still mtime-keyed for consistency/safety.

## Measured (real 289-transcript project, simulated restart → cold persistent cache, then warm)

| | cold | warm (after restart) |
|---|---|---|
| bulk `getSessionUsage` (all sessions) | ~596 ms | **~2 ms** |
| `getAgentSessions` | ~1.29 s | **~0.91 s** |

The ~0.91 s floor on `getAgentSessions` is the attribution-index rebuild — addressed in a separate follow-up PR (making that index incremental). A third follow-up parallelizes the enrichment loop. The three compose.

## Tests

- `session-metadata.test.ts`: round-trip for `getSidechain`/`batchSetSidechains` (incl. `false`) and `getUsage`/`setUsage`, plus field-preservation.
- `session-discovery.test.ts`: sidechain cache hit (no transcript read) / miss (reads + batch-writes) / cached-as-sidechain exclusion; usage cache hit vs miss (parses + persists) vs no-agentName (bypasses cache).
- Full core suite green apart from the pre-existing root-only `directory.test.ts` permission test (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)