### PR TITLE
fix(core): emit job:created at creation + job:output on manual trigger (#328)

### DIFF
--- a/.changeset/fix-job-event-emission-328.md
+++ b/.changeset/fix-job-event-emission-328.md
@@ -1,0 +1,22 @@
+---
+"@herdctl/core": minor
+---
+
+Fix job lifecycle event ordering and add `job:output` on manual triggers (#328)
+
+`job:created` is now emitted the moment the job record is created (status
+`pending`), before any `job:output` and before the run completes — on both the
+manual `trigger()` path and the scheduled path. Previously it was emitted only
+*after* `JobExecutor.execute()` resolved, so consumers saw `job:created` fire
+after the job had already run (and, on the scheduled path, after its own
+`job:output` events).
+
+Manual `trigger()` now also emits `job:output` events as the agent streams,
+matching the scheduled path. Previously manual triggers emitted zero
+`job:output`.
+
+This aligns the observable event stream with the documented contract
+("`job:created` … status will be 'pending' at this point") and restores the
+`created → output → completed` ordering. The SDK-message → `job:output` payload
+mapping is now shared between both paths, so payloads are identical. This is a
+public event-contract change, hence the minor bump.

--- a/packages/core/src/fleet-manager/__tests__/integration.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/integration.test.ts
@@ -412,6 +412,60 @@ describe("FleetManager Integration Tests (US-13)", () => {
       expect(jobCompletedEvents[0].durationSeconds).toBeGreaterThanOrEqual(0);
     });
 
+    it("emits job:created (pending) before job:output before job:completed on scheduled path (issue #328)", async () => {
+      await createAgentConfig("ordered-schedule-agent", {
+        name: "ordered-schedule-agent",
+        schedules: {
+          quick: {
+            type: "interval",
+            interval: "100ms",
+            prompt: "Execute test prompt",
+          },
+        },
+      });
+
+      const configPath = await createConfig({
+        version: 1,
+        agents: [{ path: "./agents/ordered-schedule-agent.yaml" }],
+      });
+
+      (mockQueryFn as Mock).mockImplementation(async function* () {
+        yield { type: "system" as const, subtype: "init", session_id: "test-session-123" };
+        yield { type: "assistant" as const, content: "Scheduled response" };
+      });
+
+      const manager = new FleetManager({
+        configPath,
+        stateDir,
+        checkInterval: 50,
+        logger: createSilentLogger(),
+      });
+
+      const order: string[] = [];
+      let createdStatus: string | undefined;
+      manager.on("job:created", (payload) => {
+        order.push("job:created");
+        createdStatus ??= payload.job.status;
+      });
+      manager.on("job:output", () => order.push("job:output"));
+      manager.on("job:completed", () => order.push("job:completed"));
+
+      await manager.initialize();
+      await manager.start();
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      await manager.stop();
+
+      // Trim to the first job's lifecycle (interval may fire more than once).
+      const firstCreated = order.indexOf("job:created");
+      const firstCompleted = order.indexOf("job:completed");
+      expect(firstCreated).toBe(0);
+      expect(order).toContain("job:output");
+      expect(createdStatus).toBe("pending");
+      // created precedes the first output precedes the first completed
+      expect(order.indexOf("job:output")).toBeGreaterThan(firstCreated);
+      expect(order.indexOf("job:output")).toBeLessThan(firstCompleted);
+    });
+
     it("emits job:failed when execution fails", async () => {
       await createAgentConfig("failing-agent", {
         name: "failing-agent",

--- a/packages/core/src/fleet-manager/__tests__/trigger.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/trigger.test.ts
@@ -142,6 +142,85 @@ describe("Manual Agent Triggering (US-5)", () => {
       );
     });
 
+    it("emits job:created with 'pending' status at creation time (issue #328)", async () => {
+      await createAgentConfig("pending-agent", { name: "pending-agent" });
+      const configPath = await createConfig({
+        version: 1,
+        agents: [{ path: "./agents/pending-agent.yaml" }],
+      });
+
+      const manager = createTestManager(configPath);
+      await manager.initialize();
+
+      const jobCreatedHandler = vi.fn();
+      manager.on("job:created", jobCreatedHandler);
+
+      await manager.trigger("pending-agent");
+
+      // The record carried by job:created must reflect its state AT creation
+      // (pending), not the finalized (completed) status — proving the event is
+      // emitted up front rather than after execution resolves.
+      expect(jobCreatedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          job: expect.objectContaining({ status: "pending" }),
+        }),
+      );
+    });
+
+    it("emits job:created BEFORE job:output and job:completed on manual trigger (issue #328)", async () => {
+      await createAgentConfig("order-agent", { name: "order-agent" });
+      const configPath = await createConfig({
+        version: 1,
+        agents: [{ path: "./agents/order-agent.yaml" }],
+      });
+
+      const manager = createTestManager(configPath);
+      await manager.initialize();
+
+      const order: string[] = [];
+      manager.on("job:created", () => order.push("job:created"));
+      manager.on("job:output", () => order.push("job:output"));
+      manager.on("job:completed", () => order.push("job:completed"));
+
+      await manager.trigger("order-agent");
+
+      // Manual triggers previously emitted ZERO job:output and fired
+      // job:created only AFTER completion. Now: created → output → completed.
+      expect(order[0]).toBe("job:created");
+      expect(order).toContain("job:output");
+      expect(order.at(-1)).toBe("job:completed");
+      expect(order.indexOf("job:created")).toBeLessThan(order.indexOf("job:output"));
+      expect(order.indexOf("job:output")).toBeLessThan(order.indexOf("job:completed"));
+      // Exactly one job:created — the event was MOVED, not duplicated.
+      expect(order.filter((e) => e === "job:created")).toHaveLength(1);
+    });
+
+    it("emits job:output for streamed assistant messages on manual trigger (issue #328)", async () => {
+      await createAgentConfig("output-agent", { name: "output-agent" });
+      const configPath = await createConfig({
+        version: 1,
+        agents: [{ path: "./agents/output-agent.yaml" }],
+      });
+
+      const manager = createTestManager(configPath);
+      await manager.initialize();
+
+      const jobOutputHandler = vi.fn();
+      manager.on("job:output", jobOutputHandler);
+
+      const result = await manager.trigger("output-agent");
+
+      // The mocked SDK yields an assistant message with content "Test complete".
+      expect(jobOutputHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: result.jobId,
+          agentName: "output-agent",
+          output: "Test complete",
+          outputType: "assistant",
+        }),
+      );
+    });
+
     it("throws InvalidStateError before initialization", async () => {
       const configPath = await createConfig({
         version: 1,

--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -33,6 +33,7 @@ import {
   ScheduleNotFoundError,
   StreamingSessionUnsupportedError,
 } from "./errors.js";
+import { buildJobOutputPayload } from "./job-output-mapper.js";
 import type {
   AgentInfo,
   CancelJobResult,
@@ -206,10 +207,32 @@ export class JobControl {
           "manual") as import("../state/schemas/job-metadata.js").TriggerType,
         schedule: scheduleName,
         outputToFile: schedule?.outputToFile ?? false,
-        onMessage: options?.onMessage,
-        onJobCreated: (id) => {
+        onMessage: async (message) => {
+          // Stream job:output during execution (parity with the scheduled
+          // path). The manual trigger previously forwarded onMessage raw and
+          // never emitted job:output.
+          if (registeredJobId) {
+            const payload = buildJobOutputPayload(registeredJobId, agentName, message);
+            if (payload) {
+              emitter.emit("job:output", payload);
+            }
+          }
+          await options?.onMessage?.(message);
+        },
+        onJobCreated: (id, job) => {
           registeredJobId = id;
           this.runningControllers.set(id, abortController);
+
+          // Emit job:created at creation time (status `pending`), BEFORE any
+          // job:output streams and before completion. The record is passed
+          // in-hand so no disk read is needed and ordering is guaranteed.
+          emitter.emit("job:created", {
+            job,
+            agentName,
+            scheduleName: scheduleName ?? null,
+            timestamp,
+          });
+
           options?.onJobCreated?.(id);
         },
         resume: sessionId,
@@ -243,18 +266,12 @@ export class JobControl {
       };
     }
 
-    // Emit job:created event
+    // Read the finalized record for completion/failure events + hooks.
+    // (job:created is emitted up front in onJobCreated above.)
     const jobsDir = join(stateDir, "jobs");
     const jobMetadata = await getJob(jobsDir, result.jobId, { logger });
 
     if (jobMetadata) {
-      emitter.emit("job:created", {
-        job: jobMetadata,
-        agentName,
-        scheduleName: scheduleName ?? null,
-        timestamp,
-      });
-
       // Emit completion or failure event based on result
       if (result.success) {
         emitter.emit("job:completed", {

--- a/packages/core/src/fleet-manager/job-output-mapper.ts
+++ b/packages/core/src/fleet-manager/job-output-mapper.ts
@@ -1,0 +1,92 @@
+/**
+ * Job Output Mapper
+ *
+ * Shared translation of a runtime {@link SDKMessage} into a
+ * {@link JobOutputPayload} for the `job:output` fleet event. Both the scheduled
+ * execution path ({@link ScheduleExecutor}) and the manual trigger path
+ * ({@link JobControl.trigger}) stream output through this so the payloads they
+ * emit are identical.
+ *
+ * @module job-output-mapper
+ */
+
+import type { SDKMessage } from "../runner/index.js";
+import type { JobOutputPayload } from "./types.js";
+
+/**
+ * Map an SDK message type to the `job:output` output type discriminator.
+ */
+export function mapMessageTypeToOutputType(
+  messageType: string,
+): "stdout" | "stderr" | "assistant" | "tool" | "system" {
+  switch (messageType) {
+    case "assistant":
+      return "assistant";
+    case "tool_use":
+    case "tool_result":
+      return "tool";
+    case "system":
+      return "system";
+    case "error":
+      return "stderr";
+    default:
+      return "stdout";
+  }
+}
+
+/**
+ * Extract a human-readable content string from an SDK message, or `null` when
+ * the message carries no meaningful content to stream.
+ */
+export function extractMessageContent(message: SDKMessage): string | null {
+  // Handle different message types
+  if (message.content && typeof message.content === "string") {
+    return message.content;
+  }
+
+  if (message.message && typeof message.message === "string") {
+    return message.message;
+  }
+
+  // For tool_use messages, stringify the input
+  if (message.type === "tool_use" && message.name && message.input) {
+    return `Tool: ${message.name}\n${JSON.stringify(message.input, null, 2)}`;
+  }
+
+  // For tool_result messages
+  if (message.type === "tool_result" && message.content) {
+    return typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+  }
+
+  return null;
+}
+
+/**
+ * Build a {@link JobOutputPayload} from an SDK message.
+ *
+ * Returns `null` when the message has no meaningful content — callers should
+ * skip emitting `job:output` in that case.
+ *
+ * @param jobId - The id of the job producing the output
+ * @param agentName - The qualified name of the agent executing the job
+ * @param message - The SDK message to translate
+ * @returns A ready-to-emit payload, or `null` when there is nothing to emit
+ */
+export function buildJobOutputPayload(
+  jobId: string,
+  agentName: string,
+  message: SDKMessage,
+): JobOutputPayload | null {
+  const output = extractMessageContent(message);
+  if (!output) {
+    return null;
+  }
+
+  return {
+    jobId,
+    agentName,
+    output,
+    outputType: mapMessageTypeToOutputType(message.type),
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/packages/core/src/fleet-manager/schedule-executor.ts
+++ b/packages/core/src/fleet-manager/schedule-executor.ts
@@ -26,6 +26,7 @@ import {
   emitJobFailed as emitJobFailedFn,
   emitJobOutput as emitJobOutputFn,
 } from "./event-emitters.js";
+import { buildJobOutputPayload } from "./job-output-mapper.js";
 import type {
   JobCompletedPayload,
   JobCreatedPayload,
@@ -105,42 +106,38 @@ export class ScheduleExecutor {
         triggerType: "schedule",
         schedule: scheduleName,
         outputToFile: schedule.outputToFile ?? false,
-        onJobCreated: (id: string) => {
-          // Set jobId early so onMessage can emit events during execution
+        onJobCreated: (id: string, job: JobMetadata) => {
+          // Set jobId early so onMessage can emit events during execution.
           jobId = id;
           logger.debug(`Job ${id} created for ${agent.qualifiedName}/${scheduleName}`);
+
+          // Emit job:created at creation time (status `pending`), BEFORE any
+          // job:output streams. The record is passed in-hand so no disk read
+          // is needed and ordering is guaranteed.
+          this.emitJobCreated({
+            job,
+            agentName: agent.qualifiedName,
+            scheduleName,
+            timestamp: new Date().toISOString(),
+          });
         },
         onMessage: async (message: SDKMessage) => {
           // Emit job:output events for real-time streaming
           if (jobId) {
-            const outputType = this.mapMessageTypeToOutputType(message.type);
-            const outputContent = this.extractMessageContent(message);
-
-            if (outputContent) {
-              this.emitJobOutput({
-                jobId,
-                agentName: agent.qualifiedName,
-                output: outputContent,
-                outputType,
-                timestamp: new Date().toISOString(),
-              });
+            const payload = buildJobOutputPayload(jobId, agent.qualifiedName, message);
+            if (payload) {
+              this.emitJobOutput(payload);
             }
           }
         },
       });
 
-      // Emit job:created event now that we have the job info
+      // Read the finalized record for completion/failure events + hooks.
+      // (job:created is emitted up front in onJobCreated above.)
       const jobsDir = join(stateDir, "jobs");
       const jobMetadata = await getJob(jobsDir, result.jobId, { logger });
 
       if (jobMetadata) {
-        this.emitJobCreated({
-          job: jobMetadata,
-          agentName: agent.qualifiedName,
-          scheduleName,
-          timestamp: new Date().toISOString(),
-        });
-
         // Emit completion or failure event based on result
         if (result.success) {
           this.emitJobCompleted({
@@ -182,55 +179,6 @@ export class ScheduleExecutor {
       logger.error(`Error in ${agent.qualifiedName}/${scheduleName}: ${err.message}`);
       // Don't re-throw - we want to continue running the fleet even if a job fails
     }
-  }
-
-  /**
-   * Map SDK message type to job output type
-   */
-  private mapMessageTypeToOutputType(
-    messageType: string,
-  ): "stdout" | "stderr" | "assistant" | "tool" | "system" {
-    switch (messageType) {
-      case "assistant":
-        return "assistant";
-      case "tool_use":
-      case "tool_result":
-        return "tool";
-      case "system":
-        return "system";
-      case "error":
-        return "stderr";
-      default:
-        return "stdout";
-    }
-  }
-
-  /**
-   * Extract content string from SDK message
-   */
-  private extractMessageContent(message: SDKMessage): string | null {
-    // Handle different message types
-    if (message.content && typeof message.content === "string") {
-      return message.content;
-    }
-
-    if (message.message && typeof message.message === "string") {
-      return message.message;
-    }
-
-    // For tool_use messages, stringify the input
-    if (message.type === "tool_use" && message.name && message.input) {
-      return `Tool: ${message.name}\n${JSON.stringify(message.input, null, 2)}`;
-    }
-
-    // For tool_result messages
-    if (message.type === "tool_result" && message.content) {
-      return typeof message.content === "string"
-        ? message.content
-        : JSON.stringify(message.content);
-    }
-
-    return null;
   }
 
   // ===========================================================================

--- a/packages/core/src/runner/job-executor.ts
+++ b/packages/core/src/runner/job-executor.ts
@@ -172,9 +172,12 @@ export class JobExecutor {
 
       this.logger.info?.(`Created job ${job.id} for agent ${agent.name}`);
 
-      // Notify caller of job ID immediately (before execution starts)
+      // Notify caller of job ID immediately (before execution starts).
+      // Pass the freshly-created record (status `pending`) and await the
+      // callback so consumers can emit `job:created` up front — guaranteed to
+      // complete before any `onMessage`/`job:output` streams below.
       if (onJobCreated) {
-        onJobCreated(job.id);
+        await onJobCreated(job.id, job);
       }
     } catch (error) {
       this.logger.error(`Failed to create job: ${(error as Error).message}`);

--- a/packages/core/src/runner/types.ts
+++ b/packages/core/src/runner/types.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ResolvedAgent } from "../config/index.js";
-import type { JobOutputInput, TriggerType } from "../state/index.js";
+import type { JobMetadata, JobOutputInput, TriggerType } from "../state/index.js";
 
 // =============================================================================
 // Runner Options Types
@@ -95,8 +95,12 @@ export type MessageCallback = (message: SDKMessage) => void | Promise<void>;
 
 /**
  * Callback for when a job is created (before execution starts)
+ *
+ * Receives both the job id and the freshly-created {@link JobMetadata} record
+ * (status `pending`), so callers can emit a `job:created` event up front —
+ * before any output streams — without re-reading the record from disk.
  */
-export type JobCreatedCallback = (jobId: string) => void;
+export type JobCreatedCallback = (jobId: string, job: JobMetadata) => void | Promise<void>;
 
 /**
  * Extended options including callbacks


### PR DESCRIPTION
## Summary

Fixes #328 — two related defects in FleetManager job lifecycle events:

1. **`job:created` was emitted after job completion.** Both `trigger()` (`job-control.ts`) and `executeSchedule()` (`schedule-executor.ts`) emitted `job:created` only *after* `JobExecutor.execute()` resolved. On the scheduled path this meant `job:created` fired *after* the job's own `job:output` events and after completion.
2. **Manual `trigger()` never emitted `job:output`.** It forwarded the executor's `onMessage` straight to the caller and emitted zero `job:output` fleet events, so web/UI consumers streaming a manual trigger saw nothing.

## The change

- **`job:created` is now emitted up front**, from inside the executor's `onJobCreated` callback on both paths — at the moment the record is created with status `pending`, before any `job:output` and before completion. The callback now receives the freshly-created `JobMetadata` in-hand (no disk read, no race), and `JobExecutor` awaits it so it always precedes streaming.
- The **post-completion `job:created` emits were removed** on both paths, so the event is *moved*, not duplicated (verified: exactly one `job:created` per run).
- **Manual `trigger()` now streams `job:output`**, matching the scheduled path.
- The SDK-message → `JobOutputPayload` mapping (`mapMessageTypeToOutputType` / `extractMessageContent`) was **extracted into a shared `job-output-mapper.ts`** used by both paths, so payloads are identical.
- The aborted-manual-run early return is coherent: `job:created` (up front) → `job:cancelled` (via `cancelJob`), with no dangling `job:completed`/`job:failed`.

This restores the `created → output → completed` ordering and makes the documented contract in `event-emitters.ts` ("status will be 'pending' at `job:created`") accurate.

## ⚠️ Public event-contract change

This changes observable public event **ordering** and adds `job:output` on manual triggers — flagged for reviewer attention. Changeset: **`@herdctl/core` minor**.

## Consumer audit

Re-confirmed against source; **nothing depends on the old ordering**:
- Web `FleetBridge` → WS → client: `job:created` → `addJob` (hardcodes `status: "running"`, does not read `payload.job.status`); `job:output` → `appendOutput`; `job:completed` → `completeJob`. Independent store slices — earlier `job:created` just surfaces the job sooner; manual web triggers now stream output where they previously streamed none.
- Chat connectors (Slack/Discord/web-chat) stream via their own `onMessage`, don't subscribe to fleet `job:output`/`job:created` — unaffected.
- CLI `trigger` renders via its own `onMessage` — unaffected.

## Tests

- New tests (`fleet-manager/__tests__/trigger.test.ts`, `integration.test.ts`): `job:created` fires first with `pending` status, `created → output → completed` ordering on both manual and scheduled paths, manual `trigger()` now emits `job:output`, exactly one `job:created` (no duplicate).
- Full `@herdctl/core` suite: **3260 passed**, 1 pre-existing failure (`directory.test.ts` "parent directory is not writable" — root bypasses the chmod-based check; unrelated).
- `@herdctl/web` typecheck passes; `@herdctl/core` build + typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)