### PR TITLE
feat(chat): emit in-flight tool_use via onToolStart

### DIFF
--- a/.changeset/on-tool-start-371.md
+++ b/.changeset/on-tool-start-371.md
@@ -1,0 +1,16 @@
+---
+"@herdctl/chat": minor
+---
+
+feat(chat): emit in-flight tool_use via a new `onToolStart` handler
+
+`SDKMessageTranslator` previously only surfaced a tool call once its `tool_use`
+was paired with the eventual `tool_result` (via `onToolCall`), so long-running
+tools — especially subagents (`Task`/`Agent`) that run for minutes — were
+invisible to consumers until they completed. Adds an optional
+`onToolStart(toolUse: TranslatedToolStart)` handler fired from `handleAssistant`
+the moment a `tool_use` block appears, carrying `{ toolName, inputSummary,
+toolUseId, parentToolUseId }`. Consumers can render a pending/"running…" row
+keyed by `toolUseId` and reconcile it against the existing `onToolCall`
+completion. Backward compatible (the handler is optional; `onToolCall` is
+unchanged) and fires regardless of the `toolResults` option. Refs #371.

--- a/packages/chat/src/__tests__/sdk-message-translator.test.ts
+++ b/packages/chat/src/__tests__/sdk-message-translator.test.ts
@@ -8,6 +8,7 @@ import {
   createSDKMessageHandler,
   SDKMessageTranslator,
   type TranslatedToolCall,
+  type TranslatedToolStart,
 } from "../sdk-message-translator.js";
 
 // =============================================================================
@@ -364,6 +365,85 @@ describe("SDKMessageTranslator", () => {
         expect(calls[0].durationMs).toBeUndefined();
         expect(calls[0].toolUseId).toBeUndefined();
       });
+    });
+  });
+
+  describe("tool starts (in-flight)", () => {
+    it("emits onToolStart immediately when a tool_use appears, before any result", async () => {
+      const starts: TranslatedToolStart[] = [];
+      const calls: TranslatedToolCall[] = [];
+      const t = new SDKMessageTranslator({
+        onToolStart: (s) => void starts.push(s),
+        onToolCall: (c) => void calls.push(c),
+      });
+
+      await t.handle(assistantToolUse("t1", "Bash", { command: "sleep 300" }));
+
+      // Fires before the tool_result arrives — no completion yet.
+      expect(starts).toHaveLength(1);
+      expect(starts[0]).toEqual({
+        toolName: "Bash",
+        inputSummary: "sleep 300",
+        toolUseId: "t1",
+        parentToolUseId: null,
+      });
+      expect(calls).toHaveLength(0);
+    });
+
+    it("reconciles: onToolStart then onToolCall share the same toolUseId", async () => {
+      const starts: TranslatedToolStart[] = [];
+      const calls: TranslatedToolCall[] = [];
+      const t = new SDKMessageTranslator({
+        onToolStart: (s) => void starts.push(s),
+        onToolCall: (c) => void calls.push(c),
+      });
+
+      await t.handle(assistantToolUse("t1", "Task", { description: "do work" }));
+      await t.handle(toolResult("t1", "done"));
+
+      expect(starts).toHaveLength(1);
+      expect(calls).toHaveLength(1);
+      expect(starts[0].toolUseId).toBe("t1");
+      expect(calls[0].toolUseId).toBe("t1");
+    });
+
+    it("attributes a subagent's in-flight tool_use to its spawning Task id", async () => {
+      const starts: TranslatedToolStart[] = [];
+      const t = new SDKMessageTranslator({ onToolStart: (s) => void starts.push(s) });
+
+      await t.handle(subagentToolUse("s1", "Grep", "task-42", { pattern: "foo" }));
+
+      expect(starts).toHaveLength(1);
+      expect(starts[0]).toEqual({
+        toolName: "Grep",
+        inputSummary: "foo",
+        toolUseId: "s1",
+        parentToolUseId: "task-42",
+      });
+    });
+
+    it("still fires onToolStart when toolResults is false (independent concern)", async () => {
+      const onToolStart = vi.fn();
+      const onToolCall = vi.fn();
+      const t = new SDKMessageTranslator({ onToolStart, onToolCall }, { toolResults: false });
+
+      await t.handle(assistantToolUse("t1", "Bash", { command: "ls" }));
+      await t.handle(toolResult("t1", "out"));
+
+      expect(onToolStart).toHaveBeenCalledTimes(1);
+      expect(onToolCall).not.toHaveBeenCalled();
+    });
+
+    it("does not require onToolStart to be present (backward compatible)", async () => {
+      const calls: TranslatedToolCall[] = [];
+      const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+      // No onToolStart handler — must not throw.
+      await t.handle(assistantToolUse("t1", "Bash", { command: "echo hi" }));
+      await t.handle(toolResult("t1", "hi"));
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].toolName).toBe("Bash");
     });
   });
 

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -139,6 +139,7 @@ export {
   type SDKMessageTranslatorOptions,
   // Types
   type TranslatedToolCall,
+  type TranslatedToolStart,
 } from "./sdk-message-translator.js";
 
 // =============================================================================

