### PR TITLE
perf(state): make the attribution index incremental

### DIFF
--- a/.changeset/incremental-attribution-index.md
+++ b/.changeset/incremental-attribution-index.md
@@ -1,0 +1,21 @@
+---
+"@herdctl/core": minor
+---
+
+perf(state): make the attribution index incremental
+
+Building the session attribution index read and YAML-parsed **every** job record
+in `.herdctl/jobs/` on each build. For a long-running fleet that accumulates
+thousands of jobs, that re-parse (repeated every time the per-listing attribution
+cache expires) is the dominant cost of listing sessions.
+
+Job records are effectively immutable except for a small tail — a job gains its
+`session_id` and a terminal status when it finishes — so a new `AttributionIndexBuilder`
+keeps a per-file cache keyed on mtime and re-parses only files that are new or
+whose mtime changed. Each rebuild becomes O(jobs) cheap `stat`s plus O(changed)
+parses instead of O(jobs) reads+parses. `SessionDiscoveryService` holds one
+builder for its lifetime, so post-TTL refreshes are cheap. The standalone
+`buildAttributionIndex` (full build) is unchanged for one-shot callers.
+
+Measured on a real ~600-job state dir: a warm rebuild (nothing changed) dropped
+from ~350 ms to ~10 ms.

--- a/packages/core/src/state/__tests__/session-attribution.test.ts
+++ b/packages/core/src/state/__tests__/session-attribution.test.ts
@@ -1,10 +1,10 @@
-import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, realpath, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import yaml from "yaml";
 import type { JobMetadata, JobStatus, TriggerType } from "../schemas/job-metadata.js";
-import { buildAttributionIndex } from "../session-attribution.js";
+import { AttributionIndexBuilder, buildAttributionIndex } from "../session-attribution.js";
 
 // Mock listJobs
 vi.mock("../job-metadata.js", () => ({
@@ -693,5 +693,151 @@ describe("buildAttributionIndex", () => {
 
       expect(index.size).toBe(3);
     });
+  });
+});
+
+// =============================================================================
+// AttributionIndexBuilder (incremental) — reads real job files off disk, so
+// these do NOT use the mocked listJobs above.
+// =============================================================================
+
+/** Write a real job YAML to <stateDir>/jobs/<id>.yaml; optionally pin its mtime. */
+async function writeJobFile(
+  stateDir: string,
+  overrides: Parameters<typeof createMockJob>[0] & { id: string },
+  mtime?: Date,
+): Promise<string> {
+  const jobsDir = join(stateDir, "jobs");
+  await mkdir(jobsDir, { recursive: true });
+  const filePath = join(jobsDir, `${overrides.id}.yaml`);
+  await writeFile(filePath, yaml.stringify(createMockJob(overrides)));
+  if (mtime) {
+    await utimes(filePath, mtime, mtime);
+  }
+  return filePath;
+}
+
+describe("AttributionIndexBuilder (incremental)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("attributes a session from a job file (parity with buildAttributionIndex)", async () => {
+    await writeJobFile(tempDir, {
+      id: "job-2024-01-15-aaa111",
+      session_id: "sess-1",
+      agent: "fleet/keeper",
+      trigger_type: "web",
+    });
+
+    const index = await new AttributionIndexBuilder().build(tempDir);
+    expect(index.getAttribute("sess-1")).toEqual({
+      origin: "web",
+      agentName: "fleet/keeper",
+      triggerType: "web",
+    });
+  });
+
+  it("returns an empty index when the jobs dir does not exist", async () => {
+    const index = await new AttributionIndexBuilder().build(tempDir);
+    expect(index.getAttribute("whatever").agentName).toBeUndefined();
+    expect(index.size).toBe(0);
+  });
+
+  it("picks up a NEW job file on a later build (same builder instance)", async () => {
+    const builder = new AttributionIndexBuilder();
+    await writeJobFile(tempDir, { id: "job-2024-01-15-aaa111", session_id: "sess-1", agent: "a" });
+
+    let index = await builder.build(tempDir);
+    expect(index.getAttribute("sess-1").agentName).toBe("a");
+    expect(index.getAttribute("sess-2").agentName).toBeUndefined();
+
+    await writeJobFile(tempDir, { id: "job-2024-01-15-bbb222", session_id: "sess-2", agent: "b" });
+    index = await builder.build(tempDir);
+    expect(index.getAttribute("sess-1").agentName).toBe("a");
+    expect(index.getAttribute("sess-2").agentName).toBe("b");
+  });
+
+  it("re-parses a job whose mtime changed (running → completed with a session_id)", async () => {
+    const builder = new AttributionIndexBuilder();
+
+    // A running job: no session_id yet. Pin an older mtime.
+    const older = new Date(Date.now() - 10_000);
+    await writeJobFile(
+      tempDir,
+      { id: "job-2024-01-15-aaa111", session_id: null, status: "running", agent: "keeper" },
+      older,
+    );
+
+    let index = await builder.build(tempDir);
+    // Nothing attributed yet — the running job has no session_id.
+    expect(index.size).toBe(0);
+
+    // The job finishes: session_id filled in, and its mtime bumps (as an atomic
+    // rewrite does on disk). The builder MUST re-read it despite having cached it.
+    await writeJobFile(
+      tempDir,
+      { id: "job-2024-01-15-aaa111", session_id: "sess-1", status: "completed", agent: "keeper" },
+      new Date(),
+    );
+
+    index = await builder.build(tempDir);
+    expect(index.getAttribute("sess-1").agentName).toBe("keeper");
+  });
+
+  it("does NOT re-read an unchanged job file (cache hit by mtime)", async () => {
+    const builder = new AttributionIndexBuilder();
+    const filePath = await writeJobFile(tempDir, {
+      id: "job-2024-01-15-aaa111",
+      session_id: "sess-1",
+      agent: "keeper",
+    });
+    // Pin a clean millisecond-precision mtime so the cached key and the post-
+    // rewrite key compare exactly (raw fs mtimes carry sub-ms precision that
+    // utimes() would truncate, which would look like a change).
+    const pinned = new Date(Date.now() - 5_000);
+    await utimes(filePath, pinned, pinned);
+
+    await builder.build(tempDir); // caches the contribution keyed on `pinned`
+
+    // Rewrite the CONTENT to a different agent but restore the SAME mtime.
+    // Keyed on mtime, the builder should serve the cached (original) value.
+    await writeFile(
+      filePath,
+      yaml.stringify(
+        createMockJob({
+          id: "job-2024-01-15-aaa111",
+          session_id: "sess-1",
+          agent: "SHOULD-NOT-APPEAR",
+        }),
+      ),
+    );
+    await utimes(filePath, pinned, pinned);
+
+    const index = await builder.build(tempDir);
+    expect(index.getAttribute("sess-1").agentName).toBe("keeper");
+  });
+
+  it("drops attribution for a deleted job file", async () => {
+    const builder = new AttributionIndexBuilder();
+    const filePath = await writeJobFile(tempDir, {
+      id: "job-2024-01-15-aaa111",
+      session_id: "sess-1",
+      agent: "keeper",
+    });
+
+    let index = await builder.build(tempDir);
+    expect(index.getAttribute("sess-1").agentName).toBe("keeper");
+
+    await rm(filePath);
+    index = await builder.build(tempDir);
+    expect(index.getAttribute("sess-1").agentName).toBeUndefined();
+    expect(index.size).toBe(0);
   });
 });

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -7,10 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Mocks
 // =============================================================================
 
