### PR TITLE
perf(state): mtime-cache parseSessionMessages (#351)

### DIFF
--- a/.changeset/message-cache.md
+++ b/.changeset/message-cache.md
@@ -1,0 +1,18 @@
+---
+"@herdctl/core": patch
+---
+
+perf(state): mtime-cache parsed transcript messages so repeat chat opens skip a full re-parse
+
+`SessionDiscoveryService.getSessionMessages` delegated straight to
+`parseSessionMessages` with no memo, so opening/refreshing a chat re-parsed the
+entire JSONL every time — measured ~114ms of synchronous `JSON.parse`-per-line for
+an ~8MB / 500K-token / 1107-message transcript, recomputed on every open and
+stalling the event loop on the constrained host. Its siblings `getSessionUsage`
+and `getSessionMetadata` were already mtime-cached; messages were the outlier.
+
+Added a small mtime-keyed, LRU-bounded in-memory cache (keyed on the transcript
+file path + its current mtime). A transcript is immutable except when a new turn
+appends (which bumps mtime), so an exact-mtime match serves the parsed array with
+no re-parse; a bumped mtime invalidates the entry. Repeat opens of an unchanged
+chat drop from ~114ms to ~0.

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -912,6 +912,65 @@ describe("SessionDiscoveryService", () => {
       expect(result).toEqual(mockMessages);
       expect(mockParseSessionMessages).toHaveBeenCalled();
     });
+
+    it("serves a repeat open from the mtime cache without re-parsing", async () => {
+      // Use a docker session so the transcript lives under the (controllable)
+      // state dir and stat() actually succeeds — the cache keys on the file mtime.
+      mockParseSessionMessages.mockClear();
+      const dockerSessionsDir = join(tempStateDir, "docker-sessions");
+      await mkdir(dockerSessionsDir, { recursive: true });
+      await createSessionFile(dockerSessionsDir, "session-abc");
+
+      const mockMessages = [
+        { role: "user" as const, content: "Hello", timestamp: "2024-01-15T10:00:00Z" },
+      ];
+      mockParseSessionMessages.mockResolvedValue(mockMessages);
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      const first = await service.getSessionMessages("/opt/workspace", "session-abc", {
+        dockerEnabled: true,
+      });
+      const second = await service.getSessionMessages("/opt/workspace", "session-abc", {
+        dockerEnabled: true,
+      });
+
+      expect(first).toEqual(mockMessages);
+      expect(second).toEqual(mockMessages);
+      // Second open is a cache hit — no second parse of the whole transcript.
+      expect(mockParseSessionMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-parses when the transcript mtime advances (new turn appended)", async () => {
+      mockParseSessionMessages.mockClear();
+      const dockerSessionsDir = join(tempStateDir, "docker-sessions");
+      await mkdir(dockerSessionsDir, { recursive: true });
+      const filePath = join(dockerSessionsDir, "session-abc.jsonl");
+      await createSessionFile(dockerSessionsDir, "session-abc");
+
+      mockParseSessionMessages.mockResolvedValue([
+        { role: "user" as const, content: "Hello", timestamp: "2024-01-15T10:00:00Z" },
+      ]);
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      await service.getSessionMessages("/opt/workspace", "session-abc", { dockerEnabled: true });
+
+      // Advance the file mtime to simulate a new turn being appended.
+      const later = new Date(Date.now() + 5000);
+      await utimes(filePath, later, later);
+
+      await service.getSessionMessages("/opt/workspace", "session-abc", { dockerEnabled: true });
+
+      // Stale cache entry is invalidated by the mtime change — parse runs again.
+      expect(mockParseSessionMessages).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("getSessionMetadata", () => {

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -49,6 +49,15 @@ import { mapWithConcurrency } from "./utils/concurrency.js";
 const SESSION_ENRICHMENT_CONCURRENCY = 16;
 
 /**
+ * Max number of parsed-transcript entries retained by the message cache in
+ * {@link SessionDiscoveryService.getSessionMessages}. Parsed message arrays for
+ * large chats are multiple MB each, so the cache is kept small (LRU-evicted) to
+ * bound memory on the constrained host while still covering the common
+ * open/refresh-the-same-few-chats pattern.
+ */
+const MESSAGE_CACHE_MAX_ENTRIES = 8;
+
+/**
  * A discovered session with attribution and metadata
  */
 export interface DiscoveredSession {
@@ -206,6 +215,20 @@ export class SessionDiscoveryService {
 
   private directoryCache: Map<string, DirectoryCacheEntry> = new Map();
   private metadataCache: Map<string, SessionMetadata> = new Map();
+  /**
+   * mtime-keyed cache of fully-parsed transcript messages, keyed on the
+   * transcript file path. A transcript is immutable except when a new turn
+   * appends (which bumps its mtime), so an entry is served only when the
+   * recorded mtime still matches the file's current mtime. This kills the
+   * repeat-open cost — parsing an ~8MB / 500K-token transcript is ~114ms of
+   * synchronous JSON.parse-per-line that otherwise ran on *every* open and
+   * stalled the event loop on the constrained host.
+   *
+   * Bounded to {@link MESSAGE_CACHE_MAX_ENTRIES} entries (each parsed array can
+   * be multiple MB) with simple LRU eviction — Map preserves insertion order, so
+   * the oldest key is evicted first and a hit re-inserts to mark it most-recent.
+   */
+  private messageCache: Map<string, { mtime: string; messages: ChatMessage[] }> = new Map();
 
   private readonly sessionMetadataStore: SessionMetadataStore;
 
@@ -1040,7 +1063,38 @@ export class SessionDiscoveryService {
       sessionId,
       options?.dockerEnabled,
     );
-    return parseSessionMessages(filePath);
+
+    // Key the cache on the transcript's current mtime. A transcript only changes
+    // when a new turn appends (bumping mtime), so an exact mtime match means the
+    // parsed messages are still current and we can skip the full re-parse. If the
+    // file can't be stat'd (e.g. gone), fall back to a direct parse rather than
+    // caching against a bogus key.
+    let mtimeStr: string | undefined;
+    try {
+      mtimeStr = (await stat(filePath)).mtime.toISOString();
+    } catch {
+      return parseSessionMessages(filePath);
+    }
+
+    const cached = this.messageCache.get(filePath);
+    if (cached && cached.mtime === mtimeStr) {
+      // LRU touch: re-insert so this key is marked most-recently-used.
+      this.messageCache.delete(filePath);
+      this.messageCache.set(filePath, cached);
+      return cached.messages;
+    }
+
+    const messages = await parseSessionMessages(filePath);
+
+    this.messageCache.set(filePath, { mtime: mtimeStr, messages });
+    // Evict least-recently-used entries beyond the cap (oldest insertion first).
+    while (this.messageCache.size > MESSAGE_CACHE_MAX_ENTRIES) {
+      const oldest = this.messageCache.keys().next().value;
+      if (oldest === undefined) break;
+      this.messageCache.delete(oldest);
+    }
+
+    return messages;
   }
 
   /**
@@ -1159,6 +1213,7 @@ export class SessionDiscoveryService {
       this.attributionIndex = null;
       this.attributionFetchedAt = 0;
       this.metadataCache.clear();
+      this.messageCache.clear();
       logger.debug("Invalidated all caches");
     }
   }


### PR DESCRIPTION
Closes #351.

## Problem

`SessionDiscoveryService.getSessionMessages` delegated straight to `parseSessionMessages` with **no cache**, so opening/refreshing a chat re-parsed the entire transcript JSONL every time. Measured on a real ~8MB / 3132-line / ~500K-token transcript: **~114ms** of synchronous `JSON.parse`-per-line → 1107 messages, recomputed on **every** open. On the single weak core of the deployment LXC, that stalls the event loop for all other concurrent requests. Its siblings `getSessionUsage`/`getSessionMetadata` were already mtime-cached; messages were the outlier.

## Fix

Added a small **mtime-keyed, LRU-bounded** in-memory cache (keyed on the transcript file path + its current mtime), capped at 8 entries since parsed arrays are multi-MB:

- On open: `stat` the file; if a cache entry exists with the exact same mtime, return the parsed array with no re-parse.
- A transcript is immutable except when a new turn appends (which bumps mtime), so a bumped mtime invalidates the entry and triggers a fresh parse.
- LRU eviction via `Map` insertion order (hit re-inserts to mark most-recent; oldest evicted past the cap).
- If the file can't be stat'd, fall back to a direct parse (no bogus cache entry).
- The no-arg `invalidateCache()` also clears it.

## Impact

Repeat opens / refreshes of an unchanged chat drop from ~114ms (large chat) to ~0. Removes a recurring event-loop stall on the constrained host.

## Tests

- Repeat open is served from cache (parse runs once across two opens).
- Advancing the transcript mtime (simulating a new turn) invalidates the entry and re-parses.
- Full `session-discovery` suite passes (72 tests).

Companion to #350; complements the Paddock `enrichWithSubagents` double-parse ticket. Patch — internal caching only, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)