### PR TITLE
fix(core): pass denied_tools to SDK as disallowedTools, not deniedTools

### DIFF
--- a/.changeset/sdk-denied-tools-disallowed.md
+++ b/.changeset/sdk-denied-tools-disallowed.md
@@ -1,0 +1,9 @@
+---
+"@herdctl/core": patch
+---
+
+Fix `denied_tools` being silently ignored on `runtime: sdk` agents (edspencer/herdctl#322).
+
+The SDK adapter passed an agent's `denied_tools` to the Claude Agent SDK as `deniedTools`, but the SDK's actual option is named `disallowedTools`. Because the options object is spread into `query()` untyped, the misspelled key was silently dropped — so tools listed in `denied_tools` remained fully available to SDK-runtime agents. The CLI runtime was unaffected (it already passes `--disallowedTools`).
+
+`toSDKOptions` now emits `disallowedTools`, and `SDKQueryOptions` declares the correctly named field so the compiler catches any future drift.

--- a/docs/src/content/docs/architecture/docker-runtime.md
+++ b/docs/src/content/docs/architecture/docker-runtime.md
@@ -230,7 +230,7 @@ Claude Code includes native sandboxing via bubblewrap (Linux) and Seatbelt (macO
 
 Docker's primary advantages are environment variable isolation (the container has no access to host environment variables unless explicitly passed), resource limits (preventing runaway memory or CPU usage), and true filesystem isolation (host files do not exist inside the container unless mounted).
 
-Native sandboxing provides tool-level permission control that Docker does not -- the `permissionMode` and `allowedTools` / `deniedTools` settings operate at the Claude Code level regardless of whether Docker is used.
+Native sandboxing provides tool-level permission control that Docker does not -- the `permissionMode` and `allowedTools` / `disallowedTools` settings operate at the Claude Code level regardless of whether Docker is used.
 
 ### hostConfigOverride
 

--- a/docs/src/content/docs/architecture/runner.md
+++ b/docs/src/content/docs/architecture/runner.md
@@ -157,7 +157,7 @@ The SDK Adapter (`sdk-adapter.ts`) transforms a `ResolvedAgent` configuration in
 |--------------------|-----------|-------|
 | `permission_mode` | `permissionMode` | Defaults to `acceptEdits` |
 | `allowed_tools` | `allowedTools` | Direct passthrough, supports wildcards |
-| `denied_tools` | `deniedTools` | Direct passthrough |
+| `denied_tools` | `disallowedTools` | Direct passthrough |
 | `system_prompt` | `systemPrompt` | Plain string; falls back to `claude_code` preset |
 | `setting_sources` | `settingSources` | Explicit config, or `["project"]` if working directory set, else `[]` |
 | `mcp_servers` | `mcpServers` | Each server transformed individually |

--- a/packages/core/src/runner/__tests__/sdk-adapter.test.ts
+++ b/packages/core/src/runner/__tests__/sdk-adapter.test.ts
@@ -127,12 +127,21 @@ describe("toSDKOptions", () => {
       expect(result.allowedTools).toEqual(["Read", "Write", "Edit"]);
     });
 
-    it("passes denied_tools as deniedTools (direct passthrough)", () => {
+    it("passes denied_tools as disallowedTools (SDK option name)", () => {
       const agent = createTestAgent({
         denied_tools: ["Bash(rm *)", "WebFetch"],
       });
       const result = toSDKOptions(agent);
-      expect(result.deniedTools).toEqual(["Bash(rm *)", "WebFetch"]);
+      expect(result.disallowedTools).toEqual(["Bash(rm *)", "WebFetch"]);
+    });
+
+    it("does not emit a deniedTools key (regression: #322)", () => {
+      const agent = createTestAgent({
+        denied_tools: ["Bash(rm *)", "WebFetch"],
+      });
+      const result = toSDKOptions(agent);
+      expect(result).not.toHaveProperty("deniedTools");
+      expect(result.disallowedTools).toEqual(["Bash(rm *)", "WebFetch"]);
     });
 
     it("does not include allowedTools when empty array", () => {
@@ -143,12 +152,12 @@ describe("toSDKOptions", () => {
       expect(result.allowedTools).toBeUndefined();
     });
 
-    it("does not include deniedTools when empty array", () => {
+    it("does not include disallowedTools when empty array", () => {
       const agent = createTestAgent({
         denied_tools: [],
       });
       const result = toSDKOptions(agent);
-      expect(result.deniedTools).toBeUndefined();
+      expect(result.disallowedTools).toBeUndefined();
     });
 
     it("does not include allowedTools when not specified", () => {
@@ -173,7 +182,7 @@ describe("toSDKOptions", () => {
       });
       const result = toSDKOptions(agent);
       expect(result.allowedTools).toEqual(["Read", "Bash(git *)", "Bash(npm *)"]);
-      expect(result.deniedTools).toEqual(["Bash(sudo *)", "Bash(rm -rf *)"]);
+      expect(result.disallowedTools).toEqual(["Bash(sudo *)", "Bash(rm -rf *)"]);
     });
   });
 
@@ -366,7 +375,7 @@ describe("toSDKOptions", () => {
         permissionMode: "bypassPermissions",
         tools: ["Read", "Write", "Bash", "Grep"],
         allowedTools: ["Read", "Write", "Bash(git *)"],
-        deniedTools: ["WebFetch", "Bash(sudo *)"],
+        disallowedTools: ["WebFetch", "Bash(sudo *)"],
         systemPrompt: "You are a specialized test agent.", // Custom prompts are plain strings
         settingSources: [], // Empty - autonomous agents don't load project settings
         mcpServers: {

--- a/packages/core/src/runner/sdk-adapter.ts
+++ b/packages/core/src/runner/sdk-adapter.ts
@@ -161,8 +161,9 @@ export function toSDKOptions(
     result.allowedTools = agent.allowed_tools;
   }
 
+  // The SDK option is named `disallowedTools` (not `deniedTools`)
   if (agent.denied_tools?.length) {
-    result.deniedTools = agent.denied_tools;
+    result.disallowedTools = agent.denied_tools;
   }
 
   // Tools whitelist (direct passthrough to SDK)

--- a/packages/core/src/runner/types.ts
+++ b/packages/core/src/runner/types.ts
@@ -226,7 +226,7 @@ export type SDKSystemPrompt = string | { type: "preset"; preset: "claude_code"; 
 export interface SDKQueryOptions {
   tools?: string[];
   allowedTools?: string[];
-  deniedTools?: string[];
+  disallowedTools?: string[];
   permissionMode?:
     | "default"
     | "acceptEdits"


### PR DESCRIPTION
## Summary

`toSDKOptions` (packages/core/src/runner/sdk-adapter.ts) emitted an agent's `denied_tools` under the key `deniedTools`, but the Claude Agent SDK option is named `disallowedTools` (confirmed against the installed `@anthropic-ai/claude-agent-sdk@0.3.205` — `sdk.d.ts` declares `disallowedTools?: string[]` and has no `deniedTools`). Because `sdk-runtime.ts` spreads the options object into `query()` as an untyped record, the misspelled key was silently dropped — tools listed in `denied_tools` remained fully available to `runtime: sdk` agents. The CLI runtime was unaffected (it already passes `--disallowedTools`).

The typo compiled because the hand-rolled `SDKQueryOptions` interface in `packages/core/src/runner/types.ts` also declared `deniedTools?: string[]`.

## Changes

- `sdk-adapter.ts`: emit `result.disallowedTools = agent.denied_tools`
- `types.ts`: rename the `SDKQueryOptions` field to `disallowedTools`, so the compiler catches future drift
- `sdk-adapter.test.ts`: update existing assertions and add a regression test asserting the emitted options contain `disallowedTools` with the denied list and do **not** contain a `deniedTools` key
- Docs: fix the SDK option name in `architecture/runner.md` (transformation map) and `architecture/docker-runtime.md`
- Changeset: patch bump for `@herdctl/core`

The `deniedTools` fields in `packages/discord/*` are Discord's own display DTO (fed directly from `agent.denied_tools`, never sent to the SDK) and are intentionally untouched.

## Testing

- `packages/core` targeted: `sdk-adapter.test.ts` — 60/60 pass
- `packages/core` full suite: 3257 passed, 1 failed, 29 skipped — the single failure is the known root-only `src/state/__tests__/directory.test.ts` permission test, confirmed to fail identically on a clean `origin/main` checkout (pre-existing, unrelated)
- `pnpm --filter @herdctl/core build` and `typecheck` pass

Fixes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)