### PR TITLE
fix(core): inject refreshed OAuth token into reused persistent containers (#327)

### DIFF
--- a/.changeset/oauth-persistent-container-exec.md
+++ b/.changeset/oauth-persistent-container-exec.md
@@ -1,0 +1,16 @@
+---
+"@herdctl/core": patch
+---
+
+fix(core): inject refreshed OAuth credentials into reused persistent containers
+
+Docker credentials were only ever applied to a container's env at creation
+time. For persistent agents (`docker.ephemeral: false`) the same container is
+reused across executions, so a token refreshed by `buildContainerEnv()` never
+reached the already-running container — on token-expiry retry the `docker exec`
+still inherited the stale creation-time token and the agent looped on expired
+credentials. Each execution now re-injects the current credential env
+(`CLAUDE_CODE_OAUTH_TOKEN` / `CLAUDE_REFRESH_TOKEN` / `CLAUDE_EXPIRES_AT` /
+`ANTHROPIC_API_KEY`) into every exec (SDK `exec` `Env`, CLI `docker exec -e`
+args), so reused persistent containers always run with fresh credentials.
+Ephemeral containers were unaffected. Fixes edspencer/herdctl#327.

--- a/packages/core/src/runner/job-executor.ts
+++ b/packages/core/src/runner/job-executor.ts
@@ -625,8 +625,11 @@ export class JobExecutor {
         }
 
         // Check if this is an OAuth token expiry error
-        // When the access token expires mid-session, retry triggers buildContainerEnv()
-        // which reads the credentials file and refreshes the token automatically.
+        // On retry, buildContainerEnv() re-reads the credentials file and
+        // refreshes the token. The fresh credentials reach the container via a
+        // new ephemeral container (created with the new env) or, for reused
+        // persistent containers, by being injected into each docker exec — so
+        // both cases pick up the refreshed token. See edspencer/herdctl#327.
         if (isTokenExpiredError(error as Error) && !retriedAfterTokenExpiry) {
           this.logger.warn(`OAuth token expired for ${agent.name}. Retrying with fresh token.`);
 

--- a/packages/core/src/runner/runtime/__tests__/container-runner-oauth.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/container-runner-oauth.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression tests for edspencer/herdctl#327
+ *
+ * A refreshed OAuth token must reach REUSED persistent containers. Container
+ * env is fixed at creation time, so for ephemeral:false agents (where
+ * getOrCreateContainer returns a still-running container) the current
+ * credentials have to be re-injected into every `docker exec`. These tests use
+ * a mock Docker client (no daemon required) to prove that the SECOND execution
+ * against a reused container carries the NEW CLAUDE_CODE_OAUTH_TOKEN.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedAgent } from "../../../config/index.js";
+import { extractCredentialEnv } from "../container-manager.js";
+import { ContainerRunner } from "../container-runner.js";
+import { resolveDockerConfig } from "../docker-config.js";
+import { SDKRuntime } from "../sdk-runtime.js";
+
+// ---------------------------------------------------------------------------
+// extractCredentialEnv (pure)
+// ---------------------------------------------------------------------------
+
+describe("extractCredentialEnv", () => {
+  it("keeps only auth-credential keys and drops everything else", () => {
+    const env = [
+      "HOME=/home/claude",
+      "TERM=xterm-256color",
+      "CLAUDE_CODE_OAUTH_TOKEN=tok-abc",
+      "CLAUDE_REFRESH_TOKEN=ref-abc",
+      "CLAUDE_EXPIRES_AT=123456",
+      "ANTHROPIC_API_KEY=sk-xyz",
+      "GITHUB_TOKEN=ghp_should_not_leak",
+    ];
+
+    const creds = extractCredentialEnv(env);
+
+    expect(creds).toContain("CLAUDE_CODE_OAUTH_TOKEN=tok-abc");
+    expect(creds).toContain("CLAUDE_REFRESH_TOKEN=ref-abc");
+    expect(creds).toContain("CLAUDE_EXPIRES_AT=123456");
+    expect(creds).toContain("ANTHROPIC_API_KEY=sk-xyz");
+    // Non-credential vars must not be forwarded to per-exec env.
+    expect(creds).not.toContain("HOME=/home/claude");
+    expect(creds).not.toContain("TERM=xterm-256color");
+    expect(creds.some((e) => e.startsWith("GITHUB_TOKEN="))).toBe(false);
+  });
+
+  it("returns an empty array when no credential keys are present", () => {
+    expect(extractCredentialEnv(["HOME=/x", "TERM=y"])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ContainerRunner: refreshed token reaches a reused persistent container
+// ---------------------------------------------------------------------------
+
+/** Captured `container.exec()` options per exec call. */
+interface MockDocker {
+  docker: unknown;
+  execCalls: Array<{ Env?: string[]; Cmd?: string[] }>;
+  createContainerCalls: () => number;
+}
+
+function makeMockDocker(): MockDocker {
+  const execCalls: Array<{ Env?: string[]; Cmd?: string[] }> = [];
+  let createContainerCallCount = 0;
+
+  const container = {
+    // Used both by getOrCreateContainer (State.Running) and execute (Id).
+    inspect: vi.fn().mockResolvedValue({ Id: "cid-persistent", State: { Running: true } }),
+    start: vi.fn().mockResolvedValue(undefined),
+    exec: vi.fn(async (opts: { Env?: string[]; Cmd?: string[] }) => {
+      execCalls.push(opts);
+      return {
+        // Reject start() so the generator terminates deterministically right
+        // after the exec options (incl. Env) have been captured — avoids the
+        // real JSONL/demux stream plumbing which needs a live socket.
+        start: vi.fn().mockRejectedValue(new Error("test-terminate-after-capture")),
+        inspect: vi.fn().mockResolvedValue({ ExitCode: 0 }),
+      };
+    }),
+    stop: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const docker = {
+    createContainer: vi.fn(async () => {
+      createContainerCallCount++;
+      return container;
+    }),
+    listContainers: vi.fn().mockResolvedValue([]),
+    getContainer: vi.fn(),
+  };
+
+  return {
+    docker,
+    execCalls,
+    createContainerCalls: () => createContainerCallCount,
+  };
+}
+
+async function drain(gen: AsyncIterable<unknown>): Promise<void> {
+  // The mock forces exec.start() to reject, so execute() yields a single
+  // "Docker execution failed" error message and then completes.
+  for await (const _msg of gen) {
+    // discard
+  }
+}
+
+function writeCredentials(homeDir: string, accessToken: string): void {
+  const claudeDir = path.join(homeDir, ".claude");
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(claudeDir, ".credentials.json"),
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken,
+        refreshToken: "refresh-token-static",
+        // Well beyond the 5-minute refresh buffer, so buildContainerEnv reads
+        // the file verbatim and makes no network refresh call.
+        expiresAt: Date.now() + 60 * 60 * 1000,
+      },
+    }),
+  );
+}
+
+describe("ContainerRunner OAuth injection into reused persistent container (#327)", () => {
+  let tmpRoot: string;
+  let homeDir: string;
+  let stateDir: string;
+  let workspaceDir: string;
+  let originalHome: string | undefined;
+  let originalApiKey: string | undefined;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "herdctl-327-"));
+    homeDir = path.join(tmpRoot, "home");
+    stateDir = path.join(tmpRoot, "state");
+    workspaceDir = path.join(tmpRoot, "workspace");
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.mkdirSync(workspaceDir, { recursive: true });
+
+    // buildContainerEnv reads ~/.claude/.credentials.json via os.homedir(),
+    // which honors $HOME on POSIX.
+    originalHome = process.env.HOME;
+    process.env.HOME = homeDir;
+
+    // Keep the credential env deterministic (no ambient API key).
+    originalApiKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalApiKey;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("SDK exec carries the NEW token after a host-side refresh, with the container reused", async () => {
+    const mock = makeMockDocker();
+    const config = resolveDockerConfig({ enabled: true, ephemeral: false });
+    const agent = {
+      name: "persistent-agent",
+      configPath: "/path/to/agent.yaml",
+      working_directory: workspaceDir,
+    } as ResolvedAgent;
+
+    const runner = new ContainerRunner(
+      new SDKRuntime(),
+      config,
+      stateDir,
+      mock.docker as import("dockerode"),
+    );
+
+    // ---- First execution: token1, container is created ---------------------
+    writeCredentials(homeDir, "token-ONE");
+    await drain(runner.execute({ prompt: "hi", agent }));
+
+    expect(mock.createContainerCalls()).toBe(1);
+    expect(mock.execCalls).toHaveLength(1);
+    expect(mock.execCalls[0].Env).toContain("CLAUDE_CODE_OAUTH_TOKEN=token-ONE");
+
+    // ---- Host refreshes the token on disk (new access token) ---------------
+    writeCredentials(homeDir, "token-TWO");
+
+    // ---- Second execution: same persistent container is reused -------------
+    await drain(runner.execute({ prompt: "hi again", agent }));
+
+    // Container was NOT recreated — the persistent one was reused...
+    expect(mock.createContainerCalls()).toBe(1);
+    expect(mock.execCalls).toHaveLength(2);
+
+    // ...yet the reused container's exec receives the NEW token (the bug fix).
+    const secondEnv = mock.execCalls[1].Env ?? [];
+    expect(secondEnv).toContain("CLAUDE_CODE_OAUTH_TOKEN=token-TWO");
+    expect(secondEnv).not.toContain("CLAUDE_CODE_OAUTH_TOKEN=token-ONE");
+
+    // The injected exec env is credential-only (no HOME/TERM leakage).
+    expect(secondEnv.some((e) => e.startsWith("HOME="))).toBe(false);
+    expect(secondEnv.some((e) => e.startsWith("TERM="))).toBe(false);
+  });
+});

--- a/packages/core/src/runner/runtime/container-manager.ts
+++ b/packages/core/src/runner/runtime/container-manager.ts
@@ -392,6 +392,42 @@ async function refreshClaudeOAuthToken(
 }
 
 /**
+ * Auth-credential env var keys that must be re-applied on every exec.
+ *
+ * A container's env is fixed at creation time and cannot change while it runs.
+ * For persistent (ephemeral: false) containers the same container is reused
+ * across executions, so a freshly-refreshed OAuth token computed by
+ * buildContainerEnv() never reaches the already-running container unless it is
+ * re-injected into each `docker exec`. These are the keys carrying such
+ * (potentially just-refreshed) credentials. See edspencer/herdctl#327.
+ */
+const CREDENTIAL_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "CLAUDE_REFRESH_TOKEN",
+  "CLAUDE_EXPIRES_AT",
+];
+
+/**
+ * Extract the auth-credential subset from a computed container env array.
+ *
+ * Returns only the "KEY=value" entries whose key is a credential key (see
+ * CREDENTIAL_ENV_KEYS). The result is injected into each exec so reused
+ * persistent containers always run with the current credentials rather than
+ * the ones baked in at container-creation time.
+ *
+ * @param env - Full container env as "KEY=value" strings
+ * @returns Credential-only subset, preserving order
+ */
+export function extractCredentialEnv(env: string[]): string[] {
+  return env.filter((entry) => {
+    const eq = entry.indexOf("=");
+    const key = eq === -1 ? entry : entry.slice(0, eq);
+    return CREDENTIAL_ENV_KEYS.includes(key);
+  });
+}
+
+/**
  * Build environment variables for container
  *
  * Reads OAuth tokens from the mounted credentials file and refreshes

--- a/packages/core/src/runner/runtime/container-runner.ts
+++ b/packages/core/src/runner/runtime/container-runner.ts
@@ -26,7 +26,12 @@ import { createLogger } from "../../utils/logger.js";
 import { toSDKOptions } from "../sdk-adapter.js";
 import type { SDKMessage } from "../types.js";
 import { CLIRuntime } from "./cli-runtime.js";
-import { buildContainerEnv, buildContainerMounts, ContainerManager } from "./container-manager.js";
+import {
+  buildContainerEnv,
+  buildContainerMounts,
+  ContainerManager,
+  extractCredentialEnv,
+} from "./container-manager.js";
 import type { DockerConfig } from "./docker-config.js";
 import type { RuntimeExecuteOptions, RuntimeInterface } from "./interface.js";
 import { type McpHttpBridge, startMcpHttpBridge } from "./mcp-http-bridge.js";
@@ -80,6 +85,13 @@ export class ContainerRunner implements RuntimeInterface {
     const mounts = buildContainerMounts(agent, this.config, this.stateDir);
     const env = await buildContainerEnv(agent, this.config);
 
+    // Credentials (incl. any freshly-refreshed OAuth token) are baked into a
+    // container's env only at creation time. Persistent (ephemeral: false)
+    // containers are reused across executions, so the current credentials must
+    // be re-injected into each exec — otherwise a refreshed token never reaches
+    // an already-running container. See edspencer/herdctl#327.
+    const credentialEnv = extractCredentialEnv(env);
+
     // Get or create container
     const container = await this.manager.getOrCreateContainer(agent.name, this.config, mounts, env);
 
@@ -90,11 +102,11 @@ export class ContainerRunner implements RuntimeInterface {
 
       // Handle CLI runtime with session file watching
       if (this.wrapped instanceof CLIRuntime) {
-        yield* this.executeCLIRuntime(containerId, dockerSessionsDir, options);
+        yield* this.executeCLIRuntime(containerId, dockerSessionsDir, options, credentialEnv);
       }
       // Handle SDK runtime with wrapper script
       else if (this.wrapped instanceof SDKRuntime) {
-        yield* this.executeSDKRuntime(container, options);
+        yield* this.executeSDKRuntime(container, options, credentialEnv);
       }
       // Unknown runtime type
       else {
@@ -143,6 +155,7 @@ export class ContainerRunner implements RuntimeInterface {
     containerId: string,
     dockerSessionsDir: string,
     options: RuntimeExecuteOptions,
+    credentialEnv: string[],
   ): AsyncIterable<SDKMessage> {
     // Create CLI runtime with Docker-specific spawner
     const cliRuntime = new CLIRuntime({
@@ -163,11 +176,17 @@ export class ContainerRunner implements RuntimeInterface {
           .join(" ");
         const claudeCommand = `cd /workspace && printf %s "${escapedPrompt}" | claude ${claudeArgs}`;
 
+        // Inject current credentials into this exec so reused persistent
+        // containers pick up a freshly-refreshed OAuth token (see #327).
+        // Array args avoid shell escaping/injection; never build a shell
+        // string from credential values.
+        const envArgs = credentialEnv.flatMap((entry) => ["-e", entry]);
+
         logger.debug(`Executing docker exec in container ${containerId}`);
         logger.debug(`Prompt length: ${prompt.length}`);
 
         // execa returns Subprocess directly (which is promise-like)
-        return execa("docker", ["exec", containerId, "sh", "-c", claudeCommand], {
+        return execa("docker", ["exec", ...envArgs, containerId, "sh", "-c", claudeCommand], {
           cancelSignal: signal,
         });
       },
@@ -189,6 +208,7 @@ export class ContainerRunner implements RuntimeInterface {
   private async *executeSDKRuntime(
     container: import("dockerode").Container,
     options: RuntimeExecuteOptions,
+    credentialEnv: string[],
   ): AsyncIterable<SDKMessage> {
     // Start HTTP bridges for injected MCP servers
     const bridges: McpHttpBridge[] = [];
@@ -255,6 +275,10 @@ export class ContainerRunner implements RuntimeInterface {
 
       const exec = await container.exec({
         Cmd: ["bash", "-l", "-c", command],
+        // Inject current credentials so reused persistent containers pick up a
+        // freshly-refreshed OAuth token rather than the one baked in at
+        // container-creation time (see #327).
+        Env: credentialEnv,
         AttachStdout: true,
         AttachStderr: true,
         AttachStdin: false,


### PR DESCRIPTION
## Problem

Fixes #327 — a refreshed OAuth token never reaches reused persistent containers (`docker.ephemeral: false`).

Docker credentials reach the container **only** as env vars set at container **creation**; there is no credentials-file mount. `buildContainerEnv()` reads `~/.claude/.credentials.json`, refreshes an expired token, and emits `CLAUDE_CODE_OAUTH_TOKEN` / `CLAUDE_REFRESH_TOKEN` / `CLAUDE_EXPIRES_AT`. Those are placed in the container's `Env` only inside `createContainer()`.

For persistent containers, `getOrCreateContainer()` returns the still-running container and **silently discards the freshly-computed env**. On token-expiry retry (`JobExecutor.execute`), a new `buildContainerEnv()` refreshes the token, but the subsequent `docker exec` inherits the container's stale creation-time env — so the agent loops on expired credentials. Ephemeral containers were unaffected (each execution creates a fresh container).

## Fix (inject fresh creds into every exec — do **not** recreate the container)

Recreating the persistent container would destroy the state that `ephemeral: false` exists to preserve. Instead, since each execution already computes fresh env and spawns a new process:

- `extractCredentialEnv()` factors the auth-credential subset (`CLAUDE_CODE_OAUTH_TOKEN` / `CLAUDE_REFRESH_TOKEN` / `CLAUDE_EXPIRES_AT` / `ANTHROPIC_API_KEY`) out of the computed env.
- **SDK path:** set `Env` on the `container.exec({...})` options.
- **CLI path:** add `docker exec -e KEY=VALUE` array args (array args → no shell escaping / injection risk; no shell string is built from credential values).

This fixes persistent containers **generally** — every exec carries the current credentials — not just on retry. Also corrects the now-accurate comment in `job-executor.ts` about how the retry's refreshed creds reach the container. Credential values are never logged.

## Tests

New mock-Docker regression test (`container-runner-oauth.test.ts`, no daemon required) proving that after a host-side token refresh, the **second** execution against a **reused** persistent container carries the **new** `CLAUDE_CODE_OAUTH_TOKEN` (verified to fail without the fix). Plus unit tests for `extractCredentialEnv`.

- `env -u NODE_ENV npx vitest run` (core): **3259 passed**, 29 skipped, 1 failure = the pre-existing root-only `state/__tests__/directory.test.ts` chmod test (root bypasses the unwritable-parent guard; unrelated to this change).
- `pnpm --filter @herdctl/core build` + `typecheck`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)