### PR TITLE
fix(web): forward agentName to engage persistent usage cache (#358)

### DIFF
--- a/.changeset/web-usage-cache-agentname.md
+++ b/.changeset/web-usage-cache-agentname.md
@@ -1,0 +1,15 @@
+---
+"@herdctl/web": patch
+---
+
+fix(web): forward agentName so the dashboard usage endpoint hits the persistent usage cache
+
+`WebChatManager.getSessionUsage` had the `agentName` in scope but omitted it from
+the options passed to `SessionDiscoveryService.getSessionUsage`, so the
+mtime-keyed persistent usage cache (added in #320) was never engaged on the web
+`/usage` path. Every dashboard navigation that read per-session usage took the
+uncached `extractSessionUsage` branch and re-streamed the whole transcript — the
+exact O(transcript-size) cost the cache was meant to eliminate.
+
+Forwarding `agentName` in the options opts the web path into the cache, matching
+the sibling `getSessionMessages` call that already forwards its options.

--- a/packages/web/src/server/__tests__/web-chat-manager.test.ts
+++ b/packages/web/src/server/__tests__/web-chat-manager.test.ts
@@ -632,7 +632,17 @@ describe("WebChatManager", () => {
       expect(mockDiscoveryService.getSessionUsage).toHaveBeenCalledWith(
         "/home/user/project",
         "session-123",
-        { dockerEnabled: false },
+        { dockerEnabled: false, agentName: "test-agent" },
+      );
+    });
+
+    it("forwards agentName so the persistent usage cache is engaged", async () => {
+      await manager.getSessionUsage("test-agent", "session-123");
+
+      expect(mockDiscoveryService.getSessionUsage).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ agentName: "test-agent" }),
       );
     });
 

--- a/packages/web/src/server/chat/web-chat-manager.ts
+++ b/packages/web/src/server/chat/web-chat-manager.ts
@@ -246,6 +246,7 @@ export class WebChatManager {
     const dockerEnabled = agent.docker?.enabled ?? false;
     const usage = await this.discoveryService!.getSessionUsage(workDir, sessionId, {
       dockerEnabled,
+      agentName,
     });
     return this.transformCoreUsage(usage);
   }


### PR DESCRIPTION
Closes #358.

## Problem

`WebChatManager.getSessionUsage` had `agentName` in scope but did not forward it to `SessionDiscoveryService.getSessionUsage`, so the mtime-keyed persistent usage cache added in #320 was **never engaged** on the web `/usage` path. Every dashboard navigation that read per-session usage took the uncached `extractSessionUsage` branch and re-streamed the whole transcript — the exact O(transcript-size) cost the cache was meant to eliminate. The sibling `getSessionMessages` already forwarded its options, so the pattern was inconsistent.

## Fix

Pass `agentName` in the options object, opting the web path into the cache.

```ts
const usage = await this.discoveryService!.getSessionUsage(workDir, sessionId, {
  dockerEnabled,
  agentName,
});
```

## Tests

- Updated the delegation assertion in `web-chat-manager.test.ts` to expect `agentName` in the forwarded options.
- Added a coverage assertion that `agentName` is forwarded so the persistent usage cache is engaged.
- `vitest run` (getSessionUsage suite): passing.

A `@herdctl/web` patch changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session usage loading in the web dashboard by enabling cached results.
  * Reduced unnecessary transcript reprocessing when navigating between usage views.

* **Tests**
  * Added coverage to verify agent-specific usage requests are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->