### PR TITLE
fix(session): don't reap the parent session when a synchronous subagent finishes

### DIFF
--- a/.changeset/subagentstop-no-reap.md
+++ b/.changeset/subagentstop-no-reap.md
@@ -1,0 +1,16 @@
+---
+"@herdctl/core": patch
+---
+
+fix(session): a synchronous subagent finishing no longer reaps the parent session
+
+`buildLifecycleHooks` mapped both `Stop` and `SubagentStop` to a `turn_end`
+lifecycle signal. `SubagentStop` fires when a *synchronous* subagent (a
+`Task`/`Agent` tool call) completes mid-parent-turn, so the session reaper —
+which reaps on any `turn_end` that has no live background work — closed the
+streaming session out from under the still-live parent turn. A keeper driving a
+managed session (`openChatSession({ manageLifecycle: true })`, i.e. Paddock's
+session drive-mode) then appeared to "stop" the instant a synchronous subagent
+returned, never consuming its result. Only the main-agent `Stop` is a
+reap-eligible turn boundary now; subagent-registered background tasks and crons
+still surface via the `background_tasks_changed` stream and the parent `Stop`.

--- a/packages/core/src/runner/runtime/interface.ts
+++ b/packages/core/src/runner/runtime/interface.ts
@@ -51,7 +51,7 @@ export interface RuntimeExecuteOptions {
   /**
    * Streaming sessions only: observe the session's background-work lifecycle.
    *
-   * Called at each turn boundary (the SDK `Stop`/`SubagentStop` hook) and when
+   * Called at each turn boundary (the SDK main-agent `Stop` hook) and when
    * the live background-task set changes (`background_tasks_changed`), with a
    * snapshot of the session's pending timer-class wakeups (`sessionCrons`) and
    * continuous-class background work (`backgroundTasks`). The session-reaper

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -22,10 +22,29 @@ async function* stream(messages: SDKMessage[]): AsyncGenerator<SDKMessage> {
 }
 
 describe("buildLifecycleHooks", () => {
-  it("registers Stop and SubagentStop matchers", () => {
+  it("registers a Stop matcher only (never SubagentStop)", () => {
     const hooks = buildLifecycleHooks(vi.fn());
     expect(hooks?.Stop?.[0].hooks).toHaveLength(1);
-    expect(hooks?.SubagentStop?.[0].hooks).toHaveLength(1);
+    // SubagentStop must NOT be wired: it fires mid-parent-turn when a synchronous
+    // subagent finishes, and treating it as a turn_end reaps the live parent
+    // session out from under the keeper. See isMainAgentStop.
+    expect(hooks?.SubagentStop).toBeUndefined();
+  });
+
+  it("ignores a SubagentStop input (no turn_end for a synchronous subagent)", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    const subagentStop = {
+      hook_event_name: "SubagentStop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+    } as unknown as HookInput;
+    const result = await cb(subagentStop, undefined, { signal: new AbortController().signal });
+    expect(result).toEqual({ continue: true });
+    expect(sink).not.toHaveBeenCalled();
   });
 
   it("forwards a turn_end signal carrying the crons/tasks snapshot", async () => {

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -2,7 +2,7 @@
  * Translate SDK lifecycle events into herdctl {@link SessionLifecycleSignal}s.
  *
  * Two surfaces feed the session-reaper:
- * - {@link buildLifecycleHooks} — `Stop`/`SubagentStop` hooks that carry the
+ * - {@link buildLifecycleHooks} — the main-agent `Stop` hook that carries the
  *   authoritative turn-boundary snapshot (`session_crons` + `background_tasks`).
  * - {@link tapLifecycleStream} — a pass-through over the session's message
  *   stream that surfaces mid-turn `background_tasks_changed` events and a single
@@ -18,7 +18,6 @@ import type {
   Options,
   SessionCronSummary,
   StopHookInput,
-  SubagentStopHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKMessage } from "../runner/types.js";
 import { createLogger } from "../utils/logger.js";
@@ -42,18 +41,34 @@ function emit(sink: LifecycleSignalSink, signal: SessionLifecycleSignal): void {
     });
 }
 
-function isStopLike(input: HookInput): input is StopHookInput | SubagentStopHookInput {
-  return input.hook_event_name === "Stop" || input.hook_event_name === "SubagentStop";
+/**
+ * A main-agent `Stop` is the only reap-eligible turn boundary.
+ *
+ * `SubagentStop` is deliberately NOT treated as one. It fires when a
+ * *synchronous* subagent (a `Task`/`Agent` tool call) finishes, which happens
+ * *mid* the parent turn — the parent is still live and about to consume the
+ * subagent's result and continue. Emitting a `turn_end` for it let the
+ * session-reaper (which reaps on any `turn_end` with no live background work)
+ * close the streaming session out from under the running parent turn: a keeper
+ * driving a managed session (`openChatSession({ manageLifecycle: true })`) then
+ * appeared to "stop" the instant a synchronous subagent returned, never
+ * consuming the result. The parent emits its own `Stop` when the turn actually
+ * ends, and any background tasks/crons a subagent registers still reach the
+ * reaper via the `background_tasks_changed` stream and that authoritative
+ * parent `Stop`.
+ */
+function isMainAgentStop(input: HookInput): input is StopHookInput {
+  return input.hook_event_name === "Stop";
 }
 
 /**
- * Build the `Stop`/`SubagentStop` hooks that forward each turn-boundary snapshot
- * to `sink`. The hook awaits the sink so cron capture completes before the turn
+ * Build the main-agent `Stop` hook that forwards each turn-boundary snapshot to
+ * `sink`. The hook awaits the sink so cron capture completes before the turn
  * unwinds, then returns `{ continue: true }` to leave turn flow untouched.
  */
 export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"] {
   const callback = async (input: HookInput) => {
-    if (isStopLike(input)) {
+    if (isMainAgentStop(input)) {
       const sessionCrons: SessionCronSummary[] = input.session_crons ?? [];
       const backgroundTasks: BackgroundTaskSummary[] = input.background_tasks ?? [];
       // Never let a sink failure reject the hook (which would disrupt turn flow);
@@ -63,9 +78,10 @@ export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"]
     return { continue: true };
   };
 
+  // Only `Stop` is registered — see {@link isMainAgentStop} for why a
+  // `SubagentStop` must not reach the reaper as a turn boundary.
   return {
     Stop: [{ hooks: [callback] }],
-    SubagentStop: [{ hooks: [callback] }],
   };
 }
 

--- a/packages/core/src/session/types.ts
+++ b/packages/core/src/session/types.ts
@@ -17,7 +17,7 @@ export type { BackgroundTaskSummary, SessionCronSummary };
 
 /**
  * A snapshot of a session's pending background work, captured at a turn
- * boundary (the SDK `Stop`/`SubagentStop` hook) or when the live background-task
+ * boundary (the SDK main-agent `Stop` hook) or when the live background-task
  * set changes (`background_tasks_changed`).
  *
  * `sessionCrons` are the timer-class wakeups (`ScheduleWakeup`, `CronCreate`,
@@ -28,7 +28,7 @@ export type { BackgroundTaskSummary, SessionCronSummary };
 export interface SessionLifecycleSignal {
   /**
    * What produced the signal:
-   * - `turn_end` — a `Stop`/`SubagentStop` hook fired; `sessionCrons` and
+   * - `turn_end` — the main-agent `Stop` hook fired; `sessionCrons` and
    *   `backgroundTasks` are the authoritative turn-boundary snapshot.
    * - `background_tasks_changed` — the live background-task set changed
    *   mid-session; `backgroundTasks` is fresh, `sessionCrons` is not reported


### PR DESCRIPTION
Fixes #366.

## Problem

In a managed streaming session (`openChatSession({ manageLifecycle: true })` — the session-reaper from #307, used by Paddock's `drive_mode: session` keepers), a **synchronous** subagent (a foreground `Task`/`Agent` tool call) *finishing* causes the reaper to close the streaming session **out from under the still-live parent turn**. The keeper appears to "stop" the instant the subagent returns: its `tool_result` is persisted but never consumed, so the turn never continues until a human nudges it — then stalls again on the next synchronous subagent.

Distinct from #180 (background `run_in_background` subagents): a synchronous subagent is never in `background_tasks`, so the keep-alive guard can't protect it, and it's the subagent *completing* that trips the reap.

## Root cause

`buildLifecycleHooks` wired **both** `Stop` and `SubagentStop` to a `turn_end` signal. `SubagentStop` fires mid-parent-turn when a synchronous subagent completes; the timer-less reaper reaps any `turn_end` with no live background work → `session.close()` aborts the running parent turn.

Reap log lines from a live keeper landed at the exact second each synchronous subagent returned (03:29 / 03:48:36 / 12:03:11 UTC), each after a `status: completed` subagent, with no keeper output afterward until manually nudged.

## Fix

Only the **main-agent `Stop`** is a reap-eligible turn boundary. `SubagentStop` is no longer registered / mapped to `turn_end`. The parent emits its own `Stop` when the turn actually ends; background tasks/crons a subagent registers still reach the reaper via the `background_tasks_changed` stream and the authoritative parent `Stop`. Affects only `manageLifecycle: true` streaming sessions — batch execution is untouched.

## Tests

- Updated `session-hooks.test.ts`: asserts only a `Stop` matcher is registered (never `SubagentStop`), and that a `SubagentStop` input emits no `turn_end`.
- `packages/core` full suite green (3344 passed / 1 skipped), `tsc --noEmit` clean.
- Changeset: `@herdctl/core` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session lifecycle handling so completed subagents no longer prematurely end or reap the parent session.
  * Turn-boundary events are now emitted only when the main agent’s turn ends.
  * Background tasks and scheduled jobs continue to be surfaced correctly.

* **Documentation**
  * Clarified session lifecycle and turn-boundary behavior in the SDK documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->