-// Mock session-attribution
-vi.mock("../session-attribution.js", () => ({
-  buildAttributionIndex: vi.fn(),
-}));
+// Mock session-attribution. The service now builds its index through
+// AttributionIndexBuilder#build; route that to the SAME fn exported as
+// buildAttributionIndex, so `vi.mocked(buildAttributionIndex)` drives both.
+vi.mock("../session-attribution.js", () => {
+  const fn = vi.fn();
+  return {
+    buildAttributionIndex: fn,
+    AttributionIndexBuilder: class MockAttributionIndexBuilder {
+      build = fn;
+    },
+  };
+});
 
 // Mock jsonl-parser
 vi.mock("../jsonl-parser.js", () => ({

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -83,6 +83,7 @@ export {
 // Re-export session attribution functions
 export {
   type AttributionIndex,
+  AttributionIndexBuilder,
   buildAttributionIndex,
   type SessionAttribution,
   type SessionOrigin,

--- a/packages/core/src/state/session-attribution.ts
+++ b/packages/core/src/state/session-attribution.ts
@@ -11,7 +11,8 @@ import yaml from "yaml";
 import { z } from "zod";
 import { createLogger } from "../utils/logger.js";
 import { listJobs } from "./job-metadata.js";
-import type { TriggerType } from "./schemas/job-metadata.js";
+import { JobMetadataSchema, type TriggerType } from "./schemas/job-metadata.js";
+import { safeReadYaml } from "./utils/reads.js";
 
 // =============================================================================
 // Types
@@ -195,6 +196,18 @@ export async function buildAttributionIndex(stateDir: string): Promise<Attributi
     buildPlatformIndex(stateDir),
   ]);
 
+  return createAttributionIndex(jobIndex, platformIndex);
+}
+
+/**
+ * Assemble the {@link AttributionIndex} lookup object from a job index and a
+ * platform index. Shared by the full {@link buildAttributionIndex} and the
+ * incremental {@link AttributionIndexBuilder}.
+ */
+function createAttributionIndex(
+  jobIndex: Map<string, JobIndexEntry>,
+  platformIndex: Map<string, PlatformIndexEntry>,
+): AttributionIndex {
   const getAttribute = (sessionId: string): SessionAttribution => {
     // Check job index first
     const jobEntry = jobIndex.get(sessionId);
@@ -242,4 +255,122 @@ export async function buildAttributionIndex(stateDir: string): Promise<Attributi
       return allSessionIds.size;
     },
   };
+}
+
+/** One job file's contribution to the index, memoized by the builder. */
+interface CachedJobFile {
+  /** File mtime (epoch ms) when last parsed — the cache-invalidation key. */
+  mtimeMs: number;
+  /**
+   * The session→attribution entry this job contributes, or `null` when the job
+   * has no `session_id` yet (e.g. still running) or failed to parse. Cached
+   * either way so we don't re-read an unchanged file.
+   */
+  entry: { sessionId: string; agent: string; triggerType: string } | null;
+}
+
+/**
+ * Incremental builder for the attribution index.
+ *
+ * The full {@link buildAttributionIndex} reads and YAML-parses *every* job record
+ * on each build. For a long-running fleet that accumulates thousands of jobs,
+ * that's the dominant cost of listing sessions once the per-listing cache
+ * expires. Job records are effectively immutable except for a small tail (a job
+ * gains its `session_id` and a terminal status when it finishes), so this builder
+ * keeps a per-file cache keyed on mtime and re-parses only files that are new or
+ * whose mtime changed — turning each rebuild from O(jobs) reads into O(jobs)
+ * cheap stats + O(changed) parses.
+ *
+ * Platform session files are few and mutable, so they're still read in full each
+ * build.
+ *
+ * A single builder instance must be reused across builds to get the benefit.
+ */
+export class AttributionIndexBuilder {
+  private readonly jobFileCache = new Map<string, CachedJobFile>();
+
+  /** Build (or incrementally refresh) the attribution index for a state dir. */
+  async build(stateDir: string): Promise<AttributionIndex> {
+    const jobsDir = path.join(stateDir, "jobs");
+    const [jobIndex, platformIndex] = await Promise.all([
+      this.buildJobIndexIncremental(jobsDir),
+      buildPlatformIndex(stateDir),
+    ]);
+    return createAttributionIndex(jobIndex, platformIndex);
+  }
+
+  private async buildJobIndexIncremental(jobsDir: string): Promise<Map<string, JobIndexEntry>> {
+    let files: string[];
+    try {
+      files = await fs.readdir(jobsDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        this.jobFileCache.clear();
+        return new Map();
+      }
+      throw error;
+    }
+
+    const jobFiles = files.filter((f) => f.startsWith("job-") && f.endsWith(".yaml"));
+    const present = new Set(jobFiles);
+
+    // Drop cache entries for job files that have been deleted/pruned.
+    for (const cachedFile of this.jobFileCache.keys()) {
+      if (!present.has(cachedFile)) {
+        this.jobFileCache.delete(cachedFile);
+      }
+    }
+
+    // Stat every file (cheap); re-parse only new or changed ones.
+    await Promise.all(
+      jobFiles.map(async (file) => {
+        const filePath = path.join(jobsDir, file);
+
+        let mtimeMs: number;
+        try {
+          mtimeMs = (await fs.stat(filePath)).mtimeMs;
+        } catch {
+          // Vanished between readdir and stat — forget it.
+          this.jobFileCache.delete(file);
+          return;
+        }
+
+        const cached = this.jobFileCache.get(file);
+        if (cached && cached.mtimeMs === mtimeMs) {
+          return; // unchanged — reuse the cached contribution
+        }
+
+        const result = await safeReadYaml<unknown>(filePath);
+        if (!result.success) {
+          logger.warn(`Failed to read job file ${filePath}: ${result.error.message}`);
+          this.jobFileCache.set(file, { mtimeMs, entry: null });
+          return;
+        }
+
+        const parsed = JobMetadataSchema.safeParse(result.data);
+        if (!parsed.success) {
+          logger.warn(`Corrupted job file ${filePath}: ${parsed.error.message}`);
+          this.jobFileCache.set(file, { mtimeMs, entry: null });
+          return;
+        }
+
+        const job = parsed.data;
+        this.jobFileCache.set(file, {
+          mtimeMs,
+          entry: job.session_id
+            ? { sessionId: job.session_id, agent: job.agent, triggerType: job.trigger_type }
+            : null,
+        });
+      }),
+    );
+
+    // Assemble the session→attribution map from the cached per-file contributions.
+    const index = new Map<string, JobIndexEntry>();
+    for (const { entry } of this.jobFileCache.values()) {
+      if (entry) {
+        index.set(entry.sessionId, { agent: entry.agent, triggerType: entry.triggerType });
+      }
+    }
+    return index;
+  }
 }

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -30,7 +30,7 @@ import {
 } from "./jsonl-parser.js";
 import {
   type AttributionIndex,
-  buildAttributionIndex,
+  AttributionIndexBuilder,
   type SessionOrigin,
 } from "./session-attribution.js";
 import { SessionMetadataStore } from "./session-metadata.js";
@@ -188,6 +188,12 @@ export class SessionDiscoveryService {
 
   private attributionIndex: AttributionIndex | null = null;
   private attributionFetchedAt: number = 0;
+  /**
+   * Incremental builder for the attribution index. Held for the service's
+   * lifetime so its per-job-file cache survives across rebuilds — a post-TTL
+   * refresh then re-parses only new/changed job files instead of all of them.
+   */
+  private readonly attributionBuilder = new AttributionIndexBuilder();
 
   private directoryCache: Map<string, DirectoryCacheEntry> = new Map();
   private metadataCache: Map<string, SessionMetadata> = new Map();
@@ -245,7 +251,8 @@ export class SessionDiscoveryService {
     }
 
     logger.debug("Building attribution index");
-    this.attributionIndex = await buildAttributionIndex(this.stateDir);
+    // Incremental: re-parses only new/changed job files since the last build.
+    this.attributionIndex = await this.attributionBuilder.build(this.stateDir);
     this.attributionFetchedAt = Date.now();
     logger.debug(`Attribution index built with ${this.attributionIndex.size} entries`);
 


### PR DESCRIPTION
## Problem

Building the session attribution index reads and YAML-parses **every** job record in `.herdctl/jobs/` on each build (`buildJobIndex` → `listJobs`). For a long-running fleet that accumulates thousands of jobs, that re-parse — repeated every time the per-listing attribution cache (30s TTL) expires — is the dominant cost of listing an agent's sessions.

## Change

Job records are effectively immutable except for a small tail: a job starts with `session_id: null` / `status: running` and gains its `session_id` + a terminal status when it finishes. So the safe invalidation key is the job file's **mtime**, not just its presence.

A new `AttributionIndexBuilder` keeps a per-job-file cache keyed on mtime and, on each build:
- `readdir`s the jobs dir and drops cache entries for deleted files,
- `stat`s every file (cheap) and **re-parses only files that are new or whose mtime changed**,
- reassembles the session→attribution map from the cached per-file contributions.

Each rebuild becomes **O(jobs) cheap stats + O(changed) parses** instead of O(jobs) reads+parses. `SessionDiscoveryService` holds one builder for its lifetime, so post-TTL refreshes reuse the cache. Platform session files (few, mutable) are still read in full. The standalone `buildAttributionIndex` is untouched for one-shot callers; `AttributionIndexBuilder` is exported alongside it.

## Measured (real ~600-job state dir)

| build | time |
|---|---|
| `buildAttributionIndex` (full, every call) | ~350–500 ms |
| `AttributionIndexBuilder` #1 (cold — parses all) | ~250 ms |
| `AttributionIndexBuilder` #2+ (warm — nothing changed) | **~7–11 ms** |

This removes the ~350 ms attribution rebuild that dominated `getAgentSessions` once the per-listing caches are warm.

## Correctness / tests

The key hazard is the mutable tail — a job cached while `running` (no `session_id`) must be re-read once it completes. Covered explicitly:

- **`re-parses a job whose mtime changed (running → completed with a session_id)`** — the critical case.
- New job picked up on a later build; deleted job dropped; unchanged file served from cache (same mtime); parity with `buildAttributionIndex`; empty index when jobs dir is absent.
- `session-discovery.test.ts` updated to route `AttributionIndexBuilder#build` through the same mock it already drives.
- Full core suite green apart from the pre-existing root-only `directory.test.ts` permission test (unrelated).

## Relationship to the other perf PRs

This is the third of three independent core PRs (fact-caching, parallel enrichment, incremental attribution). It targets the cost that the fact-caching PR's measurements showed dominates a warm `getAgentSessions`. They compose and can land in any order (may need a trivial rebase where they touch adjacent lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved attribution index rebuild performance by reusing previously processed job data.
  * Warm rebuilds can now complete significantly faster, reducing processing time from approximately 350 ms to 10 ms in typical large state directories.
  * Attribution updates continue to reflect newly added, modified, or deleted job records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->