### PR TITLE
fix(core): cancel in-flight jobs on shutdown via shared AbortController registry

### DIFF
--- a/.changeset/shutdown-bulk-cancel-registry.md
+++ b/.changeset/shutdown-bulk-cancel-registry.md
@@ -1,0 +1,19 @@
+---
+"@herdctl/core": patch
+---
+
+fix(core): shutdown bulk-cancel now actually cancels in-flight jobs
+
+`FleetManager.stop({ cancelOnTimeout: true })` was a guaranteed no-op: on a
+shutdown timeout it read jobs from a `current_job` fleet-state field that nothing
+ever wrote, so no jobs were ever cancelled. Manual and scheduled jobs that stalled
+shutdown kept running.
+
+In-flight jobs are now tracked in a single shared AbortController registry that
+both manual triggers (`JobControl.trigger`) and scheduled jobs
+(`ScheduleExecutor`) register into. Shutdown bulk-cancel iterates that registry and
+genuinely aborts each live run (killing the CLI subprocess / aborting the SDK
+query). The registry is keyed by job id, so it is concurrency-safe under
+`instances.max_concurrent > 1`. This is an internal, non-breaking change.
+
+Refs edspencer/herdctl#324.

--- a/packages/core/src/fleet-manager/__tests__/integration.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/integration.test.ts
@@ -21,6 +21,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 
 // Import the mocked query function for test configuration
 import { query as mockQueryFn } from "@anthropic-ai/claude-agent-sdk";
+import { listJobs } from "../../state/index.js";
 import { AgentNotFoundError, InvalidStateError, ScheduleNotFoundError } from "../errors.js";
 import type {
   AgentStartedPayload,
@@ -73,6 +74,40 @@ describe("FleetManager Integration Tests (US-13)", () => {
       warn: vi.fn(),
       error: vi.fn(),
     };
+  }
+
+  // Poll a directory tree until its contents (file paths + sizes) stop changing
+  // across consecutive samples, i.e. all background writes have flushed. Used to
+  // avoid a teardown race where a still-draining background job writes into the
+  // temp state dir while afterEach recursively removes it (ENOTEMPTY).
+  async function waitForStateDirQuiescent(dir: string): Promise<void> {
+    const { readdir, stat } = await import("node:fs/promises");
+    const snapshot = async (): Promise<string> => {
+      const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+      const parts: string[] = [];
+      for (const e of entries) {
+        if (e.isFile()) {
+          const p = join(e.parentPath ?? e.path, e.name);
+          try {
+            parts.push(`${p}:${(await stat(p)).size}`);
+          } catch {
+            // File vanished between readdir and stat — treat as changing.
+            parts.push(`${p}:gone`);
+          }
+        }
+      }
+      return parts.sort().join("|");
+    };
+    let prev = await snapshot();
+    await vi.waitFor(
+      async () => {
+        const next = await snapshot();
+        const stable = next === prev;
+        prev = next;
+        expect(stable).toBe(true);
+      },
+      { timeout: 3000, interval: 60 },
+    );
   }
 
   // Create a test manager with common options
@@ -1379,6 +1414,98 @@ describe("FleetManager Integration Tests (US-13)", () => {
         });
 
         expect(manager.state.status).toBe("stopped");
+      });
+
+      it("aborts an in-flight SCHEDULED job at shutdown via the shared registry", async () => {
+        // Regression test for edspencer/herdctl#324: a scheduled job that is
+        // genuinely in-flight when the fleet shuts down must be aborted. Before
+        // the fix, scheduled jobs were registered in no cancellation registry, so
+        // cancelRunningJobs() read a never-written `current_job` field and was a
+        // guaranteed no-op — the agent process kept running.
+        await createAgentConfig("shutdown-sched-agent", {
+          name: "shutdown-sched-agent",
+          schedules: {
+            frequent: {
+              type: "interval",
+              interval: "100ms",
+              prompt: "long running scheduled task",
+            },
+          },
+        });
+
+        const configPath = await createConfig({
+          version: 1,
+          agents: [{ path: "./agents/shutdown-sched-agent.yaml" }],
+        });
+
+        // Mock the SDK to block mid-turn until the run's AbortController fires.
+        // If shutdown bulk-cancel reaches this scheduled job, `sawAbort` flips.
+        let sawAbort = false;
+        (mockQueryFn as Mock).mockImplementation(
+          ({ options }: { options?: { abortController?: AbortController } }) =>
+            (async function* () {
+              yield { type: "system", subtype: "init", session_id: "sched-cancel-session" };
+              const signal = options?.abortController?.signal;
+              await new Promise<void>((resolve) => {
+                if (!signal || signal.aborted) return resolve();
+                signal.addEventListener("abort", () => {
+                  sawAbort = true;
+                  resolve();
+                });
+              });
+            })(),
+        );
+
+        const manager = new FleetManager({
+          configPath,
+          stateDir,
+          checkInterval: 50,
+          logger: createSilentLogger(),
+        });
+
+        let triggered = false;
+        manager.on("schedule:triggered", () => {
+          triggered = true;
+        });
+
+        await manager.initialize();
+        await manager.start();
+
+        // Wait until the schedule has fired and its job is genuinely in-flight
+        // (a running job record exists on disk).
+        const jobsDir = join(stateDir, "jobs");
+        await vi.waitFor(
+          async () => {
+            expect(triggered).toBe(true);
+            const { jobs } = await listJobs(jobsDir);
+            expect(jobs.some((j) => j.status === "running")).toBe(true);
+          },
+          { timeout: 2000, interval: 20 },
+        );
+
+        // Stop: scheduler.stop() times out waiting for the blocked job →
+        // SchedulerShutdownError → cancelRunningJobs() must now actually abort it.
+        await manager.stop({
+          timeout: 100,
+          cancelOnTimeout: true,
+          cancelTimeout: 500,
+        });
+
+        // The scheduled job's AbortController fired — the fix worked.
+        expect(sawAbort).toBe(true);
+        expect(manager.state.status).toBe("stopped");
+
+        // And the job is persisted as cancelled, not left running.
+        const { jobs } = await listJobs(jobsDir);
+        const cancelled = jobs.find((j) => j.status === "cancelled");
+        expect(cancelled).toBeDefined();
+        expect(cancelled?.exit_reason).toBe("cancelled");
+
+        // Wait for the aborted run's background scheduler promise to fully drain
+        // (it writes final job + schedule-state files after abort) so those writes
+        // flush before afterEach removes the temp dir — otherwise the recursive
+        // rmdir races concurrent writes and throws ENOTEMPTY.
+        await waitForStateDirQuiescent(stateDir);
       });
     });
 

