### PR TITLE
fix(core): resolve fresh CLI session by set difference, not mtime (#357)

### DIFF
--- a/.changeset/cli-session-id-collision.md
+++ b/.changeset/cli-session-id-collision.md
@@ -1,0 +1,24 @@
+---
+"@herdctl/core": patch
+---
+
+fix(core): resolve a fresh CLI session by set difference, not mtime, so co-located agents can't steal each other's session id
+
+`waitForNewSessionFile` resolved a freshly-spawned `resume:null` (or forked) CLI
+turn by picking the newest `.jsonl` whose `mtime > startTime` in the agent's
+session directory. When two agents **share a working directory** — hence the same
+`~/.claude/projects/<encoded-cwd>/` session dir — a concurrently *streaming*
+session from the other agent also has `mtime > startTime`, and can be newer than
+the file the CLI just created. The new turn was then mis-resolved to the **other
+agent's** session id and its job record written with that foreign `session_id`.
+Because job attribution is last-writer-wins per `session_id`, the victim session
+flipped to the wrong agent and vanished from its owner's chat list until a later,
+correctly-attributed turn (so it was intermittent). Observed live on Paddock,
+whose per-project keeper and sweeper share the project directory as cwd.
+
+Fix: snapshot the set of `.jsonl` filenames *before* spawning the CLI
+(`snapshotSessionFiles`) and identify the new session by **set difference** — the
+file whose *name* is new since the snapshot — which a co-located agent's
+pre-existing (merely-appended-to) file can never be, regardless of mtime. The
+mtime heuristic is retained only as a post-deadline fallback (with a warning) for
+genuinely degenerate cases where no new-named file ever appears.

--- a/packages/core/src/runner/runtime/__tests__/cli-runtime.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/cli-runtime.test.ts
@@ -8,6 +8,7 @@ const flushMessages: SDKMessage[] = [];
 vi.mock("../cli-session-path.js", () => ({
   getCliSessionDir: vi.fn(() => "/tmp/sessions"),
   getCliSessionFile: vi.fn(() => "/tmp/sessions/session-1.jsonl"),
+  snapshotSessionFiles: vi.fn(async () => new Set<string>()),
   waitForNewSessionFile: vi.fn(async () => "/tmp/sessions/session-1.jsonl"),
 }));
 
@@ -32,7 +33,12 @@ vi.mock("../cli-session-watcher.js", () => ({
 }));
 
 import { CLIRuntime } from "../cli-runtime.js";
-import { getCliSessionDir, getCliSessionFile, waitForNewSessionFile } from "../cli-session-path.js";
+import {
+  getCliSessionDir,
+  getCliSessionFile,
+  snapshotSessionFiles,
+  waitForNewSessionFile,
+} from "../cli-session-path.js";
 
 function makeSubprocess(exitCode = 0): Promise<{ exitCode: number }> & {
   pid: number;
@@ -252,6 +258,8 @@ describe("CLIRuntime session fork (--fork-session)", () => {
     flushMessages.length = 0;
     vi.mocked(getCliSessionFile).mockClear();
     vi.mocked(waitForNewSessionFile).mockClear();
+    vi.mocked(snapshotSessionFiles).mockClear();
+    vi.mocked(snapshotSessionFiles).mockResolvedValue(new Set(["pre-existing.jsonl"]));
     // Distinct paths so we can tell which resolver drove the watched file: a
     // plain resume watches the source file in place; a fork must wait for a new
     // one (Claude Code writes a new session file for `--fork-session`).
@@ -311,5 +319,22 @@ describe("CLIRuntime session fork (--fork-session)", () => {
     expect(vi.mocked(getCliSessionFile)).toHaveBeenCalled();
     expect(vi.mocked(waitForNewSessionFile)).not.toHaveBeenCalled();
     expect(initId(messages)).toBe("source");
+  });
+
+  it("snapshots the session dir pre-spawn and forwards it as knownFiles (issue #357)", async () => {
+    await run({ resume: "source", fork: true });
+    // The snapshot must be taken (before spawn) and threaded into the resolver
+    // so the new file is found by set difference, not mtime.
+    expect(vi.mocked(snapshotSessionFiles)).toHaveBeenCalled();
+    expect(vi.mocked(waitForNewSessionFile)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Number),
+      expect.objectContaining({ knownFiles: new Set(["pre-existing.jsonl"]) }),
+    );
+  });
+
+  it("does NOT snapshot on a plain resume (no new file is expected)", async () => {
+    await run({ resume: "source" });
+    expect(vi.mocked(snapshotSessionFiles)).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/runner/runtime/__tests__/cli-session-path.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/cli-session-path.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   encodePathForCli,
   getCliSessionDir,
@@ -9,6 +9,8 @@ import {
   getDockerSessionFile,
   readSessionCwd,
   sessionBelongsToWorkingDirectory,
+  snapshotSessionFiles,
+  waitForNewSessionFile,
 } from "../cli-session-path.js";
 
 describe("encodePathForCli", () => {
@@ -554,5 +556,166 @@ describe("sessionBelongsToWorkingDirectory", () => {
     expect(
       await sessionBelongsToWorkingDirectory(file, "/anything", { defaultWhenUnknown: false }),
     ).toBe(false);
+  });
+});
+
+describe("snapshotSessionFiles", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "herdctl-snapshot-test-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns the set of .jsonl filenames currently present", async () => {
+    await writeFile(join(dir, "a.jsonl"), "");
+    await writeFile(join(dir, "b.jsonl"), "");
+    await writeFile(join(dir, "notes.txt"), ""); // ignored — not a transcript
+
+    const snapshot = await snapshotSessionFiles(dir);
+    expect(snapshot).toEqual(new Set(["a.jsonl", "b.jsonl"]));
+  });
+
+  it("returns basenames (not full paths) so they compare against a later readdir", async () => {
+    await writeFile(join(dir, "abc123.jsonl"), "");
+    const snapshot = await snapshotSessionFiles(dir);
+    expect(snapshot.has("abc123.jsonl")).toBe(true);
+    expect(snapshot.has(join(dir, "abc123.jsonl"))).toBe(false);
+  });
+
+  it("returns an empty set for a non-existent directory (first-ever session)", async () => {
+    const snapshot = await snapshotSessionFiles(join(dir, "does-not-exist"));
+    expect(snapshot).toEqual(new Set());
+  });
+});
+
+describe("waitForNewSessionFile", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "herdctl-waitnew-test-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // Set a file's mtime to `ms` epoch milliseconds so tests can order files
+  // deterministically regardless of write speed.
+  async function setMtime(file: string, ms: number): Promise<void> {
+    const when = new Date(ms);
+    await utimes(file, when, when);
+  }
+
+  describe("set-difference path (knownFiles supplied) — issue #357", () => {
+    it("returns the brand-new file even when a co-located session is newer", async () => {
+      // Agent A's session already exists and is actively streaming.
+      const coLocated = join(dir, "aaaaaaaa-cccc-4444-8888-000000000000.jsonl");
+      await writeFile(coLocated, "");
+      const knownFiles = await snapshotSessionFiles(dir);
+
+      const startTime = Date.now() - 10_000;
+
+      // Agent B spawns and creates its own new file...
+      const brandNew = join(dir, "bbbbbbbb-cccc-4444-8888-111111111111.jsonl");
+      await writeFile(brandNew, "");
+      await setMtime(brandNew, startTime + 1000);
+      // ...but agent A keeps streaming, so its file is now the NEWEST by mtime.
+      await setMtime(coLocated, startTime + 5000);
+
+      const resolved = await waitForNewSessionFile(dir, startTime, {
+        knownFiles,
+        timeoutMs: 2000,
+        pollIntervalMs: 10,
+      });
+
+      // Must be B's brand-new file, not A's newer-mtime streaming file.
+      expect(resolved).toBe(brandNew);
+    });
+
+    it("(contrast) the legacy mtime path picks the wrong (co-located) file", async () => {
+      // Same setup, but WITHOUT the snapshot — demonstrates the bug the
+      // set-difference path fixes.
+      const coLocated = join(dir, "aaaaaaaa-cccc-4444-8888-000000000000.jsonl");
+      await writeFile(coLocated, "");
+      const startTime = Date.now() - 10_000;
+
+      const brandNew = join(dir, "bbbbbbbb-cccc-4444-8888-111111111111.jsonl");
+      await writeFile(brandNew, "");
+      await setMtime(brandNew, startTime + 1000);
+      await setMtime(coLocated, startTime + 5000);
+
+      const resolved = await waitForNewSessionFile(dir, startTime, {
+        timeoutMs: 2000,
+        pollIntervalMs: 10,
+      });
+
+      // Legacy heuristic grabs the newest-by-mtime file — the co-located one.
+      expect(resolved).toBe(coLocated);
+    });
+
+    it("keeps polling until the new-named file appears (ignores co-located churn)", async () => {
+      const coLocated = join(dir, "aaaaaaaa-cccc-4444-8888-000000000000.jsonl");
+      await writeFile(coLocated, "");
+      const knownFiles = await snapshotSessionFiles(dir);
+      const startTime = Date.now() - 10_000;
+
+      // The new file appears only after a couple of poll intervals.
+      const brandNew = join(dir, "bbbbbbbb-cccc-4444-8888-111111111111.jsonl");
+      setTimeout(() => {
+        void writeFile(brandNew, "");
+      }, 60);
+
+      const resolved = await waitForNewSessionFile(dir, startTime, {
+        knownFiles,
+        timeoutMs: 2000,
+        pollIntervalMs: 10,
+      });
+      expect(resolved).toBe(brandNew);
+    });
+
+    it("falls back to newest-by-mtime after the deadline if no new-named file appears", async () => {
+      // Only co-located files exist; none is 'new'. After the timeout the
+      // function falls back to the mtime heuristic rather than the primary path.
+      const coLocated = join(dir, "aaaaaaaa-cccc-4444-8888-000000000000.jsonl");
+      await writeFile(coLocated, "");
+      const knownFiles = await snapshotSessionFiles(dir);
+      const startTime = Date.now() - 10_000;
+      await setMtime(coLocated, startTime + 1000);
+
+      const resolved = await waitForNewSessionFile(dir, startTime, {
+        knownFiles,
+        timeoutMs: 150,
+        pollIntervalMs: 20,
+      });
+      expect(resolved).toBe(coLocated);
+    });
+  });
+
+  describe("legacy mtime path (no knownFiles)", () => {
+    it("returns the newest file created after startTime", async () => {
+      const startTime = Date.now() - 10_000;
+      const older = join(dir, "older.jsonl");
+      const newer = join(dir, "newer.jsonl");
+      await writeFile(older, "");
+      await writeFile(newer, "");
+      await setMtime(older, startTime + 1000);
+      await setMtime(newer, startTime + 2000);
+
+      const resolved = await waitForNewSessionFile(dir, startTime, {
+        timeoutMs: 2000,
+        pollIntervalMs: 10,
+      });
+      expect(resolved).toBe(newer);
+    });
+
+    it("throws on timeout when no file is created after startTime", async () => {
+      const stale = join(dir, "stale.jsonl");
+      await writeFile(stale, "");
+      const startTime = Date.now() + 10_000; // future — nothing qualifies
+
+      await expect(
+        waitForNewSessionFile(dir, startTime, { timeoutMs: 120, pollIntervalMs: 20 }),
+      ).rejects.toThrow(/Timeout waiting for new session file/);
+    });
   });
 });

--- a/packages/core/src/runner/runtime/cli-runtime.ts
+++ b/packages/core/src/runner/runtime/cli-runtime.ts
@@ -18,7 +18,12 @@ import { execa, type Subprocess } from "execa";
 import { createLogger } from "../../utils/logger.js";
 import { transformMcpServers } from "../sdk-adapter.js";
 import type { SDKMessage } from "../types.js";
-import { getCliSessionDir, getCliSessionFile, waitForNewSessionFile } from "./cli-session-path.js";
+import {
+  getCliSessionDir,
+  getCliSessionFile,
+  snapshotSessionFiles,
+  waitForNewSessionFile,
+} from "./cli-session-path.js";
 import { CLISessionWatcher } from "./cli-session-watcher.js";
 import type { RuntimeExecuteOptions, RuntimeInterface } from "./interface.js";
 import { type McpHttpBridge, startMcpHttpBridge } from "./mcp-http-bridge.js";
@@ -362,6 +367,17 @@ export class CLIRuntime implements RuntimeInterface {
       // Record start time before spawning process
       const processStartTime = Date.now();
 
+      // Snapshot the session directory's existing .jsonl files BEFORE spawning.
+      // A fresh (or forked) session writes a brand-new file; we identify it by
+      // set difference against this snapshot rather than by mtime, so a
+      // co-located agent concurrently streaming its own session in a shared
+      // session dir can't be mistaken for the file we just created (issue #357).
+      // Only needed when we actually wait for a new file (new session or fork).
+      const needNewSessionFile = !options.resume || !!options.fork;
+      const preSpawnSessionFiles = needNewSessionFile
+        ? await snapshotSessionFiles(sessionDir)
+        : undefined;
+
       // Spawn claude subprocess with prompt via stdin
       // Uses custom spawner if provided (e.g., for Docker execution)
       // Note: processSpawner returns Subprocess directly (which is promise-like)
@@ -425,6 +441,7 @@ export class CLIRuntime implements RuntimeInterface {
         sessionFilePath = await waitForNewSessionFile(sessionDir, processStartTime, {
           timeoutMs: 60000, // Allow up to 60s for MCP servers to initialize
           pollIntervalMs: 200,
+          knownFiles: preSpawnSessionFiles,
         });
         logger.debug(`New session, watching newly created file: ${sessionFilePath}`);
       }

--- a/packages/core/src/runner/runtime/cli-session-path.ts
+++ b/packages/core/src/runner/runtime/cli-session-path.ts
@@ -11,6 +11,9 @@ import { readdir, stat } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as readline from "node:readline";
+import { createLogger } from "../../utils/logger.js";
+
+const logger = createLogger("CLISessionPath");
 
 /**
  * Maximum length of an encoded path before Claude Code truncates it.
@@ -283,81 +286,112 @@ export function getDockerSessionFile(stateDir: string, sessionId: string): strin
 }
 
 /**
- * Find the newest session file in a CLI session directory
+ * Snapshot the set of `.jsonl` session filenames currently present in a session
+ * directory.
  *
- * Scans the session directory for .jsonl files and returns the path to the
- * most recently modified one. This is useful when spawning a new CLI session
- * without knowing the session ID upfront - the newest file is typically the
- * one just created.
+ * Callers take this snapshot *immediately before* spawning a CLI subprocess that
+ * will create a new session file, then pass it to {@link waitForNewSessionFile}
+ * as `knownFiles`. The freshly-created session is then identified by **set
+ * difference** (a filename not in the snapshot) rather than by an mtime
+ * heuristic — see the issue-#357 note on {@link waitForNewSessionFile}.
  *
- * @example
- * ```typescript
- * const sessionDir = getCliSessionDir('/Users/ed/Code/myproject');
- * const newestFile = await findNewestSessionFile(sessionDir);
- * // => '/Users/ed/.claude/projects/-Users-ed-Code-myproject/abc123.jsonl'
- * ```
+ * Filenames (basenames, e.g. `abc123.jsonl`), not full paths, are returned so
+ * the set can be compared directly against a later `readdir`.
  *
  * @param sessionDir - Absolute path to CLI session directory
- * @returns Promise resolving to path of newest .jsonl file
- * @throws {Error} If directory doesn't exist or contains no .jsonl files
+ * @returns Set of `.jsonl` filenames present now; empty if the directory does
+ *   not exist yet or cannot be read
  */
-async function findNewestSessionFile(sessionDir: string): Promise<string> {
+export async function snapshotSessionFiles(sessionDir: string): Promise<Set<string>> {
   try {
     const files = await readdir(sessionDir);
-    const jsonlFiles = files.filter((f) => f.endsWith(".jsonl"));
-
-    if (jsonlFiles.length === 0) {
-      throw new Error(`No session files found in ${sessionDir}`);
-    }
-
-    // Get stats for all .jsonl files
-    const fileStats = await Promise.all(
-      jsonlFiles.map(async (file) => {
-        const filePath = path.join(sessionDir, file);
-        const stats = await stat(filePath);
-        return { path: filePath, mtime: stats.mtime };
-      }),
-    );
-
-    // Sort by modification time (newest first)
-    fileStats.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
-
-    return fileStats[0].path;
+    return new Set(files.filter((f) => f.endsWith(".jsonl")));
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(`Session directory does not exist: ${sessionDir}`);
+    // Directory may not exist yet (first-ever session for this cwd) — treat as
+    // an empty snapshot. Any other error is also non-fatal here; the caller
+    // still polls for the new file.
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      logger.debug(`Could not snapshot session dir ${sessionDir}: ${error}`);
     }
-    throw error;
+    return new Set();
   }
 }
 
 /**
- * Wait for a new session file to be created after a given timestamp
+ * Given a list of `.jsonl` filenames in a session directory, return the absolute
+ * path of the one with the newest mtime (or `null` if the list is empty or none
+ * could be stat'd).
+ */
+async function newestSessionFileByMtime(
+  sessionDir: string,
+  fileNames: string[],
+): Promise<string | null> {
+  const stats: Array<{ path: string; mtime: Date }> = [];
+  for (const file of fileNames) {
+    const filePath = path.join(sessionDir, file);
+    try {
+      const s = await stat(filePath);
+      stats.push({ path: filePath, mtime: s.mtime });
+    } catch {
+      // File vanished between readdir and stat — skip it.
+    }
+  }
+  if (stats.length === 0) return null;
+  stats.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  return stats[0].path;
+}
+
+/**
+ * Wait for a new session file to be created after a CLI subprocess is spawned.
  *
- * Polls the session directory until a new .jsonl file appears that was
- * created after the specified start time. This prevents picking up old
- * session files when spawning a new CLI session.
+ * Polls the session directory until the freshly-created `.jsonl` appears, then
+ * returns its path so the caller can adopt its session id.
+ *
+ * ## Identifying the *right* new file (issue #357)
+ *
+ * When two agents share a working directory they also share a single
+ * `~/.claude/projects/<encoded-cwd>/` session directory. If agent A is
+ * *streaming* a turn (continuously appending to its own transcript) while agent
+ * B spawns a fresh `resume:null` turn, agent A's file also has
+ * `mtime > startTime` — and can even be *newer* than the file B just created.
+ * The old mtime-after-`startTime` heuristic then mis-resolved B's turn to **A's**
+ * session id, corrupting job attribution and making A's chat vanish from its
+ * owner's list until a later turn re-attributed it.
+ *
+ * The robust fix is **set difference**: the caller snapshots the session
+ * directory's `.jsonl` filenames *before* spawning (via
+ * {@link snapshotSessionFiles}) and passes them as `knownFiles`. The new session
+ * is then the file whose *name* is new since that snapshot — which a co-located
+ * agent's pre-existing (merely-appended-to) file can never be, regardless of
+ * mtime. The mtime heuristic is retained only as a fallback for when no
+ * snapshot is supplied, or defensively if no new-named file ever appears.
  *
  * @example
  * ```typescript
+ * const knownFiles = await snapshotSessionFiles(sessionDir);
  * const startTime = Date.now();
  * // ... spawn claude CLI ...
- * const sessionFile = await waitForNewSessionFile(sessionDir, startTime);
+ * const sessionFile = await waitForNewSessionFile(sessionDir, startTime, { knownFiles });
  * // => '/Users/ed/.claude/projects/-Users-ed-Code-myproject/new-session.jsonl'
  * ```
  *
  * @param sessionDir - Absolute path to CLI session directory
- * @param startTime - Timestamp (ms) before which files should be ignored
+ * @param startTime - Timestamp (ms) before which files should be ignored (used
+ *   only by the mtime fallback path)
  * @param options - Optional configuration
+ * @param options.knownFiles - Snapshot of `.jsonl` filenames present *before*
+ *   spawning. When supplied, the new session is identified by set difference
+ *   against this set (the collision-proof path); when omitted, the legacy
+ *   mtime-after-`startTime` heuristic is used.
  * @returns Promise resolving to path of newly created session file
  * @throws {Error} If timeout exceeded or directory doesn't exist
  */
 export async function waitForNewSessionFile(
   sessionDir: string,
   startTime: number,
-  options: { timeoutMs?: number; pollIntervalMs?: number } = {},
+  options: { timeoutMs?: number; pollIntervalMs?: number; knownFiles?: ReadonlySet<string> } = {},
 ): Promise<string> {
-  const { timeoutMs = 5000, pollIntervalMs = 100 } = options;
+  const { timeoutMs = 5000, pollIntervalMs = 100, knownFiles } = options;
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
@@ -365,22 +399,34 @@ export async function waitForNewSessionFile(
       const files = await readdir(sessionDir);
       const jsonlFiles = files.filter((f) => f.endsWith(".jsonl"));
 
-      // Find files created after startTime
-      const newFiles: Array<{ path: string; mtime: Date }> = [];
-      for (const file of jsonlFiles) {
-        const filePath = path.join(sessionDir, file);
-        const stats = await stat(filePath);
-
-        // Check if file was modified after startTime
-        if (stats.mtime.getTime() > startTime) {
-          newFiles.push({ path: filePath, mtime: stats.mtime });
+      if (knownFiles) {
+        // Primary path (issue #357): the new session is a file whose NAME did
+        // not exist before we spawned. This is immune to a co-located agent
+        // concurrently appending to its own (older) session in a shared dir.
+        const brandNew = jsonlFiles.filter((f) => !knownFiles.has(f));
+        if (brandNew.length > 0) {
+          // Normally exactly one; if several appeared (e.g. multiple co-located
+          // spawns raced), the newest is ours.
+          const newest = await newestSessionFileByMtime(sessionDir, brandNew);
+          if (newest) return newest;
         }
-      }
-
-      // Return the newest file created after startTime
-      if (newFiles.length > 0) {
-        newFiles.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
-        return newFiles[0].path;
+        // No new-named file yet — keep polling. Do NOT fall through to the mtime
+        // heuristic here, or we would grab a co-located agent's streaming file.
+      } else {
+        // Legacy path: no snapshot supplied — find files touched after startTime
+        // and return the newest.
+        const newFiles = jsonlFiles.map((f) => path.join(sessionDir, f));
+        const stats: Array<{ path: string; mtime: Date }> = [];
+        for (const filePath of newFiles) {
+          const s = await stat(filePath);
+          if (s.mtime.getTime() > startTime) {
+            stats.push({ path: filePath, mtime: s.mtime });
+          }
+        }
+        if (stats.length > 0) {
+          stats.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+          return stats[0].path;
+        }
       }
     } catch (error) {
       // Directory might not exist yet - keep polling
@@ -391,6 +437,33 @@ export async function waitForNewSessionFile(
 
     // Wait before next poll
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  // Deadline exceeded. If we were using the set-difference path and no new-named
+  // file ever appeared, fall back once to the mtime heuristic before giving up —
+  // this preserves the old behaviour for genuinely degenerate cases (e.g. the
+  // CLI reused a filename) at the cost of the collision risk the snapshot avoids.
+  if (knownFiles) {
+    try {
+      const files = await readdir(sessionDir);
+      const jsonlFiles = files.filter((f) => f.endsWith(".jsonl"));
+      const candidates: string[] = [];
+      for (const file of jsonlFiles) {
+        const s = await stat(path.join(sessionDir, file));
+        if (s.mtime.getTime() > startTime) candidates.push(file);
+      }
+      const newest = await newestSessionFileByMtime(sessionDir, candidates);
+      if (newest) {
+        logger.warn(
+          `No new session file appeared in ${sessionDir} within ${timeoutMs}ms; ` +
+            `falling back to newest-by-mtime (${path.basename(newest)}). In a shared ` +
+            `session directory this may mis-attribute a co-located agent's session (issue #357).`,
+        );
+        return newest;
+      }
+    } catch {
+      // fall through to the timeout error
+    }
   }
 
   throw new Error(`Timeout waiting for new session file in ${sessionDir} (waited ${timeoutMs}ms)`);


### PR DESCRIPTION
Closes #357.

## Problem

`waitForNewSessionFile` (`packages/core/src/runner/runtime/cli-session-path.ts`) resolved the session id of a freshly-spawned `resume:null` (or forked) CLI turn by picking the **newest `.jsonl` whose `mtime > startTime`** in the agent's session directory.

When two agents **share a working directory** they share one `~/.claude/projects/<encoded-cwd>/` session dir. If agent A is *streaming* a turn (continuously appending to its own transcript) while agent B spawns a fresh turn, A's file also has `mtime > startTime` — and can be **newer** than the file B just created. B's turn was then mis-resolved to **A's** session id, and B's job record written with that foreign `session_id`.

Because `buildJobIndex` is last-writer-wins per `session_id`, A's session flips to agent B in the attribution index and **disappears from A's chat list** until a later, correctly-attributed turn on that session rewrites it — hence the intermittent "chat vanishes" symptom.

This was observed live on **Paddock**, whose per-project **keeper** and per-project **sweeper** share the project directory as cwd: a sweep running while the keeper streamed grabbed the keeper's active session id, flipping the keeper chat to `sweeper-<project>`.

## Fix

Identify the new session by **set difference**, not mtime:

1. `snapshotSessionFiles(sessionDir)` — snapshot the set of `.jsonl` filenames **before** spawning the CLI (in `cli-runtime.ts`, only when a new file is actually expected: a new session or a fork).
2. `waitForNewSessionFile(..., { knownFiles })` — the new session is the file whose **name** is new since the snapshot. A co-located agent's pre-existing (merely-appended-to) file can never be name-new, regardless of mtime, so it can no longer be mistaken for the file we just created.
3. The old mtime-after-`startTime` heuristic is retained **only** as a post-deadline fallback (with a warning log) for genuinely degenerate cases where no new-named file ever appears, and remains the behaviour when no snapshot is supplied.

Also removes the now-redundant, previously-unused `findNewestSessionFile` dead-code helper.

## Tests

- `snapshotSessionFiles`: returns basenames, ignores non-`.jsonl`, empty set for a missing dir.
- `waitForNewSessionFile` set-difference path: **the core #357 repro** — returns agent B's brand-new file even when agent A's co-located file has a strictly newer mtime; a contrast test shows the legacy path picks the wrong (co-located) file; polls until the new-named file appears; falls back to newest-by-mtime after the deadline.
- Legacy path: newest-after-startTime, and timeout throw.
- `cli-runtime`: snapshots the session dir pre-spawn and forwards it as `knownFiles`; does **not** snapshot on a plain resume.
- Full `packages/core/src/runner/runtime/` suite green (221 passed / 28 skipped); core typecheck clean.

A `@herdctl/core` patch changeset is included.

### Note on the secondary hardening
The issue also suggests a defense-in-depth guard in `buildJobIndex` (don't let a job re-attribute a `session_id` whose transcript-recorded owner differs). This PR fixes the **root cause** in the resolver; the attribution-layer guard is left as a possible follow-up since it would add a per-session transcript read to index building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)