--- a/packages/chat/src/sdk-message-translator.ts
+++ b/packages/chat/src/sdk-message-translator.ts
@@ -61,6 +61,28 @@ export interface TranslatedToolCall {
 }
 
 /**
+ * An in-flight tool_use, surfaced the moment it appears in an assistant message
+ * — before the tool has run or produced any result. Consumers use this to
+ * render a pending/"running…" affordance (keyed by {@link toolUseId}) for slow
+ * tools, then reconcile it against the eventual {@link TranslatedToolCall} once
+ * the tool_result arrives.
+ */
+export interface TranslatedToolStart {
+  /** Tool name (e.g. "Bash", "Read", "Task") */
+  toolName: string;
+  /** Human-readable summary of the tool input (e.g. the bash command or file path) */
+  inputSummary?: string;
+  /** The originating tool_use id — the key to reconcile with the later result */
+  toolUseId?: string;
+  /**
+   * Agent attribution: `null` when the main agent invoked the tool, or the
+   * `Task` tool_use id of the subagent that invoked it. Mirrors
+   * {@link TranslatedToolCall.parentToolUseId}.
+   */
+  parentToolUseId: string | null;
+}
+
+/**
  * Handlers invoked as SDK messages are translated. All are optional and may be
  * async; the translator awaits them in order so transports can apply
  * backpressure (e.g. a slow WebSocket send).
@@ -81,6 +103,15 @@ export interface SDKMessageHandlers {
    * attribution identifies the agent whose turn is beginning.
    */
   onBoundary?: (attribution: AgentAttribution) => void | Promise<void>;
+  /**
+   * Called as soon as a tool_use block appears in an assistant message —
+   * before the tool has run or produced a result. Lets consumers render an
+   * in-flight/"running…" affordance for slow tools (especially subagents that
+   * run for minutes) keyed by `toolUseId`, then reconcile it with the eventual
+   * completion via {@link onToolCall}. Fires regardless of the `toolResults`
+   * option; optional and backward compatible.
+   */
+  onToolStart?: (toolUse: TranslatedToolStart) => void | Promise<void>;
   /** Called once per tool result, paired with its originating tool_use. */
   onToolCall?: (toolCall: TranslatedToolCall) => void | Promise<void>;
 }
@@ -271,6 +302,16 @@ export class SDKMessageTranslator {
           name: block.name,
           input: block.input,
           startTime: this.now(),
+          parentToolUseId: attribution.parentToolUseId,
+        });
+        // Surface the tool_use immediately, before it runs, so consumers can
+        // render a pending/"running…" row. The eventual tool_result drives
+        // onToolCall (below) to reconcile it. Fires even when toolResults is
+        // disabled — onToolStart is an independent, opt-in concern.
+        await this.handlers.onToolStart?.({
+          toolName: block.name,
+          inputSummary: getToolInputSummary(block.name, block.input),
+          toolUseId: block.id,
           parentToolUseId: attribution.parentToolUseId,
         });
       }


### PR DESCRIPTION
Closes #371.

## Problem

`SDKMessageTranslator` only surfaces a tool call once its `tool_use` is *paired* with the eventual `tool_result` (via `onToolCall`). For long-running tools — **especially subagents (`Task`/`Agent`) that run for minutes** — this means downstream connectors (Paddock's web UI, Slack, etc.) show **nothing at all** for that tool until it completes: no "running…" affordance, no way to tell a subagent is in flight or stuck.

## Change

Adds an optional **`onToolStart`** handler to `SDKMessageHandlers`, fired from `handleAssistant` the moment a `tool_use` block appears — before the tool runs. It carries a new `TranslatedToolStart`:

```ts
interface TranslatedToolStart {
  toolName: string;
  inputSummary?: string;
  toolUseId?: string;        // key to reconcile with the later result
  parentToolUseId: string | null;  // subagent attribution (null = main agent)
}
```

Consumers render a pending row keyed by `toolUseId`, then reconcile it against the existing `onToolCall` completion (which is unchanged).

## Compatibility

- **Backward compatible** — the handler is optional; consumers that only implement `onToolCall` are unaffected.
- Fires **regardless of the `toolResults` option** (it's an independent, opt-in concern).
- No change to `onToolCall` / `TranslatedToolCall` semantics.

## Tests

5 new tests in `sdk-message-translator.test.ts` (in-flight emission before result, start↔call reconciliation by `toolUseId`, subagent attribution, fires when `toolResults:false`, backward-compat with no handler). Full `@herdctl/chat` suite green (282 tests), typecheck + build clean.

Changeset: `@herdctl/chat` **minor** (0.5.5 → 0.6.0). Core unchanged (additive in chat only).

Downstream consumer: **edspencer/paddock#175**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `onToolStart` handler that reports tools immediately when they begin running.
  * Tool-start events include the tool name, input summary, tool ID, and parent tool ID.
  * Tool-start notifications work independently of tool-result handling, including when results are disabled.
  * Added the `TranslatedToolStart` type for integrations.

* **Documentation**
  * Added release notes describing the new backward-compatible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->