### PR TITLE
perf(state): negative-cache resolveAutoName/resolvePreview (#350)

### DIFF
--- a/.changeset/autoname-negative-cache.md
+++ b/.changeset/autoname-negative-cache.md
@@ -1,0 +1,20 @@
+---
+"@herdctl/core": patch
+---
+
+perf(state): negative-cache resolveAutoName/resolvePreview so warm listings skip transcript re-scans
+
+`SessionDiscoveryService.resolveAutoName` (and `resolvePreview`) only wrote to the
+mtime-keyed metadata cache when a value was *found*. A transcript with no
+`type:"summary"` entry cached nothing, so the next `getAgentSessions` re-scanned it
+from scratch via `extractLastSummary` — a full O(filesize) stream of a multi-MB
+file. CLI keeper sessions essentially never carry a summary, so the autoName cache
+was 0%-effective (measured 0/298 sessions cached) and a fully-warm project switch
+still spent ~580ms re-streaming every attributed transcript.
+
+Both resolvers now record the mtime even for an empty result (mirroring
+`resolveSidechain`), so a validated *negative* result is remembered and unchanged
+sessions are never re-scanned. Warm project-switch enrichment drops from ~580ms to
+tens of ms. `autoName`/`preview` may now be absent while `autoNameMtime`/
+`previewMtime` are set — presence of the mtime, not the value, is what makes the
+cache authoritative.

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -1711,7 +1711,7 @@ describe("SessionDiscoveryService", () => {
       );
     });
 
