### PR TITLE
perf(state): stop duplicating tool output in message payload (#352)

### DIFF
--- a/.changeset/dedup-tool-output.md
+++ b/.changeset/dedup-tool-output.md
@@ -1,0 +1,16 @@
+---
+"@herdctl/core": patch
+---
+
+perf(state): stop duplicating tool output in the parsed message payload
+
+`parseSessionMessages` stored each tool result's (often large) output **twice** —
+once as the message's top-level `content` and again as `toolCall.output` — so both
+copies were serialized into the `/messages` payload, roughly doubling tool-output
+bytes on the wire for tool-heavy chats.
+
+Consumers (the web dashboard, Paddock's chat UI, the sweep summary) render tool
+messages exclusively from `toolCall.output`; the top-level `content` copy for a
+tool message was never read. `content` is now left empty (`""`) for tool messages,
+keeping the single copy on `toolCall.output`. Smaller payloads and less client-side
+`JSON.parse` for chats dominated by large tool results.

--- a/packages/core/src/state/__tests__/jsonl-parser.test.ts
+++ b/packages/core/src/state/__tests__/jsonl-parser.test.ts
@@ -72,6 +72,9 @@ describe("parseSessionMessages", () => {
     expect(toolMsg.toolCall!.isError).toBe(false);
     expect(toolMsg.toolCall!.output).toContain("import express from 'express'");
     expect(toolMsg.toolCall!.inputSummary).toBe("/src/index.ts");
+    // Tool output must not be duplicated onto top-level `content` — consumers
+    // render it from toolCall.output, so the second copy only bloats the payload.
+    expect(toolMsg.content).toBe("");
 
     // Final assistant message
     expect(messages[3].role).toBe("assistant");

--- a/packages/core/src/state/jsonl-parser.ts
+++ b/packages/core/src/state/jsonl-parser.ts
@@ -253,7 +253,11 @@ export async function parseSessionMessages(
 
           messages.push({
             role: "tool",
-            content: result.output,
+            // Tool output lives on `toolCall.output` (below); consumers render
+            // tool messages from there, never from top-level `content`. Keeping a
+            // second copy here doubled the (often large) tool-output bytes in the
+            // serialized payload, so leave `content` empty for tool messages.
+            content: "",
             timestamp,
             // Anchor to the originating tool_use entry so the id is stable and
             // distinct even when several tool_results share one user line. Fall


### PR DESCRIPTION
Closes #352.

## Problem

In `parseSessionMessages`, a tool-result message stored the (potentially large) tool output **twice**: once as the message's top-level `content` and again as `toolCall.output`. Both were serialized into the `/messages` payload, roughly doubling the tool-output bytes on the wire for tool-heavy chats (the measured 8MB transcript produced a ~2.1MB payload with tool outputs kept verbatim in both fields).

## Fix

Leave `content` empty (`""`) for tool messages; keep the single copy on `toolCall.output`.

Verified every consumer of `parseSessionMessages`/`getSessionMessages` output renders tool messages from `toolCall.output`, never from top-level `content`:
- herdctl web `MessageBubble` → `ToolCallBubble` reads `toolCall.output`.
- `web-chat-manager.transformCoreMessage` copies `content` through but the web UI renders tool bubbles from `toolCall.output`.
- Paddock: `ChatPane` (`m.toolCall`), `attachments.ts` (`m.toolCall.output`), `subagents.ts` (`m.toolCall`), `sweep.ts` (tool branch reads `m.toolCall`, `m.content` only in the non-tool `else`).

(discord/slack/cli/chat handle raw SDK/Discord messages, not `parseSessionMessages` output.)

## Impact

Smaller `/messages` payloads and less client-side parse/transfer for chats dominated by large tool results. Complements the `parseSessionMessages` caching PR (#355 / #351).

## Tests

Added an assertion that a tool message's top-level `content` is `""` while `toolCall.output` still carries the data. Full `jsonl-parser` suite passes (46 tests).

Patch — payload shape for tool messages only; no field removed (kept `content: ""` so the type is unchanged). No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)