### PR TITLE
fix(core): export InvalidWorkingDirectoryOverrideError + type guard from @herdctl/core

### DIFF
--- a/.changeset/export-invalid-working-directory-error.md
+++ b/.changeset/export-invalid-working-directory-error.md
@@ -1,0 +1,5 @@
+---
+"@herdctl/core": patch
+---
+
+Export `InvalidWorkingDirectoryOverrideError` and `isInvalidWorkingDirectoryOverrideError` from `@herdctl/core` (edspencer/herdctl#325).

--- a/packages/core/src/fleet-manager/__tests__/errors.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/errors.test.ts
@@ -6,6 +6,10 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  InvalidWorkingDirectoryOverrideError as InvalidWorkingDirectoryOverrideErrorFromBarrel,
+  isInvalidWorkingDirectoryOverrideError as isInvalidWorkingDirectoryOverrideErrorFromBarrel,
+} from "../../index.js";
+import {
   AgentNotFoundError,
   ConcurrencyLimitError,
   ConfigurationError,
@@ -647,6 +651,24 @@ describe("FleetManagerError classes", () => {
       expect(FleetManagerErrorCode.INVALID_WORKING_DIRECTORY_OVERRIDE).toBe(
         "INVALID_WORKING_DIRECTORY_OVERRIDE",
       );
+    });
+  });
+
+  // ===========================================================================
+  // Public API surface (package barrel)
+  // ===========================================================================
+  describe("public exports", () => {
+    it("exports InvalidWorkingDirectoryOverrideError and its type guard from the package index", () => {
+      // Regression test for edspencer/herdctl#325: these were thrown to
+      // consumers by trigger() but missing from the barrel exports.
+      expect(InvalidWorkingDirectoryOverrideErrorFromBarrel).toBe(
+        InvalidWorkingDirectoryOverrideError,
+      );
+      expect(isInvalidWorkingDirectoryOverrideErrorFromBarrel).toBe(
+        isInvalidWorkingDirectoryOverrideError,
+      );
+      const error = new InvalidWorkingDirectoryOverrideErrorFromBarrel("");
+      expect(isInvalidWorkingDirectoryOverrideErrorFromBarrel(error)).toBe(true);
     });
   });
 });

--- a/packages/core/src/fleet-manager/index.ts
+++ b/packages/core/src/fleet-manager/index.ts
@@ -61,11 +61,13 @@ export {
   FleetManagerShutdownError,
   FleetManagerStateDirError,
   InvalidStateError,
+  InvalidWorkingDirectoryOverrideError,
   isAgentNotFoundError,
   isConcurrencyLimitError,
   isConfigurationError,
   isFleetManagerError,
   isInvalidStateError,
+  isInvalidWorkingDirectoryOverrideError,
   // Job control error type guards (US-6)
   isJobCancelError,
   isJobForkError,


### PR DESCRIPTION
## Summary

`InvalidWorkingDirectoryOverrideError` and `isInvalidWorkingDirectoryOverrideError` are thrown to consumers by `trigger()` (via `applyWorkingDirectoryOverride` in `job-control.ts`), but were missing from the explicit named-export list in `packages/core/src/fleet-manager/index.ts`. Since the top-level `packages/core/src/index.ts` re-exports the fleet-manager barrel, consumers could not `instanceof`-match or type-guard this error from the public API.

## Changes

- Add `InvalidWorkingDirectoryOverrideError` and `isInvalidWorkingDirectoryOverrideError` to the `export { ... } from "./errors.js"` block in `packages/core/src/fleet-manager/index.ts` (purely additive; alphabetical ordering preserved).
- Add a regression test in `errors.test.ts` asserting both symbols are importable from the package barrel (`src/index.ts`) and identical to the `errors.ts` originals.
- Changeset: patch bump for `@herdctl/core`.

## Testing

- `env -u NODE_ENV npx vitest run src/fleet-manager/__tests__/errors.test.ts` — 73/73 pass
- `env -u NODE_ENV pnpm --filter @herdctl/core build` — clean; verified `dist/index.js` exposes both symbols
- `biome check` clean on touched files

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)