-    it("returns undefined autoName when session has no summary", async () => {
+    it("negative-caches (records mtime) when session has no summary", async () => {
       const workingDir = "/Users/ed/Code/myproject";
       const encodedPath = "-Users-ed-Code-myproject";
       const projectDir = join(tempClaudeHome, "projects", encodedPath);
@@ -1730,7 +1730,41 @@ describe("SessionDiscoveryService", () => {
       const sessions = await service.getAgentSessions("my-agent", workingDir, false);
 
       expect(sessions[0].autoName).toBeUndefined();
-      // Should not batch write when there's nothing to write
+      // The empty result must still be persisted (autoName undefined but a fresh
+      // autoNameMtime) so the next listing trusts the cache instead of
+      // re-streaming the whole transcript via extractLastSummary (issue #350).
+      expect(mockBatchSetAutoNames).toHaveBeenCalledTimes(1);
+      expect(mockBatchSetAutoNames).toHaveBeenCalledWith(
+        "my-agent",
+        expect.arrayContaining([
+          expect.objectContaining({ sessionId: "session-abc", autoName: undefined }),
+        ]),
+      );
+    });
+
+    it("skips extractLastSummary on a valid negative cache (autoNameMtime set, no autoName)", async () => {
+      const workingDir = "/Users/ed/Code/myproject";
+      const encodedPath = "-Users-ed-Code-myproject";
+      const projectDir = join(tempClaudeHome, "projects", encodedPath);
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "session-abc");
+
+      // A previously-recorded negative result: fresh mtime, no autoName value.
+      mockGetAutoName.mockResolvedValue({
+        autoName: undefined,
+        autoNameMtime: "2099-01-01T00:00:00.000Z",
+      });
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+
+      expect(sessions[0].autoName).toBeUndefined();
+      // Negative cache is authoritative — no transcript re-scan, no re-write.
+      expect(mockExtractLastSummary).not.toHaveBeenCalled();
       expect(mockBatchSetAutoNames).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -392,11 +392,13 @@ export class SessionDiscoveryService {
       : getCliSessionFile(workingDirectory, sessionId);
     const summary = await extractLastSummary(filePath);
 
-    if (summary) {
-      return { autoName: summary, needsUpdate: true };
-    }
-
-    return { autoName: undefined, needsUpdate: false };
+    // Always signal an update so the (possibly empty) result is negative-cached:
+    // record `autoNameMtime` even when no summary was found. CLI keeper sessions
+    // essentially never produce a `type:"summary"` entry, so without this the
+    // cache would be 0%-effective and `extractLastSummary` would re-stream the
+    // whole transcript on every listing. Mirrors `resolveSidechain`, which
+    // already records the mtime for negative results.
+    return { autoName: summary || undefined, needsUpdate: true };
   }
 
   /**
@@ -429,11 +431,11 @@ export class SessionDiscoveryService {
       : getCliSessionFile(workingDirectory, sessionId);
     const preview = await extractFirstMessagePreview(filePath);
 
-    if (preview) {
-      return { preview, needsUpdate: true };
-    }
-
-    return { preview: undefined, needsUpdate: false };
+    // Always signal an update so the (possibly empty) result is negative-cached:
+    // record `previewMtime` even when no preview was found. A transcript with no
+    // plain-text user line otherwise streams end-to-end on every listing looking
+    // for one. Mirrors `resolveSidechain`/`resolveAutoName`.
+    return { preview: preview || undefined, needsUpdate: true };
   }
 
   /**
@@ -594,18 +596,19 @@ export class SessionDiscoveryService {
         return {
           session,
           sidechainUpdate,
-          autoNameUpdate:
-            needsUpdate && autoName ? { sessionId, autoName, mtime: mtimeStr } : undefined,
-          previewUpdate:
-            previewNeedsUpdate && preview ? { sessionId, preview, mtime: mtimeStr } : undefined,
+          // Record the update even when the value is empty so the negative result
+          // (no summary / no preview) is cached against this mtime — see
+          // resolveAutoName/resolvePreview.
+          autoNameUpdate: needsUpdate ? { sessionId, autoName, mtime: mtimeStr } : undefined,
+          previewUpdate: previewNeedsUpdate ? { sessionId, preview, mtime: mtimeStr } : undefined,
         };
       },
     );
 
     // Reduce the (order-preserving) results into the session list + cache updates.
     const sessions: DiscoveredSession[] = [];
-    const autoNameUpdates: Array<{ sessionId: string; autoName: string; mtime: string }> = [];
-    const previewUpdates: Array<{ sessionId: string; preview: string; mtime: string }> = [];
+    const autoNameUpdates: Array<{ sessionId: string; autoName?: string; mtime: string }> = [];
+    const previewUpdates: Array<{ sessionId: string; preview?: string; mtime: string }> = [];
     const sidechainUpdates: Array<{ sessionId: string; isSidechain: boolean; mtime: string }> = [];
     for (const result of enriched) {
       // A refreshed sidechain flag is recorded even for excluded sessions.
@@ -864,8 +867,8 @@ export class SessionDiscoveryService {
 
     for (const dir of directories) {
       const sessions: DiscoveredSession[] = [];
-      const autoNameUpdates: Array<{ sessionId: string; autoName: string; mtime: string }> = [];
-      const previewUpdates: Array<{ sessionId: string; preview: string; mtime: string }> = [];
+      const autoNameUpdates: Array<{ sessionId: string; autoName?: string; mtime: string }> = [];
+      const previewUpdates: Array<{ sessionId: string; preview?: string; mtime: string }> = [];
       const sidechainUpdates: Array<{ sessionId: string; isSidechain: boolean; mtime: string }> =
         [];
       let visibleSessionCount = 0;
@@ -937,7 +940,9 @@ export class SessionDiscoveryService {
           dir.dockerEnabled,
         );
 
-        if (needsUpdate && autoName) {
+        // Record even an empty result so the negative case is cached (see
+        // resolveAutoName). autoName may be undefined here.
+        if (needsUpdate) {
           autoNameUpdates.push({ sessionId, autoName, mtime: mtimeStr });
         }
 
@@ -950,7 +955,7 @@ export class SessionDiscoveryService {
           dir.dockerEnabled,
         );
 
-        if (previewNeedsUpdate && preview) {
+        if (previewNeedsUpdate) {
           previewUpdates.push({ sessionId, preview, mtime: mtimeStr });
         }
 

--- a/packages/core/src/state/session-metadata.ts
+++ b/packages/core/src/state/session-metadata.ts
@@ -24,11 +24,20 @@ const logger = createLogger("SessionMetadataStore");
  */
 export const SessionMetadataEntrySchema = z.object({
   customName: z.string().optional(),
-  /** Auto-generated session name (extracted from JSONL summary) */
+  /**
+   * Auto-generated session name (extracted from JSONL summary). May be absent
+   * while {@link autoNameMtime} is set — that records a validated *negative*
+   * result (the transcript carried no summary at that mtime) so discovery can
+   * skip re-streaming it. Presence of `autoNameMtime`, not of `autoName`, is
+   * what makes the cache authoritative.
+   */
   autoName: z.string().optional(),
   /** ISO 8601 timestamp of when autoName was extracted (for cache invalidation) */
   autoNameMtime: z.string().optional(),
-  /** First user message preview (truncated to 100 chars) */
+  /**
+   * First user message preview (truncated to 100 chars). Like {@link autoName},
+   * may be absent while {@link previewMtime} is set (negative-cached).
+   */
   preview: z.string().optional(),
   /** ISO 8601 timestamp of when preview was extracted (for cache invalidation) */
   previewMtime: z.string().optional(),
@@ -357,7 +366,7 @@ export class SessionMetadataStore {
    */
   async batchSetAutoNames(
     agentName: string,
-    entries: Array<{ sessionId: string; autoName: string; mtime: string }>,
+    entries: Array<{ sessionId: string; autoName?: string; mtime: string }>,
   ): Promise<void> {
     if (entries.length === 0) {
       return;
@@ -369,7 +378,9 @@ export class SessionMetadataStore {
       metadata = this.createEmptyMetadata(agentName);
     }
 
-    // Apply all updates
+    // Apply all updates. `autoName` may be undefined — that records a validated
+    // *negative* result (this transcript has no summary at this mtime) so the
+    // next listing trusts the cache instead of re-streaming the whole file.
     for (const { sessionId, autoName, mtime } of entries) {
       const sessionEntry = metadata.sessions[sessionId] ?? {};
       metadata.sessions[sessionId] = {
@@ -460,7 +471,7 @@ export class SessionMetadataStore {
    */
   async batchSetPreviews(
     agentName: string,
-    entries: Array<{ sessionId: string; preview: string; mtime: string }>,
+    entries: Array<{ sessionId: string; preview?: string; mtime: string }>,
   ): Promise<void> {
     if (entries.length === 0) {
       return;
@@ -472,6 +483,8 @@ export class SessionMetadataStore {
       metadata = this.createEmptyMetadata(agentName);
     }
 
+    // `preview` may be undefined — records a validated negative result (no
+    // plain-text user line at this mtime) so the next listing trusts the cache.
     for (const { sessionId, preview, mtime } of entries) {
       const sessionEntry = metadata.sessions[sessionId] ?? {};
       metadata.sessions[sessionId] = {


### PR DESCRIPTION
Closes #350.

## Problem

`SessionDiscoveryService.resolveAutoName` (and `resolvePreview`) only wrote to the mtime-keyed metadata cache when a value was **found**. A transcript with no `type:"summary"` entry cached nothing, so the next `getAgentSessions` re-scanned it from scratch via `extractLastSummary` — a full O(filesize) stream of a multi-MB file.

CLI keeper sessions essentially never carry a summary, so the autoName cache was **0%-effective** (measured 0/298 sessions cached) and a fully-warm project switch still spent **~580ms** re-streaming every attributed transcript. `resolveSidechain` already did the right thing (always records the mtime); autoName/preview were the outliers.

## Fix

Record the mtime even for an **empty** result, mirroring `resolveSidechain`:

- `resolveAutoName`/`resolvePreview` now always return `needsUpdate: true` on a real read, so the (possibly empty) result is persisted against the current mtime.
- The batch-update collection sites record the entry even when the value is undefined.
- `batchSetAutoNames`/`batchSetPreviews` accept an optional value and always write the `*Mtime`.
- `autoName`/`preview` may now be absent while `autoNameMtime`/`previewMtime` is set — presence of the **mtime**, not the value, is what makes the cache authoritative. Schema comments updated to document this.

## Impact

Warm project-switch enrichment: **~580ms → tens of ms** (no transcript re-scans for unchanged sessions). This is the largest remaining project-switch cost after 5.19.0 and the smallest fix.

## Tests

- Updated the "no summary" test to assert the negative result is now persisted (fresh `autoNameMtime`, `autoName: undefined`).
- Added a test that a valid negative cache (mtime set, no value) skips `extractLastSummary` and does not re-write.
- Full `session-discovery` + `session-metadata` suites pass (124 tests).

Follow-up to the 5.19.0 perf work (#320/#321/#330). Patch — internal caching only, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session listing performance by caching sessions without auto-generated names or preview text.
  * Warm project switches and repeated session listings now avoid unnecessary transcript rescans.
  * Session metadata remains accurate when summaries or previews are unavailable.

* **Tests**
  * Added coverage for negative caching and verified that cached missing values prevent repeated transcript extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->