### PR TITLE
fix(core): emit agent:started/agent:stopped, remove dead schedule:skipped event

### DIFF
--- a/.changeset/lifecycle-events-emitted.md
+++ b/.changeset/lifecycle-events-emitted.md
@@ -1,0 +1,9 @@
+---
+"@herdctl/core": minor
+---
+
+Emit `agent:started` / `agent:stopped` lifecycle events and remove the never-emitted `schedule:skipped` event (edspencer/herdctl#323).
+
+- `agent:started` is now emitted for each configured agent when `FleetManager.start()` completes, and when an agent is registered at runtime via `addAgent()`.
+- `agent:stopped` is now emitted for each agent during `FleetManager.stop()` (reason `"shutdown"`), and when an agent is unregistered via `removeAgent()` (reason `"removed"`). Both events were previously declared and documented but never fired.
+- The `schedule:skipped` event has been removed from the FleetManager public event surface (`FleetManagerEventMap`), along with the `ScheduleSkippedPayload` type and the `emitScheduleSkipped` helper. It was never emitted, nothing subscribed to it, and its declared reason enum did not match the scheduler's actual skip reasons. The separate `JobQueue` class's own `schedule:skipped` event is unaffected.

--- a/docs/src/content/docs/architecture/overview.md
+++ b/docs/src/content/docs/architecture/overview.md
@@ -195,7 +195,6 @@ FleetManager extends Node.js `EventEmitter` and provides strongly-typed events f
 | Event | Payload | When Emitted |
 |-------|---------|-------------|
 | `schedule:triggered` | `{ agentName, scheduleName, schedule, timestamp }` | Schedule fires, before job creation |
-| `schedule:skipped` | `{ agentName, scheduleName, reason, timestamp }` | Schedule check skipped (already running, disabled, concurrency limit, empty work source) |
 
 **Job events:**
 

--- a/docs/src/content/docs/library-reference/events.mdx
+++ b/docs/src/content/docs/library-reference/events.mdx
@@ -140,7 +140,6 @@ manager.on('agent:stopped', (payload) => {
 | Event | Payload | Description |
 |-------|---------|-------------|
 | `schedule:triggered` | `ScheduleTriggeredPayload` | Schedule fired, job about to start |
-| `schedule:skipped` | `ScheduleSkippedPayload` | Schedule check skipped |
 
 ```typescript
 interface ScheduleTriggeredPayload {
@@ -149,30 +148,12 @@ interface ScheduleTriggeredPayload {
   schedule: Schedule;      // Full schedule configuration
   timestamp: string;       // ISO timestamp
 }
-
-interface ScheduleSkippedPayload {
-  agentName: string;
-  scheduleName: string;
-  reason: 'already_running' | 'disabled' | 'max_concurrent' | 'work_source_empty';
-  timestamp: string;
-}
 ```
 
 ```typescript
 manager.on('schedule:triggered', (payload) => {
   console.log(`Triggered: ${payload.agentName}/${payload.scheduleName}`);
   console.log(`  Type: ${payload.schedule.type}`);
-});
-
-manager.on('schedule:skipped', (payload) => {
-  const reasons = {
-    already_running: 'Agent already running',
-    disabled: 'Schedule disabled',
-    max_concurrent: 'At concurrency limit',
-    work_source_empty: 'No work items available',
-  };
-  console.log(`Skipped: ${payload.agentName}/${payload.scheduleName}`);
-  console.log(`  Reason: ${reasons[payload.reason]}`);
 });
 ```
 
@@ -414,10 +395,6 @@ manager.on('config:reloaded', (payload) => {
 // Schedule events
 manager.on('schedule:triggered', (payload) => {
   console.log(`[Schedule] ${payload.agentName}/${payload.scheduleName} triggered`);
-});
-
-manager.on('schedule:skipped', (payload) => {
-  console.log(`[Schedule] ${payload.agentName}/${payload.scheduleName} skipped: ${payload.reason}`);
 });
 
 // Job lifecycle events
@@ -956,7 +933,6 @@ import type {
 
   // Schedule events
   ScheduleTriggeredPayload,
-  ScheduleSkippedPayload,
 
   // Job events
   JobCreatedPayload,

--- a/docs/src/content/docs/library-reference/fleet-manager.mdx
+++ b/docs/src/content/docs/library-reference/fleet-manager.mdx
@@ -1686,7 +1686,6 @@ interface FleetManagerEventMap {
 
   // Schedule events
   'schedule:triggered': [payload: ScheduleTriggeredPayload];
-  'schedule:skipped': [payload: ScheduleSkippedPayload];
 
   // Job events
   'job:created': [payload: JobCreatedPayload];
@@ -1759,13 +1758,6 @@ interface ScheduleTriggeredPayload {
   schedule: Schedule;
   timestamp: string;
 }
-
-interface ScheduleSkippedPayload {
-  agentName: string;
-  scheduleName: string;
-  reason: 'already_running' | 'disabled' | 'max_concurrent' | 'work_source_empty';
-  timestamp: string;
-}
 ```
   </TabItem>
   <TabItem label="Config Events">
@@ -1830,10 +1822,6 @@ manager.on('job:failed', (payload) => {
 // Schedule events
 manager.on('schedule:triggered', (payload) => {
   console.log(`${payload.agentName}/${payload.scheduleName} triggered`);
-});
-
-manager.on('schedule:skipped', (payload) => {
-  console.log(`${payload.agentName}/${payload.scheduleName} skipped: ${payload.reason}`);
 });
 
 // Config reload
@@ -2090,6 +2078,5 @@ import type {
   JobCancelledPayload,
   JobForkedPayload,
   ScheduleTriggeredPayload,
-  ScheduleSkippedPayload,
 } from '@herdctl/core';
 ```

--- a/examples/library-usage/basic-usage.ts
+++ b/examples/library-usage/basic-usage.ts
@@ -72,10 +72,6 @@ async function main() {
     console.log(`Schedule triggered: ${payload.agentName}/${payload.scheduleName}`);
   });
 
-  manager.on("schedule:skipped", (payload) => {
-    console.log(`Schedule skipped: ${payload.agentName}/${payload.scheduleName}`);
-    console.log(`  Reason: ${payload.reason}`);
-  });
 
   // Config reload events
   manager.on("config:reloaded", (payload) => {

--- a/examples/library-usage/event-subscription.ts
+++ b/examples/library-usage/event-subscription.ts
@@ -87,19 +87,6 @@ async function main() {
     console.log(`[Schedule]   Type: ${payload.schedule.type}`);
   });
 
-  manager.on("schedule:skipped", (payload) => {
-    const reasons: Record<string, string> = {
-      already_running: "Agent already running",
-      disabled: "Schedule disabled",
-      max_concurrent: "At concurrency limit",
-      work_source_empty: "No work items available",
-    };
-    console.log(
-      `[Schedule] Skipped: ${payload.agentName}/${payload.scheduleName}`,
-    );
-    console.log(`[Schedule]   Reason: ${reasons[payload.reason]}`);
-  });
-
   // =========================================================================
   // Job Events
   // =========================================================================

--- a/examples/recipes/daemon.ts
+++ b/examples/recipes/daemon.ts
@@ -98,9 +98,6 @@ async function startDaemon() {
     console.log(`Schedule triggered: ${payload.agentName}/${payload.scheduleName}`);
   });
 
-  manager.on("schedule:skipped", (payload) => {
-    console.log(`Schedule skipped: ${payload.agentName}/${payload.scheduleName} - ${payload.reason}`);
-  });
 
   manager.on("job:created", (payload) => {
     console.log(`Job started: ${payload.job.id} (${payload.agentName})`);

--- a/examples/recipes/express-dashboard.ts
+++ b/examples/recipes/express-dashboard.ts
@@ -70,13 +70,6 @@ manager.on("schedule:triggered", (p) => {
   recordEvent("schedule:triggered", { agent: p.agentName, schedule: p.scheduleName });
 });
 
-manager.on("schedule:skipped", (p) => {
-  recordEvent("schedule:skipped", {
-    agent: p.agentName,
-    schedule: p.scheduleName,
-    reason: p.reason,
-  });
-});
 
 manager.on("config:reloaded", (p) => {
   recordEvent("config:reloaded", { agentCount: p.agentCount, changes: p.changes });

--- a/packages/core/src/fleet-manager/__tests__/agent-management.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/agent-management.test.ts
@@ -148,6 +148,29 @@ describe("FleetManager programmatic agent management", () => {
       );
     });
 
+    it("emits agent:started with the resolved agent", async () => {
+      const configPath = await createConfig({ version: 1, agents: [] });
+      const manager = createTestManager(configPath);
+      await manager.initialize();
+
+      const handler = vi.fn();
+      manager.on("agent:started", handler);
+
+      await manager.addAgent({ name: "started-agent", working_directory: tempDir });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: expect.objectContaining({
+            name: "started-agent",
+            qualifiedName: "started-agent",
+            working_directory: tempDir,
+          }),
+          timestamp: expect.any(String),
+        }),
+      );
+    });
+
     it("merges fleet defaults into the added agent", async () => {
       const configPath = await createConfig({
         version: 1,
@@ -302,12 +325,45 @@ describe("FleetManager programmatic agent management", () => {
       );
     });
 
+    it("emits agent:stopped with reason 'removed'", async () => {
+      const configPath = await createConfig({ version: 1, agents: [] });
+      const manager = createTestManager(configPath);
+      await manager.initialize();
+      await manager.addAgent({ name: "stopped-agent", working_directory: tempDir });
+
+      const handler = vi.fn();
+      manager.on("agent:stopped", handler);
+
+      await manager.removeAgent("stopped-agent");
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentName: "stopped-agent",
+          reason: "removed",
+          timestamp: expect.any(String),
+        }),
+      );
+    });
+
     it("returns false when the agent does not exist", async () => {
       const configPath = await createConfig({ version: 1, agents: [] });
       const manager = createTestManager(configPath);
       await manager.initialize();
 
       expect(await manager.removeAgent("nope")).toBe(false);
+    });
+
+    it("does not emit agent:stopped when no agent matches", async () => {
+      const configPath = await createConfig({ version: 1, agents: [] });
+      const manager = createTestManager(configPath);
+      await manager.initialize();
+
+      const handler = vi.fn();
+      manager.on("agent:stopped", handler);
+
+      expect(await manager.removeAgent("ghost")).toBe(false);
+      expect(handler).not.toHaveBeenCalled();
     });
 
     it("removes a file-loaded agent by name", async () => {

--- a/packages/core/src/fleet-manager/__tests__/integration.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/integration.test.ts
@@ -23,6 +23,8 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 import { query as mockQueryFn } from "@anthropic-ai/claude-agent-sdk";
 import { AgentNotFoundError, InvalidStateError, ScheduleNotFoundError } from "../errors.js";
 import type {
+  AgentStartedPayload,
+  AgentStoppedPayload,
   FleetManagerLogger,
   JobCompletedPayload,
   JobCreatedPayload,
@@ -187,6 +189,45 @@ describe("FleetManager Integration Tests (US-13)", () => {
       await manager.stop();
 
       expect(eventOrder).toEqual(["initialized", "started", "job:created", "stopped"]);
+    });
+
+    it("emits agent:started on start() and agent:stopped on stop() for each agent", async () => {
+      await createAgentConfig("lifecycle-alpha", { name: "lifecycle-alpha" });
+      await createAgentConfig("lifecycle-beta", { name: "lifecycle-beta" });
+
+      const configPath = await createConfig({
+        version: 1,
+        agents: [
+          { path: "./agents/lifecycle-alpha.yaml" },
+          { path: "./agents/lifecycle-beta.yaml" },
+        ],
+      });
+
+      const manager = createTestManager(configPath);
+      const started: AgentStartedPayload[] = [];
+      const stopped: AgentStoppedPayload[] = [];
+      manager.on("agent:started", (payload) => started.push(payload));
+      manager.on("agent:stopped", (payload) => stopped.push(payload));
+
+      await manager.initialize();
+      expect(started).toHaveLength(0);
+
+      await manager.start();
+      expect(started.map((p) => p.agent.qualifiedName).sort()).toEqual([
+        "lifecycle-alpha",
+        "lifecycle-beta",
+      ]);
+      for (const payload of started) {
+        expect(payload.timestamp).toEqual(expect.any(String));
+      }
+      expect(stopped).toHaveLength(0);
+
+      await manager.stop();
+      expect(stopped.map((p) => p.agentName).sort()).toEqual(["lifecycle-alpha", "lifecycle-beta"]);
+      for (const payload of stopped) {
+        expect(payload.reason).toBe("shutdown");
+        expect(payload.timestamp).toEqual(expect.any(String));
+      }
     });
 
     it("handles multiple agents in full workflow", async () => {

--- a/packages/core/src/fleet-manager/agent-management.ts
+++ b/packages/core/src/fleet-manager/agent-management.ts
@@ -28,6 +28,7 @@ import {
 } from "../config/index.js";
 import type { FleetManagerContext } from "./context.js";
 import { ConfigurationError, InvalidStateError } from "./errors.js";
+import { emitAgentStarted, emitAgentStopped } from "./event-emitters.js";
 import type { AgentInfo, ConfigChange } from "./types.js";
 
 // =============================================================================
@@ -83,7 +84,8 @@ export class AgentManagement {
    * fleet defaults (unless disabled), and normalized the same way agents loaded
    * from disk are. The resolved agent is appended to the in-memory config and
    * pushed to the scheduler so it is immediately triggerable and visible in
-   * fleet status. A `config:reloaded` event is emitted describing the change.
+   * fleet status. A `config:reloaded` event is emitted describing the change,
+   * followed by an `agent:started` event for the new agent.
    *
    * @param agent - The agent configuration to register
    * @param options - Resolution options (base dir, defaults merge, replace)
@@ -137,6 +139,11 @@ export class AgentManagement {
       buildChange(existingIndex !== -1 ? "modified" : "added", resolved),
     ]);
 
+    emitAgentStarted(this.ctx, {
+      agent: resolved,
+      timestamp: new Date().toISOString(),
+    });
+
     logger.info(
       `Agent "${resolved.qualifiedName}" ${existingIndex !== -1 ? "replaced" : "added"} programmatically`,
     );
@@ -150,7 +157,8 @@ export class AgentManagement {
    * Removes the agent from the in-memory config and the scheduler. Accepts a
    * qualified name (e.g. `"sub.agent"`) or a local name; qualified names are
    * matched first. Running jobs are unaffected — the scheduler simply stops
-   * triggering the removed agent's schedules.
+   * triggering the removed agent's schedules. A `config:reloaded` event is
+   * emitted describing the change, followed by an `agent:stopped` event.
    *
    * @param name - The agent qualified name or local name to remove
    * @returns `true` if an agent was removed, `false` if no match was found
@@ -175,6 +183,12 @@ export class AgentManagement {
     const newAgents = config.agents.filter((_, i) => i !== index);
 
     this.commit(config, newAgents, [buildChange("removed", removed)]);
+
+    emitAgentStopped(this.ctx, {
+      agentName: removed.qualifiedName,
+      timestamp: new Date().toISOString(),
+      reason: "removed",
+    });
 
     logger.info(`Agent "${removed.qualifiedName}" removed programmatically`);
     return true;

--- a/packages/core/src/fleet-manager/event-emitters.ts
+++ b/packages/core/src/fleet-manager/event-emitters.ts
@@ -17,7 +17,6 @@ import type {
   JobFailedPayload,
   JobForkedPayload,
   JobOutputPayload,
-  ScheduleSkippedPayload,
 } from "./event-types.js";
 
 // =============================================================================
@@ -84,25 +83,6 @@ export function emitAgentStopped(
   payload: AgentStoppedPayload,
 ): void {
   emitter.emit("agent:stopped", payload);
-}
-
-/**
- * Emit a schedule:skipped event
- *
- * Called when a schedule check is skipped. This can happen when:
- * - The agent is already running (already_running)
- * - The schedule is disabled (disabled)
- * - Max concurrent limit reached (max_concurrent)
- * - Work source returned no items (work_source_empty)
- *
- * @param emitter - The event emitter instance
- * @param payload - Schedule skip details including reason
- */
-export function emitScheduleSkipped(
-  emitter: FleetManagerEventEmitter,
-  payload: ScheduleSkippedPayload,
-): void {
-  emitter.emit("schedule:skipped", payload);
 }
 
 /**

--- a/packages/core/src/fleet-manager/event-types.ts
+++ b/packages/core/src/fleet-manager/event-types.ts
@@ -80,20 +80,6 @@ export interface ScheduleTriggeredPayload {
 }
 
 /**
- * Payload for schedule:skipped event
- */
-export interface ScheduleSkippedPayload {
-  /** Name of the agent whose schedule was skipped */
-  agentName: string;
-  /** Name of the schedule that was skipped */
-  scheduleName: string;
-  /** Reason why the schedule was skipped */
-  reason: "already_running" | "disabled" | "max_concurrent" | "work_source_empty";
-  /** ISO timestamp when the skip occurred */
-  timestamp: string;
-}
-
-/**
  * Payload for job:created event
  */
 export interface JobCreatedPayload {
@@ -335,12 +321,6 @@ export interface FleetManagerEventMap {
    * This is emitted before the job is created.
    */
   "schedule:triggered": [payload: ScheduleTriggeredPayload];
-
-  /**
-   * Emitted when a schedule check is skipped.
-   * This happens when the agent is already running or disabled.
-   */
-  "schedule:skipped": [payload: ScheduleSkippedPayload];
 
   // ===========================================================================
   // Job Events

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -48,6 +48,7 @@ import {
   FleetManagerStateDirError,
   InvalidStateError,
 } from "./errors.js";
+import { emitAgentStarted, emitAgentStopped } from "./event-emitters.js";
 import { JobControl } from "./job-control.js";
 import { LogStreaming } from "./log-streaming.js";
 import { ScheduleExecutor } from "./schedule-executor.js";
@@ -412,6 +413,13 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
 
       this.logger.info("Fleet manager started");
       this.emit("started");
+
+      // Announce each configured agent as started now that the scheduler is
+      // monitoring its schedules and chat managers (event subscribers) are up.
+      const startTimestamp = new Date().toISOString();
+      for (const agent of this.config?.agents ?? []) {
+        emitAgentStarted(this, { agent, timestamp: startTimestamp });
+      }
     } catch (error) {
       this.status = "error";
       this.lastError = error instanceof Error ? error.message : String(error);
@@ -471,6 +479,17 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
       await this.persistShutdownState();
       this.status = "stopped";
       this.stoppedAt = new Date().toISOString();
+
+      // Announce each configured agent as stopped — the scheduler is no longer
+      // monitoring its schedules.
+      const stopTimestamp = new Date().toISOString();
+      for (const agent of this.config?.agents ?? []) {
+        emitAgentStopped(this, {
+          agentName: agent.qualifiedName,
+          timestamp: stopTimestamp,
+          reason: "shutdown",
+        });
+      }
 
       this.logger.info("Fleet manager stopped");
       this.emit("stopped");

--- a/packages/core/src/fleet-manager/index.ts
+++ b/packages/core/src/fleet-manager/index.ts
@@ -89,7 +89,6 @@ export {
   emitJobFailed,
   emitJobForked,
   emitJobOutput,
-  emitScheduleSkipped,
   type FleetManagerEventEmitter,
 } from "./event-emitters.js";
 export type {
@@ -182,7 +181,6 @@ export type {
   LogSource,
   LogStreamOptions,
   ScheduleInfo,
-  ScheduleSkippedPayload,
   ScheduleTriggeredPayload,
   SlackErrorPayload,
   SlackMessageErrorPayload,

--- a/packages/core/src/fleet-manager/types.ts
+++ b/packages/core/src/fleet-manager/types.ts
@@ -25,7 +25,6 @@ export type {
   JobFailedPayload,
   JobForkedPayload,
   JobOutputPayload,
-  ScheduleSkippedPayload,
   ScheduleTriggeredPayload,
   SlackErrorPayload,
   SlackMessageErrorPayload,


### PR DESCRIPTION
## Summary

`agent:started`, `agent:stopped`, and `schedule:skipped` were declared in `FleetManagerEventMap`, documented, and (for the agent events) actively subscribed to by the web fleet-bridge — but nothing ever emitted them. This PR fixes that in two halves:

### 1. Emit `agent:started` / `agent:stopped` for real

- **`FleetManager.start()`** now emits `agent:started` for each configured agent once the scheduler is monitoring its schedules (emitted after `started`, so chat-manager subscribers like the web fleet-bridge are already attached).
- **`FleetManager.stop()`** emits `agent:stopped` for each agent with `reason: "shutdown"`.
- **`addAgent()`** emits `agent:started` with the resolved agent after the commit (following the existing `config:reloaded` emission, via the `emitAgentStarted` helper).
- **`removeAgent()`** emits `agent:stopped` with `reason: "removed"`.

The web fleet-bridge's existing `agent:started`/`agent:stopped` subscriptions (which rebroadcast as `agent:updated` WS messages) now actually receive events, and the docs describing these events become accurate.

### 2. Remove `schedule:skipped` from the FleetManager public event surface

Removed the event map entry, the `ScheduleSkippedPayload` type, the `emitScheduleSkipped` helper, and their exports, plus the doc rows/examples (`events.mdx`, `fleet-manager.mdx`, `architecture/overview.md`) and the example scripts' subscriptions.

> **Note — judgment call:** `schedule:skipped` was never emitted, has no subscribers, and its declared reason enum (`already_running | disabled | max_concurrent | work_source_empty`) doesn't match the scheduler's actual `ScheduleSkipReason` (`disabled | unsupported_type | not_due | at_capacity | already_running`) — wiring it up properly (without spamming `not_due` every tick) is a design task, not a bug fix. Happy to revert this half if you'd rather keep and wire it. The separate, unwired `JobQueue` class keeps its own `schedule:skipped` event untouched.

## Tests

- New tests: `agent:started` on `addAgent()` (asserting the `ResolvedAgent` payload), `agent:stopped` with `reason: "removed"` on `removeAgent()`, no emission when no agent matches, and a lifecycle integration test asserting per-agent `agent:started` on `start()` / `agent:stopped` (`reason: "shutdown"`) on `stop()`.
- Full `@herdctl/core` suite: 3260 passed / 1 failed — the failure is the known pre-existing root-only `src/state/__tests__/directory.test.ts` case (chmod-based, doesn't apply when running as root), unrelated to this change.
- `@herdctl/core` build + typecheck and `@herdctl/web` typecheck pass.

## Changeset

`@herdctl/core` minor: adds real lifecycle emissions and removes a never-emitted public event type.

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)