### PR TITLE
fix(web): honor web.session_expiry_hours in web chat manager

### DIFF
--- a/.changeset/web-session-expiry-hours.md
+++ b/.changeset/web-session-expiry-hours.md
@@ -1,0 +1,7 @@
+---
+"@herdctl/web": patch
+---
+
+Fix `web.session_expiry_hours` config not being honored by the web chat manager (edspencer/herdctl#326).
+
+The value was already plumbed from fleet config into `WebChatManager.initialize()`, but `initialize()` never captured it and `createSessionManagerForAgent()` hardcoded `sessionExpiryHours: 24` when constructing each agent's `ChatSessionManager`. The configured value is now stored on the manager and forwarded to every `ChatSessionManager`, matching how the Discord and Slack connectors already handle it.

--- a/packages/web/src/server/__tests__/web-chat-manager.test.ts
+++ b/packages/web/src/server/__tests__/web-chat-manager.test.ts
@@ -172,14 +172,16 @@ function createMockSessionManager() {
  * Create a minimal WebConfig for testing
  * Uses `as any` because we only need to test the fields that WebChatManager uses
  */
-function createMockWebConfig(overrides: { tool_results?: boolean } = {}) {
+function createMockWebConfig(
+  overrides: { tool_results?: boolean; session_expiry_hours?: number } = {},
+) {
   return {
     tool_results: overrides.tool_results ?? true,
+    session_expiry_hours: overrides.session_expiry_hours ?? 24,
     // Other required fields from the schema (not used by WebChatManager)
     host: "localhost",
     enabled: true,
     port: 3232,
-    session_expiry_hours: 24,
     open_browser: false,
     message_grouping: "separate" as const,
   };
@@ -246,6 +248,21 @@ describe("WebChatManager", () => {
           platform: "web",
           agentName: "agent-2",
           stateDir: "/state/dir",
+        }),
+      );
+    });
+
+    it("forwards session_expiry_hours to ChatSessionManager", () => {
+      manager.initialize(
+        mockFleetManager,
+        "/state/dir",
+        createMockWebConfig({ session_expiry_hours: 168 }),
+        mockDiscoveryService,
+      );
+
+      expect(ChatSessionManager).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionExpiryHours: 168,
         }),
       );
     });

--- a/packages/web/src/server/chat/web-chat-manager.ts
+++ b/packages/web/src/server/chat/web-chat-manager.ts
@@ -121,6 +121,7 @@ export class WebChatManager {
   private discoveryService: SessionDiscoveryService | null = null;
   private metadataStore: SessionMetadataStore | null = null;
   private toolResults: boolean = true;
+  private sessionExpiryHours: number = 24;
   private initialized: boolean = false;
 
   /** Per-agent session managers for attribution */
@@ -147,6 +148,7 @@ export class WebChatManager {
     this.fleetManager = fleetManager;
     this.stateDir = stateDir;
     this.toolResults = config.tool_results ?? true;
+    this.sessionExpiryHours = config.session_expiry_hours ?? 24;
     this.discoveryService = discoveryService;
     this.metadataStore = new SessionMetadataStore(stateDir);
 
@@ -694,7 +696,7 @@ export class WebChatManager {
       platform: "web",
       agentName,
       stateDir: this.stateDir!,
-      sessionExpiryHours: 24, // Default expiry for attribution
+      sessionExpiryHours: this.sessionExpiryHours,
       logger: chatLogger,
     });
 


### PR DESCRIPTION
Fixes #326

## Problem

`web.session_expiry_hours` was validated, documented, and plumbed all the way into the web server — `packages/web/src/server/index.ts` passes it to `createWebServer` and on into `chatManager.initialize()` — but `WebChatManager` dropped it on the floor:

- `WebChatManager.initialize()` only captured `config.tool_results`, never `config.session_expiry_hours`.
- `createSessionManagerForAgent()` hardcoded `sessionExpiryHours: 24` when constructing each agent's `ChatSessionManager`.

Discord (`packages/discord/src/manager.ts`) and Slack (`packages/slack/src/manager.ts`) already thread the same value correctly — web was the odd one out.

## Fix

Single-file fix in `packages/web/src/server/chat/web-chat-manager.ts`, mirroring the existing `tool_results` pattern:

- Add a private `sessionExpiryHours: number = 24` field.
- Capture `config.session_expiry_hours ?? 24` in `initialize()`.
- Forward `this.sessionExpiryHours` to the `ChatSessionManager` constructor instead of the hardcoded `24`.

## Tests

- New test in `web-chat-manager.test.ts` asserting a non-default `session_expiry_hours` (168) is forwarded to the `ChatSessionManager` constructor; `createMockWebConfig` now accepts a `session_expiry_hours` override.
- `env -u NODE_ENV npx vitest run src/server` — 110/110 pass (3 files).
- `pnpm --filter @herdctl/web typecheck` and `pnpm --filter @herdctl/web build` — pass.

Changeset included (patch bump for `@herdctl/web`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)