### PR TITLE
fix(session): defer reap on background-task completion so the re-invocation survives (#368)

### DIFF
--- a/.changeset/bg-task-completion-reap-race.md
+++ b/.changeset/bg-task-completion-reap-race.md
@@ -1,0 +1,18 @@
+---
+"@herdctl/core": patch
+---
+
+fix(session): don't reap a managed session out from under a background task's re-invocation
+
+In session drive-mode, when an asynchronous background task (a `run_in_background`
+Bash/Agent/Monitor) completed, the reaper closed the session synchronously on the
+`background_tasks_changed → empty` signal — before the SDK's re-invocation turn (which
+delivers the completed task's result) could produce output. The keeper appeared to
+"stop" the instant its background work finished, never consuming the result (#368).
+This is the asynchronous counterpart of #366/#367 (which covered only the synchronous
+`SubagentStop` path).
+
+The empty-task-set signal now arms a short grace reap instead of reaping immediately: a
+following `activity` signal (the re-invocation) cancels it, while a genuine
+fire-and-forget completion still reaps once the window elapses — so no session is leaked.
+Grace defaults to 15s and is configurable via `SessionReaperOptions.reinvocationGraceMs`.

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import type { HookInput } from "@anthropic-ai/claude-agent-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeSession } from "../../runner/runtime/interface.js";
+import type { SDKMessage } from "../../runner/types.js";
+import { buildLifecycleHooks, tapLifecycleStream } from "../session-hooks.js";
 import { SessionReaper } from "../session-reaper.js";
 import type { SessionLifecycleSignal } from "../types.js";
 import type { WakeRegistry } from "../wake-registry.js";
 
 const tick = () => new Promise((r) => setTimeout(r, 5));
+
+// A fake timers helper is used in the #368 grace-reap tests; always restore real
+// timers afterward so an early failure can't leak fake timers into later tests.
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function* stream(messages: SDKMessage[]): AsyncGenerator<SDKMessage> {
+  for (const m of messages) yield m;
+}
 
 function fakeSession(): RuntimeSession & { close: ReturnType<typeof vi.fn> } {
   async function* empty(): AsyncGenerator<never> {}
@@ -75,18 +88,132 @@ describe("SessionReaper", () => {
     expect(session.close).not.toHaveBeenCalled();
   });
 
-  it("reaps a kept-alive session once background_tasks_changed reports empty", async () => {
-    const reaper = new SessionReaper({ registry: fakeRegistry() });
+  it("reaps a kept-alive session a grace window after background_tasks_changed empties (fire-and-forget)", async () => {
+    vi.useFakeTimers();
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry: fakeRegistry(), onReap });
     const session = fakeSession();
     const managed = reaper.manage(session, "team/agent");
 
     await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
     expect(managed.isLive()).toBe(true);
 
+    // Task set drained to empty — the reap is now DEFERRED (a re-invocation might
+    // follow), not synchronous (#368).
     await managed.handleSignal(signal({ kind: "background_tasks_changed", backgroundTasks: [] }));
+    expect(managed.isLive()).toBe(true);
+    expect(onReap).not.toHaveBeenCalled();
+
+    // No re-invocation ever arrives → the grace window elapses → reap.
+    await vi.runAllTimersAsync();
+    expect(onReap).toHaveBeenCalledWith({ agent: "team/agent", sessionId: "sess-1" });
     expect(managed.isLive()).toBe(false);
-    await tick();
     expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT reap when a re-invocation follows a completed background task (#368)", async () => {
+    vi.useFakeTimers();
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry: fakeRegistry(), onReap });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    // Turn ends with a background task live → keepAlive.
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+    // Task completes → task set empties → grace reap armed (not fired).
+    await managed.handleSignal(signal({ kind: "background_tasks_changed", backgroundTasks: [] }));
+    expect(managed.isLive()).toBe(true);
+    // The SDK re-invokes the parent with the task's result: the resumed turn's
+    // first output arrives as `activity`, which must cancel the pending reap.
+    await managed.handleSignal(signal({ kind: "activity" }));
+
+    await vi.runAllTimersAsync();
+    expect(onReap).not.toHaveBeenCalled();
+    expect(managed.isLive()).toBe(true);
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("a turn_end keepAlive supersedes a pending grace reap", async () => {
+    vi.useFakeTimers();
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+    await managed.handleSignal(signal({ kind: "background_tasks_changed", backgroundTasks: [] }));
+    // The re-invoked turn ends having launched fresh background work → keepAlive
+    // again, cancelling the pending grace reap.
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+
+    await vi.runAllTimersAsync();
+    expect(managed.isLive()).toBe(true);
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("a new background task cancels a pending grace reap", async () => {
+    vi.useFakeTimers();
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+    await managed.handleSignal(signal({ kind: "background_tasks_changed", backgroundTasks: [] }));
+    // A fresh background task registers before the grace elapses → keep alive.
+    await managed.handleSignal(
+      signal({ kind: "background_tasks_changed", backgroundTasks: [TASK] }),
+    );
+
+    await vi.runAllTimersAsync();
+    expect(managed.isLive()).toBe(true);
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("integration: a completed background task's re-invocation survives (real hook + stream ordering, #368)", async () => {
+    // Real timers with a short grace: assert the session is still live PAST the
+    // window, so a regression (activity failing to cancel) would reap and fail.
+    const reaper = new SessionReaper({ registry: fakeRegistry(), reinvocationGraceMs: 40 });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+    const sink = (s: SessionLifecycleSignal) => void managed.handleSignal(s);
+
+    // Turn 1 ends via the real Stop hook, a background task still live → keepAlive.
+    const hooks = buildLifecycleHooks(sink);
+    const stop = hooks!.Stop![0].hooks[0];
+    await stop(
+      {
+        hook_event_name: "Stop",
+        session_id: "sess-1",
+        transcript_path: "/tmp/t.jsonl",
+        cwd: "/tmp",
+        stop_hook_active: false,
+        session_crons: [],
+        background_tasks: [{ task_id: "t1", task_type: "shell", description: "gh pr checks loop" }],
+      } as unknown as HookInput,
+      undefined,
+      { signal: new AbortController().signal },
+    );
+    await tick();
+    expect(managed.isLive()).toBe(true);
+
+    // Task completes and the SDK re-invokes: the real stream yields the empty
+    // task-set change, then the resumed turn's first assistant message.
+    const messages: SDKMessage[] = [
+      {
+        type: "system",
+        subtype: "background_tasks_changed",
+        session_id: "sess-1",
+        tasks: [],
+      } as unknown as SDKMessage,
+      { type: "assistant", session_id: "sess-1" } as unknown as SDKMessage,
+    ];
+    for await (const _ of tapLifecycleStream(stream(messages), sink)) {
+      /* drain */
+    }
+
+    // Wait well past the 40ms grace: the activity must have cancelled the reap.
+    await new Promise((r) => setTimeout(r, 120));
+    expect(managed.isLive()).toBe(true);
+    expect(session.close).not.toHaveBeenCalled();
   });
 
   it("ignores background_tasks_changed when the session was never kept alive", async () => {
@@ -197,6 +324,7 @@ describe("SessionReaper", () => {
   });
 
   it("keeps processing signals after a failed reconcile (no queue wedge)", async () => {
+    vi.useFakeTimers();
     const registry = {
       reconcile: vi.fn().mockRejectedValueOnce(new Error("io")).mockResolvedValue(undefined),
     } as unknown as WakeRegistry;
@@ -208,10 +336,11 @@ describe("SessionReaper", () => {
     await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
     expect(managed.isLive()).toBe(true);
 
-    // A later signal must still be processed — the queue wasn't poisoned.
+    // A later signal must still be processed — the queue wasn't poisoned. The
+    // drain-to-empty arms a grace reap that fires once the window elapses.
     await managed.handleSignal(signal({ kind: "background_tasks_changed", backgroundTasks: [] }));
+    await vi.runAllTimersAsync();
     expect(managed.isLive()).toBe(false);
-    await tick();
     expect(session.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -280,6 +280,10 @@ class ManagedSessionImpl implements ManagedSession {
       this.pendingReapTimer = undefined;
       fire();
     }, graceMs);
+    // Don't let a pending grace reap single-handedly hold the process open on a
+    // clean shutdown (e.g. FleetManager.stop draining the event loop) — the timer
+    // still fires while other work keeps the loop alive.
+    this.pendingReapTimer.unref?.();
   }
 
   /** Cancel a pending grace reap, if one is armed. */

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -22,6 +22,20 @@ import type { WakeRegistry } from "./wake-registry.js";
 
 type Logger = ReturnType<typeof createLogger>;
 
+/**
+ * How long to hold an idle session open after its background-task set drains to
+ * empty, giving a re-invocation turn (the SDK handing the parent the completed
+ * task's result) time to announce itself via an `activity` signal before we reap.
+ *
+ * Reaping is cheap and lossless (#307), so erring generous costs only a little
+ * delayed RSS reclamation for a genuine fire-and-forget completion; erring short
+ * reintroduces #368 — reaping the session out from under the re-invocation, so
+ * the keeper "stops" the instant its background work finishes and never consumes
+ * the result. An `activity` cancels the wait early, so in the common case the
+ * full window is never spent.
+ */
+export const DEFAULT_REINVOCATION_GRACE_MS = 15_000;
+
 export interface SessionReaperOptions {
   /** Durable wake store the reaper reconciles captured crons into. */
   registry: WakeRegistry;
@@ -34,6 +48,12 @@ export interface SessionReaperOptions {
     sessionId: string;
     tasks: BackgroundTaskSummary[];
   }) => void;
+  /**
+   * Grace window (ms) before reaping a session whose background-task set just
+   * drained to empty — see {@link DEFAULT_REINVOCATION_GRACE_MS}. Overridable
+   * mainly for tests. Defaults to {@link DEFAULT_REINVOCATION_GRACE_MS}.
+   */
+  reinvocationGraceMs?: number;
 }
 
 /** A handle to a session the reaper is managing. */
@@ -66,6 +86,7 @@ export class SessionReaper {
   private readonly logger: Logger;
   private readonly onReap?: SessionReaperOptions["onReap"];
   private readonly onKeepAlive?: SessionReaperOptions["onKeepAlive"];
+  private readonly reinvocationGraceMs: number;
 
   /** Live managed sessions by resolved session id. */
   private readonly liveById = new Map<string, ManagedSessionImpl>();
@@ -75,6 +96,7 @@ export class SessionReaper {
     this.logger = options.logger ?? createLogger("session-reaper");
     this.onReap = options.onReap;
     this.onKeepAlive = options.onKeepAlive;
+    this.reinvocationGraceMs = options.reinvocationGraceMs ?? DEFAULT_REINVOCATION_GRACE_MS;
   }
 
   /** Begin managing a session's lifecycle. */
@@ -100,8 +122,13 @@ export class SessionReaper {
 
   async processSignal(managed: ManagedSessionImpl, signal: SessionLifecycleSignal): Promise<void> {
     // A new turn is producing output — the session is no longer idle-waiting, so
-    // a later background_tasks_changed must not reap it out from under a live turn.
+    // a later background_tasks_changed must not reap it out from under a live
+    // turn. This is also how a re-invocation announces itself: when the SDK hands
+    // the parent a completed background task's result, the resumed turn's first
+    // output arrives here — so cancel any grace reap that task's completion armed,
+    // or we close the session out from under the turn it just started (#368).
     if (signal.kind === "activity") {
+      managed.cancelPendingReap();
       managed.setAwaitingTasks(false);
       return;
     }
@@ -111,16 +138,32 @@ export class SessionReaper {
     // this event doesn't report session_crons (dropping stale ones would delete
     // the pending wakeups).
     if (signal.kind === "background_tasks_changed") {
-      if (managed.isAwaitingTasks() && signal.backgroundTasks.length === 0) {
-        this.reap(managed, signal.sessionId);
+      if (!managed.isAwaitingTasks()) return;
+      if (signal.backgroundTasks.length > 0) {
+        // Still (or newly) holding live background work — keep the session and
+        // drop any grace reap a prior drain-to-empty had armed.
+        managed.cancelPendingReap();
+        return;
       }
+      // The task set drained to empty. A completing background task is normally
+      // followed a beat later by a re-invocation turn (the SDK delivering its
+      // result), which surfaces as an `activity` signal. Reaping synchronously
+      // here closes the session out from under that re-invocation — the keeper
+      // appears to "stop" the instant its background work finishes, never
+      // consuming the result (#368). So arm a short grace reap: an `activity`
+      // cancels it if a re-invocation arrives; otherwise (a genuine
+      // fire-and-forget) it fires and reaps, so the session is never leaked.
+      managed.armPendingReap(this.reinvocationGraceMs, () => this.reap(managed, signal.sessionId));
       return;
     }
 
-    // turn_end: authoritative snapshot. Capture pending crons first so they
-    // survive whatever we decide next. A reconcile I/O failure loses that turn's
-    // capture but must NOT block the reap — leaving the session alive is the leak
-    // this module exists to prevent — so log and press on with the decision.
+    // turn_end: the authoritative snapshot supersedes any pending grace reap.
+    managed.cancelPendingReap();
+
+    // Capture pending crons first so they survive whatever we decide next. A
+    // reconcile I/O failure loses that turn's capture but must NOT block the reap
+    // — leaving the session alive is the leak this module exists to prevent — so
+    // log and press on with the decision.
     try {
       await this.registry.reconcile(managed.agent, signal.sessionId, signal.sessionCrons);
     } catch (error) {
@@ -181,6 +224,8 @@ class ManagedSessionImpl implements ManagedSession {
   private closing = false;
   private awaitingTasks = false;
   private queue: Promise<void> = Promise.resolve();
+  /** A deferred reap armed when the background-task set drained to empty (#368). */
+  private pendingReapTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(session: RuntimeSession, agent: string, reaper: SessionReaper) {
     this.session = session;
@@ -224,6 +269,27 @@ class ManagedSessionImpl implements ManagedSession {
     this.awaitingTasks = value;
   }
 
+  /**
+   * Arm a deferred reap that a subsequent `activity` (a re-invocation) — or new
+   * background work, or an authoritative turn_end — can cancel. Re-arming resets
+   * the window. See {@link SessionReaper.processSignal} and #368.
+   */
+  armPendingReap(graceMs: number, fire: () => void): void {
+    this.cancelPendingReap();
+    this.pendingReapTimer = setTimeout(() => {
+      this.pendingReapTimer = undefined;
+      fire();
+    }, graceMs);
+  }
+
+  /** Cancel a pending grace reap, if one is armed. */
+  cancelPendingReap(): void {
+    if (this.pendingReapTimer !== undefined) {
+      clearTimeout(this.pendingReapTimer);
+      this.pendingReapTimer = undefined;
+    }
+  }
+
   detach(): void {
     this.markDone();
   }
@@ -244,6 +310,7 @@ class ManagedSessionImpl implements ManagedSession {
 
   private markDone(): void {
     this.live = false;
+    this.cancelPendingReap();
     if (this.resolvedSessionId) this.reaper.unregisterLive(this.resolvedSessionId);
   }
 }


### PR DESCRIPTION
Fixes #368.

## Problem

In session drive-mode, when an **asynchronous background task** (a `run_in_background` Bash / `Agent` / `Monitor`) completes, the SDK injects a re-invocation turn to hand the parent the task's result. But the reaper closed the session **synchronously** on the `background_tasks_changed → empty` signal — before that re-invocation turn produced any output. The keeper appeared to "stop" the instant its background work finished, never consuming the result.

This is the **asynchronous** counterpart of #366 / #367, which fixed only the *synchronous* `SubagentStop` path. The `awaitingTasks` + `activity` guard added there doesn't hold here: `tapLifecycleStream` emits the empty `background_tasks_changed` **before** the re-invoked turn's first `assistant` message (`activity`), and both are processed FIFO — so the reap wins the race deterministically.

Observed in the wild on a keeper (core 5.20.0, i.e. *with* the #367 fix): it backgrounded a CI-watch loop, ended its turn ("I'll be re-invoked when CI resolves"), the loop finished, the re-invocation notification was injected into the transcript — and then nothing, the session closed. CI had actually passed; the result was simply never consumed.

## Fix

`background_tasks_changed → empty` now **arms a short grace reap** instead of reaping synchronously:

- an `activity` signal (the re-invocation starting to produce output) **cancels** the pending reap, so the resumed turn runs to completion;
- new/continuing background work (`background_tasks_changed` with tasks, or a `turn_end` keepAlive) also cancels it;
- if nothing re-invokes — a genuine fire-and-forget completion — the timer fires and reaps, so **no session is leaked** (the invariant #307 exists to protect).

Grace defaults to `DEFAULT_REINVOCATION_GRACE_MS` (15s) and is configurable via `SessionReaperOptions.reinvocationGraceMs`. Reaping is cheap and lossless (#307), so a generous window costs only slightly delayed RSS reclamation for the rare fire-and-forget; an `activity` cancels it early in the common case, so the full window is almost never spent.

## Tests

Added to `session-reaper.test.ts` (all five fail against the pre-fix source, confirming they catch the bug):

- **does NOT reap when a re-invocation follows a completed background task (#368)** — the core case.
- **reaps after the grace window when nothing re-invokes (fire-and-forget)** — leak-prevention preserved.
- **a `turn_end` keepAlive supersedes a pending grace reap.**
- **a new background task cancels a pending grace reap.**
- **integration** — drives the *real* `buildLifecycleHooks` Stop hook + `tapLifecycleStream` emission ordering end-to-end and asserts the session survives past the grace window.

Existing immediate-reap assertions were updated to the deferred semantics. Full `@herdctl/core` suite green (3348 passed, 1 skipped), `typecheck` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background task completion handling to prevent sessions from closing before task results are delivered.
  * Added a brief grace period for session re-invocation after background work finishes.
  * Preserved cleanup for genuinely completed fire-and-forget tasks.

* **Configuration**
  * Added an optional setting to customize the re-invocation grace period, defaulting to 15 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->