--- a/packages/core/src/fleet-manager/context.ts
+++ b/packages/core/src/fleet-manager/context.ts
@@ -62,6 +62,42 @@ export interface FleetManagerContext {
   getSessionLifecycle?(): SessionLifecycleManager | null;
 
   /**
+   * Register a running job's AbortController under its job id.
+   *
+   * This is the single, shared in-memory registry of in-flight jobs. BOTH manual
+   * (`JobControl.trigger`) and scheduled (`ScheduleExecutor`) jobs register here
+   * the moment their id is known, and unregister when the run finishes. Shutdown's
+   * bulk-cancel and {@link cancelJob} consult it to actually interrupt a live run
+   * (kill the CLI subprocess / abort the SDK query) rather than only rewriting a
+   * status file. Scheduled jobs used to be absent from any registry, so shutdown
+   * bulk-cancel silently cancelled nothing (edspencer/herdctl#324).
+   *
+   * Optional (like the other lifecycle accessors) so lightweight mock contexts —
+   * e.g. those the chat-manager unit tests build — need not implement it; the
+   * real {@link FleetManager} always does, so job cancellation is fully wired in
+   * production.
+   */
+  registerJob?(jobId: string, controller: AbortController): void;
+
+  /**
+   * Remove a job from the running-job registry. Called when a run finishes
+   * (completed, failed, or cancelled).
+   */
+  unregisterJob?(jobId: string): void;
+
+  /**
+   * Look up the AbortController for a running job, or `undefined` if this process
+   * is not executing it (e.g. a job owned by another process).
+   */
+  getJobController?(jobId: string): AbortController | undefined;
+
+  /**
+   * Snapshot the ids of every job currently running in this process. Keyed by job
+   * id, so it is concurrency-safe when `instances.max_concurrent > 1`.
+   */
+  getRunningJobIds?(): string[];
+
+  /**
    * Get the current fleet manager status
    */
   getStatus(): FleetManagerStatus;

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -133,6 +133,13 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   // Key is platform name (e.g., "discord", "slack")
   private chatManagers: Map<string, IChatManager> = new Map();
 
+  // In-memory registry of currently-running jobs → their AbortController, keyed
+  // by job id. Shared across JobControl (manual triggers) and ScheduleExecutor
+  // (scheduled jobs) so shutdown's bulk-cancel can interrupt BOTH kinds of
+  // in-flight job. Keyed by id → concurrency-safe when max_concurrent > 1.
+  // See edspencer/herdctl#324.
+  private readonly runningJobControllers: Map<string, AbortController> = new Map();
+
   constructor(options: FleetManagerOptions) {
     super();
     this.configPath = options.configPath;
@@ -166,6 +173,18 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   }
   getSessionLifecycle(): SessionLifecycleManager | null {
     return this.sessionLifecycle;
+  }
+  registerJob(jobId: string, controller: AbortController): void {
+    this.runningJobControllers.set(jobId, controller);
+  }
+  unregisterJob(jobId: string): void {
+    this.runningJobControllers.delete(jobId);
+  }
+  getJobController(jobId: string): AbortController | undefined {
+    return this.runningJobControllers.get(jobId);
+  }
+  getRunningJobIds(): string[] {
+    return Array.from(this.runningJobControllers.keys());
   }
   getStatus(): FleetManagerStatus {
     return this.status;
@@ -899,7 +918,7 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
       },
       (name) => this.statusQueries.getAgentInfoByName(name),
     );
-    this.jobControl = new JobControl(this, () => this.statusQueries.getAgentInfo());
+    this.jobControl = new JobControl(this);
     this.logStreaming = new LogStreaming(this);
     this.scheduleExecutor = new ScheduleExecutor(this);
 

--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -35,7 +35,6 @@ import {
 } from "./errors.js";
 import { buildJobOutputPayload } from "./job-output-mapper.js";
 import type {
-  AgentInfo,
   CancelJobResult,
   ChatSessionOptions,
   ForkJobResult,
@@ -55,19 +54,7 @@ import type {
  * using the FleetManagerContext pattern.
  */
 export class JobControl {
-  /**
-   * In-memory registry of currently-running jobs to their AbortController, keyed
-   * by job id. A job is registered the moment its id is known (via the executor's
-   * `onJobCreated`) and removed when the run finishes. {@link cancelJob} consults
-   * this to actually interrupt a live run — without it, cancelling only rewrote
-   * the job's status file while the agent process kept running.
-   */
-  private readonly runningControllers = new Map<string, AbortController>();
-
-  constructor(
-    private ctx: FleetManagerContext,
-    private getAgentInfoFn: () => Promise<AgentInfo[]>,
-  ) {}
+  constructor(private ctx: FleetManagerContext) {}
 
   /**
    * Manually trigger an agent outside its normal schedule
@@ -221,7 +208,9 @@ export class JobControl {
         },
         onJobCreated: (id, job) => {
           registeredJobId = id;
-          this.runningControllers.set(id, abortController);
+          // Register in the shared running-job registry so shutdown bulk-cancel
+          // can interrupt this in-flight job (edspencer/herdctl#324).
+          this.ctx.registerJob?.(id, abortController);
 
           // Emit job:created at creation time (status `pending`), BEFORE any
           // job:output streams and before completion. The record is passed
@@ -244,7 +233,7 @@ export class JobControl {
       });
     } finally {
       if (registeredJobId) {
-        this.runningControllers.delete(registeredJobId);
+        this.ctx.unregisterJob?.(registeredJobId);
       }
     }
 
@@ -508,11 +497,11 @@ export class JobControl {
     // its status file rewritten while it keeps running). Jobs owned by another
     // process won't be in the registry; those fall back to the status-file update
     // below (best-effort, unchanged behavior).
-    const controller = this.runningControllers.get(jobId);
+    const controller = this.ctx.getJobController?.(jobId);
     if (controller) {
       logger.info(`Aborting in-flight job ${jobId}`);
       controller.abort();
-      this.runningControllers.delete(jobId);
+      this.ctx.unregisterJob?.(jobId);
     }
 
     const timestamp = new Date().toISOString();
@@ -687,20 +676,21 @@ export class JobControl {
   /**
    * Cancel all running jobs during shutdown
    *
+   * Sources the set of in-flight jobs from the shared running-job registry (see
+   * {@link FleetManagerContext.registerJob}). BOTH manual and scheduled jobs
+   * register there, so this now actually cancels the scheduled jobs that stall
+   * shutdown — previously it read a `current_job` state field that nothing ever
+   * wrote, so it was a guaranteed no-op (edspencer/herdctl#324). The registry is
+   * keyed by job id, so this is concurrency-safe under `max_concurrent > 1`.
+   *
    * @param cancelTimeout - Timeout for each job cancellation
    */
   async cancelRunningJobs(cancelTimeout: number): Promise<void> {
     const logger = this.ctx.getLogger();
 
-    // Get all running jobs from the fleet status
-    const agentInfoList = await this.getAgentInfoFn();
-
-    const runningJobIds: string[] = [];
-    for (const agent of agentInfoList) {
-      if (agent.currentJobId) {
-        runningJobIds.push(agent.currentJobId);
-      }
-    }
+    // Snapshot the ids of every job running in this process from the shared
+    // registry. Snapshot up front because cancelJob() mutates the registry.
+    const runningJobIds = this.ctx.getRunningJobIds?.() ?? [];
 
     if (runningJobIds.length === 0) {
       logger.debug("No running jobs to cancel");

--- a/packages/core/src/fleet-manager/schedule-executor.ts
+++ b/packages/core/src/fleet-manager/schedule-executor.ts
@@ -98,39 +98,69 @@ export class ScheduleExecutor {
       // Track job ID for streaming - set via onJobCreated callback before execution starts
       let jobId: string | undefined;
 
-      // Execute the job with streaming output
-      const result = await executor.execute({
-        agent,
-        prompt,
-        stateDir,
-        triggerType: "schedule",
-        schedule: scheduleName,
-        outputToFile: schedule.outputToFile ?? false,
-        onJobCreated: (id: string, job: JobMetadata) => {
-          // Set jobId early so onMessage can emit events during execution.
-          jobId = id;
-          logger.debug(`Job ${id} created for ${agent.qualifiedName}/${scheduleName}`);
+      // Cancellation support: give the scheduled run an AbortController and
+      // register it in the shared running-job registry under its job id (known
+      // via onJobCreated). This is what lets shutdown's bulk-cancel actually
+      // interrupt an in-flight scheduled job — before edspencer/herdctl#324,
+      // scheduled jobs registered nowhere, so shutdown's bulk-cancel cancelled
+      // nothing. Unregistered in the finally below. Mirrors JobControl.trigger().
+      const abortController = new AbortController();
+      let registeredJobId: string | undefined;
 
-          // Emit job:created at creation time (status `pending`), BEFORE any
-          // job:output streams. The record is passed in-hand so no disk read
-          // is needed and ordering is guaranteed.
-          this.emitJobCreated({
-            job,
-            agentName: agent.qualifiedName,
-            scheduleName,
-            timestamp: new Date().toISOString(),
-          });
-        },
-        onMessage: async (message: SDKMessage) => {
-          // Emit job:output events for real-time streaming
-          if (jobId) {
-            const payload = buildJobOutputPayload(jobId, agent.qualifiedName, message);
-            if (payload) {
-              this.emitJobOutput(payload);
+      // Execute the job with streaming output
+      let result: Awaited<ReturnType<typeof executor.execute>>;
+      try {
+        result = await executor.execute({
+          agent,
+          prompt,
+          stateDir,
+          triggerType: "schedule",
+          schedule: scheduleName,
+          outputToFile: schedule.outputToFile ?? false,
+          onJobCreated: (id: string, job: JobMetadata) => {
+            // Set jobId early so onMessage can emit events during execution.
+            jobId = id;
+            registeredJobId = id;
+            // Register in the shared running-job registry so shutdown bulk-cancel
+            // can interrupt this in-flight scheduled job (edspencer/herdctl#324).
+            this.ctx.registerJob?.(id, abortController);
+            logger.debug(`Job ${id} created for ${agent.qualifiedName}/${scheduleName}`);
+
+            // Emit job:created at creation time (status `pending`), BEFORE any
+            // job:output streams. The record is passed in-hand so no disk read
+            // is needed and ordering is guaranteed (edspencer/herdctl#328).
+            this.emitJobCreated({
+              job,
+              agentName: agent.qualifiedName,
+              scheduleName,
+              timestamp: new Date().toISOString(),
+            });
+          },
+          onMessage: async (message: SDKMessage) => {
+            // Emit job:output events for real-time streaming
+            if (jobId) {
+              const payload = buildJobOutputPayload(jobId, agent.qualifiedName, message);
+              if (payload) {
+                this.emitJobOutput(payload);
+              }
             }
-          }
-        },
-      });
+          },
+          abortController,
+        });
+      } finally {
+        if (registeredJobId) {
+          this.ctx.unregisterJob?.(registeredJobId);
+        }
+      }
+
+      // If the run was cancelled mid-flight (e.g. shutdown bulk-cancel),
+      // cancelJob() has already recorded the cancellation and emitted
+      // job:cancelled — don't also emit job:created/completed/failed for the
+      // aborted run. Mirrors JobControl.trigger().
+      if (abortController.signal.aborted) {
+        logger.info(`Scheduled job ${result.jobId} was cancelled`);
+        return;
+      }
 
       // Read the finalized record for completion/failure events + hooks.
       // (job:created is emitted up front in onJobCreated above.)


### PR DESCRIPTION
## Summary

Fixes the shutdown bulk-cancel no-op reported in #324. `FleetManager.stop({ cancelOnTimeout: true })` (the path the CLI `stop` command uses) was a **guaranteed no-op**: on a scheduler shutdown timeout, `cancelRunningJobs()` collected running jobs from the `current_job` fleet-state field — but **no production code path ever writes `current_job`/`last_job`** (`updateAgentState()` has zero prod callers). So the set of "running jobs" was always empty, it logged `No running jobs to cancel`, and the agents kept running.

## Why the issue's suggested fix was incomplete

The issue suggested re-sourcing bulk-cancel from the in-memory AbortController registry in `JobControl` (`runningControllers`). But that registry **only tracked manual `trigger()` jobs** — `ScheduleExecutor.executeSchedule` called `JobExecutor.execute(...)` **without** an `abortController`, so scheduled jobs registered nowhere. Scheduled jobs are exactly the ones that stall shutdown, so a registry-only fix would *still* have cancelled nothing in the real scenario.

## Approach

Move the registry to a **single shared** one, hung off `FleetManagerContext` and implemented by `FleetManager`:

- New (optional) context accessors: `registerJob` / `unregisterJob` / `getJobController` / `getRunningJobIds`, backed by one `Map<jobId, AbortController>` on `FleetManager`. Optional to match the existing lifecycle-accessor convention so the lightweight mock contexts in the chat-manager unit tests need no changes; the real `FleetManager` always implements them.
- `JobControl.trigger` / `cancelJob` repointed at the shared registry (removing the dead `getAgentInfoFn` dependency).
- `ScheduleExecutor.executeSchedule` now creates an `AbortController`, registers it in `onJobCreated`, passes it into `executor.execute(...)`, unregisters in a `finally`, and skips the completed/failed emit on abort (mirroring `trigger()`'s cancellation handling).
- `cancelRunningJobs()` now iterates `getRunningJobIds()` and calls `cancelJob(jobId, { timeout })` per entry. Keyed by job id → concurrency-safe under `instances.max_concurrent > 1`.

## Deferred (out of scope — needs a design decision)

This PR fixes the **cancel** no-op but intentionally **leaves the `current_job`/`last_job` observability fields unwritten**. A single scalar `current_job` cannot represent concurrent jobs (`max_concurrent > 1`); whether to model it as an array vs. most-recent is an open schema question. Hence `Refs #324`, not `Fixes` — this only partially resolves the issue.

## Also noted (not fixed here)

Separate latent bug in the same shutdown path: `persistShutdownState` (`fleet-manager.ts`) writes `fleet.stoppedAt`, but `FleetMetadataSchema` only defines `started_at`, so Zod silently strips it. Flagging only — left for a separate change.

## Tests

- New regression test in `integration.test.ts`: a **scheduled** job genuinely in-flight at shutdown is now aborted via the registry (asserts the job's `AbortController` fired and the job is persisted `cancelled`). Verified it **fails without the fix** (scheduled-job registration disabled → `sawAbort` stays false).
- The existing "interrupts an in-flight job" `trigger()` test continues to pass through the moved registry.
- Full `@herdctl/core` suite: 3257 passed, 1 pre-existing failure only (`state/__tests__/directory.test.ts` "parent directory not writable" — a root-only chmod test, confirmed failing identically on clean `origin/main`). `discord`/`slack` suites green; core + dependents typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shutdown cancellation now reliably stops in-progress manual and scheduled jobs when `cancelOnTimeout` is enabled.
  * Cancelled jobs now terminate active CLI processes and SDK requests, and are correctly recorded as cancelled.
  * Scheduled job completion and failure events are no longer emitted after a run has been cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->