### PR TITLE
feat(core): scheduler host-execution seam + runtime schedule mutation (#375, #376)

### DIFF
--- a/.changeset/scheduler-host-seam-and-runtime-mutation.md
+++ b/.changeset/scheduler-host-seam-and-runtime-mutation.md
@@ -1,0 +1,28 @@
+---
+"@herdctl/core": minor
+---
+
+Scheduler: host-execution seam + runtime schedule mutation (additive, backward-compatible)
+
+Make the scheduler embeddable so a host can own execution and mutate schedules at
+runtime. Existing headless fleets are unchanged — every new capability is opt-in.
+
+- **Host-execution seam (#375):** `FleetManager.setScheduleTriggerHandler(handler)`
+  mirrors `setSessionWakeHandler`. When set, a fired schedule routes to the host
+  handler (which can resume/stream the turn on its own hub) instead of the built-in
+  headless `ScheduleExecutor`; when unset, schedules run headless exactly as before.
+  Cron/interval timing is untouched. Every scheduler-fired trigger — including a
+  forced immediate fire — funnels through this seam.
+- **Relative-wake timezone hardening (#311):** `resolveSystemTimeZone()` centralizes
+  the host-timezone lookup used by `calculateNextCronTrigger`/
+  `calculatePreviousCronTrigger`, falling back to `UTC` when an ICU-less runtime
+  reports no timezone (which could otherwise revive the 24h-idle bug).
+- **Runtime schedule mutation (#376):** `FleetManager.setAgentSchedule(agent, name,
+  schedule)` and `removeAgentSchedule(agent, name)` add/remove a single schedule on a
+  registered agent without a whole-agent `addAgent(replace)`. Removal prunes persisted
+  state via the new `deleteScheduleState` helper and clears the scheduler's in-memory
+  tracking (`Scheduler.clearScheduleTracking`), so a re-added name never inherits a
+  stale `last_run_at`/`disabled` status.
+- **Mutation gate:** a new `allowScheduleMutation` FleetManager option (default
+  `false`) gates the two mutation methods; when disabled they throw the new
+  `ScheduleMutationDisabledError`. Enable/disable of existing schedules stays ungated.

--- a/.changeset/scheduler-host-seam-and-runtime-mutation.md
+++ b/.changeset/scheduler-host-seam-and-runtime-mutation.md
@@ -19,10 +19,17 @@ runtime. Existing headless fleets are unchanged — every new capability is opt-
   reports no timezone (which could otherwise revive the 24h-idle bug).
 - **Runtime schedule mutation (#376):** `FleetManager.setAgentSchedule(agent, name,
   schedule)` and `removeAgentSchedule(agent, name)` add/remove a single schedule on a
-  registered agent without a whole-agent `addAgent(replace)`. Removal prunes persisted
-  state via the new `deleteScheduleState` helper and clears the scheduler's in-memory
-  tracking (`Scheduler.clearScheduleTracking`), so a re-added name never inherits a
-  stale `last_run_at`/`disabled` status.
+  registered agent without a whole-agent `addAgent(replace)`. `setAgentSchedule` also
+  normalizes a lingering persisted `disabled` status to `idle` (via the new
+  `armScheduleState` helper) so a set-after-disable is actually eligible to fire.
+  Removal prunes persisted state via the new `deleteScheduleState` helper.
+- **Concurrency-safe mutation:** schedule-state read-modify-writes are now serialized
+  per state file (no lost sibling updates), `deleteScheduleState` tombstones the key so
+  an in-flight run's trailing write can't resurrect deleted state, and an in-flight
+  run's running-set entry is retained (only warn-once bookkeeping is cleared) so a
+  same-name re-add can't start a second concurrent execution. Full generation-fencing
+  of an old run's completion write after a same-name re-add is deferred (documented);
+  the residual is bounded, non-resurrecting, and self-correcting.
 - **Mutation gate:** a new `allowScheduleMutation` FleetManager option (default
   `false`) gates the two mutation methods; when disabled they throw the new
   `ScheduleMutationDisabledError`. Enable/disable of existing schedules stays ungated.

--- a/.changeset/scheduler-host-seam-and-runtime-mutation.md
+++ b/.changeset/scheduler-host-seam-and-runtime-mutation.md
@@ -28,15 +28,16 @@ runtime. Existing headless fleets are unchanged — every new capability is opt-
   tombstoned so that run's trailing write can't resurrect deleted state; and the
   in-flight run's running-set entry is retained (only warn-once bookkeeping is cleared)
   so a same-name re-add can't start a second concurrent execution. The tombstone is
-  bounded and self-clearing: `setAgents` lifts it for every schedule present in an
-  updated agent list — so `reload()` / `addAgent({replace})` / `setAgentSchedule` all
-  re-arm a removed name cleanly instead of leaving it tombstoned (which would no-op every
-  state write and cause runaway per-tick firing) — and it is also lifted when the
-  in-flight run completes or when removal finds no run in flight. `removeAgentSchedule`
-  is in-memory-only (like `addAgent`/`removeAgent`): it does not rewrite `herdctl.yaml`,
-  so a later `reload()` legitimately brings the schedule back. Full generation-fencing of
-  an old run's completion write after a same-name re-add is deferred (documented); the
-  residual is bounded, non-resurrecting, and self-correcting.
+  coordinated with the active execution generation so it is neither left set nor cleared
+  too early: `setAgents` lifts it for a re-armed schedule **only when no run for that key
+  is in flight** — so `reload()` / `addAgent({replace})` / `setAgentSchedule` re-arm a
+  removed name cleanly (no runaway per-tick firing from a stuck tombstone) while a still
+  in-flight removed generation's trailing `next_run_at`/`last_error` write stays
+  suppressed (can't contaminate the freshly re-added schedule); the tombstone is then
+  lifted by that run's own `executeJob` finally on completion, or immediately by the
+  remover when no run is in flight. `removeAgentSchedule` is in-memory-only (like
+  `addAgent`/`removeAgent`): it does not rewrite `herdctl.yaml`, so a later `reload()`
+  legitimately brings the schedule back.
 - **Mutation gate:** a new `allowScheduleMutation` FleetManager option (default
   `false`) gates the two mutation methods; when disabled they throw the new
   `ScheduleMutationDisabledError`. Enable/disable of existing schedules stays ungated.

--- a/.changeset/scheduler-host-seam-and-runtime-mutation.md
+++ b/.changeset/scheduler-host-seam-and-runtime-mutation.md
@@ -24,12 +24,19 @@ runtime. Existing headless fleets are unchanged — every new capability is opt-
   `armScheduleState` helper) so a set-after-disable is actually eligible to fire.
   Removal prunes persisted state via the new `deleteScheduleState` helper.
 - **Concurrency-safe mutation:** schedule-state read-modify-writes are now serialized
-  per state file (no lost sibling updates), `deleteScheduleState` tombstones the key so
-  an in-flight run's trailing write can't resurrect deleted state, and an in-flight
-  run's running-set entry is retained (only warn-once bookkeeping is cleared) so a
-  same-name re-add can't start a second concurrent execution. Full generation-fencing
-  of an old run's completion write after a same-name re-add is deferred (documented);
-  the residual is bounded, non-resurrecting, and self-correcting.
+  per state file (no lost sibling updates); a removed schedule with an in-flight run is
+  tombstoned so that run's trailing write can't resurrect deleted state; and the
+  in-flight run's running-set entry is retained (only warn-once bookkeeping is cleared)
+  so a same-name re-add can't start a second concurrent execution. The tombstone is
+  bounded and self-clearing: `setAgents` lifts it for every schedule present in an
+  updated agent list — so `reload()` / `addAgent({replace})` / `setAgentSchedule` all
+  re-arm a removed name cleanly instead of leaving it tombstoned (which would no-op every
+  state write and cause runaway per-tick firing) — and it is also lifted when the
+  in-flight run completes or when removal finds no run in flight. `removeAgentSchedule`
+  is in-memory-only (like `addAgent`/`removeAgent`): it does not rewrite `herdctl.yaml`,
+  so a later `reload()` legitimately brings the schedule back. Full generation-fencing of
+  an old run's completion write after a same-name re-add is deferred (documented); the
+  residual is bounded, non-resurrecting, and self-correcting.
 - **Mutation gate:** a new `allowScheduleMutation` FleetManager option (default
   `false`) gates the two mutation methods; when disabled they throw the new
   `ScheduleMutationDisabledError`. Enable/disable of existing schedules stays ungated.

--- a/docs/src/content/docs/library-reference/error-handling.mdx
+++ b/docs/src/content/docs/library-reference/error-handling.mdx
@@ -205,6 +205,35 @@ try {
 
 ---
 
+### ScheduleMutationDisabledError
+
+Thrown by `setAgentSchedule`/`removeAgentSchedule` when the deployment has not opted into programmatic schedule mutation (the `allowScheduleMutation` FleetManager option, which defaults to `false`).
+
+```typescript
+class ScheduleMutationDisabledError extends FleetManagerError {
+  operation: string; // e.g. "setAgentSchedule"
+}
+```
+
+**Example:**
+
+```typescript
+import { isScheduleMutationDisabledError } from '@herdctl/core';
+
+try {
+  await manager.setAgentSchedule('my-agent', 'hourly', { type: 'interval', interval: '1h' });
+} catch (error) {
+  if (isScheduleMutationDisabledError(error)) {
+    console.error(
+      `Cannot ${error.operation}: construct the FleetManager with ` +
+        `{ allowScheduleMutation: true } to enable runtime schedule mutation.`
+    );
+  }
+}
+```
+
+---
+
 ### InvalidStateError
 
 Thrown when an operation is attempted in an incompatible state.
@@ -938,6 +967,9 @@ const FleetManagerErrorCode = {
   AGENT_NOT_FOUND: 'AGENT_NOT_FOUND',
   JOB_NOT_FOUND: 'JOB_NOT_FOUND',
   SCHEDULE_NOT_FOUND: 'SCHEDULE_NOT_FOUND',
+
+  // Schedule mutation gate
+  SCHEDULE_MUTATION_DISABLED: 'SCHEDULE_MUTATION_DISABLED',
 
   // State
   INVALID_STATE: 'INVALID_STATE',

--- a/docs/src/content/docs/library-reference/fleet-manager.mdx
+++ b/docs/src/content/docs/library-reference/fleet-manager.mdx
@@ -603,6 +603,8 @@ await manager.setAgentSchedule(
 
 The programmatic counterpart to editing an agent's `schedules` in `herdctl.yaml` and calling `reload()`, scoped to one schedule. Unlike `enableSchedule`/`disableSchedule` (which flip persisted state), this changes the agent's *configuration*: the schedule is validated against `ScheduleSchema`, set on the stored agent, and the updated agent list is re-pushed to the scheduler — so it is immediately eligible to fire (or picks up new timing when replacing an existing name) without a whole-agent `addAgent({ replace: true })`, which would leave stale state. A `config:reloaded` event is emitted.
 
+If a schedule of the same name was previously **disabled**, this also normalizes the lingering persisted `disabled` status back to `idle` — otherwise the scheduler (which reads status from persisted state, not config) would keep skipping it and it would never fire.
+
 Gated behind the [`allowScheduleMutation`](#constructor) deployment option — it throws `ScheduleMutationDisabledError` when mutation is not enabled.
 
 #### Example
@@ -636,7 +638,9 @@ await manager.removeAgentSchedule(agentName: string, scheduleName: string): Prom
 
 #### Description
 
-Deletes the schedule from the stored agent and the scheduler, **prunes its persisted state**, and clears the scheduler's in-memory tracking for it. The prune matters: the scheduler decides `disabled`/next-run from state, not config, so without it a later re-add of the same name would inherit the removed schedule's stale `last_run_at`/`disabled` status. Returns `true` if a schedule was removed, `false` if the agent had no such schedule. A `config:reloaded` event is emitted.
+Deletes the schedule from the stored agent and the scheduler and **prunes its persisted state**. The prune matters: the scheduler decides `disabled`/next-run from state, not config, so without it a later re-add of the same name would inherit the removed schedule's stale `last_run_at`/`disabled` status. Returns `true` if a schedule was removed, `false` if the agent had no such schedule. A `config:reloaded` event is emitted.
+
+Removal is coordinated so it is safe to call while the scheduler is actively firing: the persisted-state read-modify-write is serialized (no lost sibling updates), the pruned key is tombstoned so a still-in-flight run's trailing write can't resurrect it, and any in-flight run's tracking is retained until it completes so a same-name re-add can't start a second concurrent execution. The removed schedule's own in-flight run (if any) is not cancelled — it finishes naturally.
 
 Gated behind the [`allowScheduleMutation`](#constructor) deployment option — it throws `ScheduleMutationDisabledError` when mutation is not enabled.
 

--- a/docs/src/content/docs/library-reference/fleet-manager.mdx
+++ b/docs/src/content/docs/library-reference/fleet-manager.mdx
@@ -61,6 +61,7 @@ const manager = new FleetManager(options: FleetManagerOptions);
 | `options.logger` | `FleetManagerLogger` | No | Console logger | Custom logger with `debug`, `info`, `warn`, `error` methods. |
 | `options.checkInterval` | `number` | No | `1000` | Interval in milliseconds between scheduler checks. |
 | `options.configOverrides` | `FleetConfigOverrides` | No | — | Runtime overrides applied after the config file is loaded and parsed — lets CLI flags or programmatic callers override specific fleet-level values. Currently supports `web` (`enabled`, `port`, `host`). |
+| `options.allowScheduleMutation` | `boolean` | No | `false` | Per-deployment gate for programmatic schedule mutation. When `false`, [`setAgentSchedule`](#setagentscheduleagentname-schedulename-schedule) and [`removeAgentSchedule`](#removeagentscheduleagentname-schedulename) throw `ScheduleMutationDisabledError`. An embedding host that exposes a schedule-editing surface opts in by setting this to `true`. Does not affect enable/disable of existing schedules. |
 
 ```typescript
 interface FleetConfigOverrides {
@@ -583,6 +584,77 @@ console.log(`Schedule status: ${schedule.status}`); // 'disabled'
 // Later, re-enable it
 await manager.enableSchedule('my-agent', 'hourly');
 ```
+
+---
+
+### `setAgentSchedule(agentName, scheduleName, schedule)`
+
+Adds or replaces a single schedule on an already-registered agent at runtime.
+
+```typescript
+await manager.setAgentSchedule(
+  agentName: string,
+  scheduleName: string,
+  schedule: Schedule
+): Promise<ScheduleInfo>
+```
+
+#### Description
+
+The programmatic counterpart to editing an agent's `schedules` in `herdctl.yaml` and calling `reload()`, scoped to one schedule. Unlike `enableSchedule`/`disableSchedule` (which flip persisted state), this changes the agent's *configuration*: the schedule is validated against `ScheduleSchema`, set on the stored agent, and the updated agent list is re-pushed to the scheduler — so it is immediately eligible to fire (or picks up new timing when replacing an existing name) without a whole-agent `addAgent({ replace: true })`, which would leave stale state. A `config:reloaded` event is emitted.
+
+Gated behind the [`allowScheduleMutation`](#constructor) deployment option — it throws `ScheduleMutationDisabledError` when mutation is not enabled.
+
+#### Example
+
+```typescript
+const schedule = await manager.setAgentSchedule('my-agent', 'hourly', {
+  type: 'interval',
+  interval: '1h',
+  prompt: 'Do the hourly sweep',
+});
+console.log(`Armed ${schedule.name} (${schedule.type})`);
+```
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `ScheduleMutationDisabledError` | `allowScheduleMutation` is not enabled |
+| `AgentNotFoundError` | The agent doesn't exist |
+| `ConfigurationError` | The schedule fails schema validation |
+
+---
+
+### `removeAgentSchedule(agentName, scheduleName)`
+
+Removes a single schedule from an agent at runtime.
+
+```typescript
+await manager.removeAgentSchedule(agentName: string, scheduleName: string): Promise<boolean>
+```
+
+#### Description
+
+Deletes the schedule from the stored agent and the scheduler, **prunes its persisted state**, and clears the scheduler's in-memory tracking for it. The prune matters: the scheduler decides `disabled`/next-run from state, not config, so without it a later re-add of the same name would inherit the removed schedule's stale `last_run_at`/`disabled` status. Returns `true` if a schedule was removed, `false` if the agent had no such schedule. A `config:reloaded` event is emitted.
+
+Gated behind the [`allowScheduleMutation`](#constructor) deployment option — it throws `ScheduleMutationDisabledError` when mutation is not enabled.
+
+#### Example
+
+```typescript
+const removed = await manager.removeAgentSchedule('my-agent', 'hourly');
+
+// A later re-add starts clean — no stale disabled/last_run_at.
+await manager.setAgentSchedule('my-agent', 'hourly', { type: 'interval', interval: '1h' });
+```
+
+#### Throws
+
+| Error | Condition |
+|-------|-----------|
+| `ScheduleMutationDisabledError` | `allowScheduleMutation` is not enabled |
+| `AgentNotFoundError` | The agent doesn't exist |
 
 ---
 
@@ -1288,6 +1360,40 @@ manager.setSessionWakeHandler(async (session, entry) => {
 <Aside type="note">
 Cron expressions in session wakes are resolved in the **host's local timezone**, not UTC — matching how Claude Code serializes `ScheduleWakeup`/`CronCreate` schedules and how the scheduler resolves fleet crons. One-shot wakes are removed after firing; recurring wakes re-arm on each fire and auto-expire 7 days after capture.
 </Aside>
+
+---
+
+### `setScheduleTriggerHandler(handler)`
+
+Registers the consumer hook that owns execution of fired **config schedules** (interval/cron), mirroring `setSessionWakeHandler`.
+
+```typescript
+manager.setScheduleTriggerHandler(
+  handler: ScheduleTriggerHandler | undefined
+): void
+
+type ScheduleTriggerHandler = (info: TriggerInfo) => void | Promise<void>;
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `handler` | `ScheduleTriggerHandler \| undefined` | **Yes** | Called with the `TriggerInfo` (agent, schedule name, schedule config, current state) each time a schedule fires. Pass `undefined` to restore headless execution |
+
+#### Description
+
+When a schedule is due, herdctl normally runs it headlessly via the built-in `ScheduleExecutor` (a fresh `JobExecutor` run). Registering a handler intercepts **execution** — every scheduler-fired trigger is routed to the handler instead, so an embedding host can run the turn on its own resume/hub path and stream it into its UI. The scheduler's cron/interval **timing is unchanged**; only what happens on a due trigger is swapped. When no handler is registered, schedules run headless exactly as before, so recurring fires keep working. Safe to call before or after `initialize()`.
+
+#### Example
+
+```typescript
+manager.setScheduleTriggerHandler(async (info) => {
+  console.log(`Schedule ${info.agent.qualifiedName}/${info.scheduleName} fired`);
+  // Run the turn on your own path (e.g. resume + stream into a chat UI)
+  await runOnHub(info);
+});
+```
 
 ---
 

--- a/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
@@ -351,25 +351,38 @@ describe("FleetManager schedule seam + runtime mutation", () => {
       expect(reAdded.lastRunAt).toBeNull();
     });
 
-    it("remove+re-add while a handler run is in flight: no double-execution, no resurrected state", async () => {
+    it("remove+re-add while a run is in flight: tombstone held during the run, old-run write can't contaminate the re-add", async () => {
       const manager = createManager({ allowScheduleMutation: true });
       await manager.initialize();
 
       let inFlight = 0;
       let maxInFlight = 0;
       let calls = 0;
-      let releaseFirstRun: () => void = () => {};
-      const firstRunGate = new Promise<void>((resolve) => {
-        releaseFirstRun = resolve;
+      let releaseGen0: () => void = () => {};
+      let releaseGen1: () => void = () => {};
+      const gen0Gate = new Promise<void>((resolve) => {
+        releaseGen0 = resolve;
+      });
+      const gen1Gate = new Promise<void>((resolve) => {
+        releaseGen1 = resolve;
       });
 
       manager.setScheduleTriggerHandler(async () => {
-        calls += 1;
+        const generation = ++calls;
         inFlight += 1;
         maxInFlight = Math.max(maxInFlight, inFlight);
-        // Hold only the first run open; it stays "in flight" across the mutation.
-        if (calls === 1) await firstRunGate;
-        inFlight -= 1;
+        try {
+          if (generation === 1) {
+            await gen0Gate;
+            // The removed generation-0 run fails → executeJob writes last_error.
+            // That write must be suppressed by the tombstone (not contaminate the
+            // re-added schedule).
+            throw new Error("gen-0 boom");
+          }
+          if (generation === 2) await gen1Gate;
+        } finally {
+          inFlight -= 1;
+        }
       });
 
       await manager.addAgent({
@@ -380,28 +393,41 @@ describe("FleetManager schedule seam + runtime mutation", () => {
       });
       await manager.start();
 
-      // Wait until the first run is actually in flight (handler entered + gated).
+      // Generation-0 run is now in flight and gated.
       await waitFor(() => calls === 1);
 
-      // While that run is still executing, remove and immediately re-add the
-      // same name. Removal must not resurrect deleted state, and the retained
-      // running-set entry must prevent a second concurrent fire of the re-add.
+      // Remove (while running → tombstoned) then immediately re-add the name.
       await manager.removeAgentSchedule("sched-agent", "tick");
       await manager.setAgentSchedule("sched-agent", "tick", {
         type: "interval",
         interval: "1h",
       });
 
-      // Let the in-flight run finish, then settle.
-      releaseFirstRun();
-      await new Promise((resolve) => setTimeout(resolve, 120));
+      // The tombstone MUST remain set while gen-0's run is still in flight — the
+      // re-add must not clear it early (that would let gen-0's trailing write land
+      // on the re-added schedule).
+      expect(isScheduleTombstoned(stateDir, "sched-agent", "tick")).toBe(true);
+
+      // Release gen-0 (it throws). Its last_error write is suppressed; its
+      // executeJob finally then lifts the tombstone, arming generation 1, which we
+      // gate so we can inspect state before it overwrites anything.
+      releaseGen0();
+      await waitFor(() => calls === 2);
+
+      // gen-0's "boom" error did NOT persist onto the re-added schedule, and the
+      // tombstone has been lifted now that the removed run is done.
+      const duringGen1 = await manager.getSchedule("sched-agent", "tick");
+      expect(duringGen1.lastError).toBeNull();
+      expect(isScheduleTombstoned(stateDir, "sched-agent", "tick")).toBe(false);
+
+      releaseGen1();
+      await new Promise((resolve) => setTimeout(resolve, 60));
       await manager.stop();
 
       // No point had two concurrent executions of the schedule.
       expect(maxInFlight).toBe(1);
 
-      // The re-added schedule's persisted state is clean, not a resurrected
-      // disabled/errored entry.
+      // Final state is clean — no resurrected/contaminated error.
       const reAdded = await manager.getSchedule("sched-agent", "tick");
       expect(reAdded.status).not.toBe("disabled");
       expect(reAdded.lastError).toBeNull();

--- a/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
@@ -24,7 +24,10 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ResolvedAgent } from "../../config/index.js";
-import { isScheduleTombstoned, type TriggerInfo } from "../../scheduler/index.js";
+import type { TriggerInfo } from "../../scheduler/index.js";
+// Internal-only helper (not re-exported from the scheduler index / package root):
+// import directly from its source module.
+import { isScheduleTombstoned } from "../../scheduler/schedule-state.js";
 import { AgentNotFoundError, ScheduleMutationDisabledError } from "../errors.js";
 import { FleetManager } from "../fleet-manager.js";
 

--- a/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
@@ -24,7 +24,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ResolvedAgent } from "../../config/index.js";
-import type { TriggerInfo } from "../../scheduler/index.js";
+import { isScheduleTombstoned, type TriggerInfo } from "../../scheduler/index.js";
 import { AgentNotFoundError, ScheduleMutationDisabledError } from "../errors.js";
 import { FleetManager } from "../fleet-manager.js";
 
@@ -402,6 +402,65 @@ describe("FleetManager schedule seam + runtime mutation", () => {
       const reAdded = await manager.getSchedule("sched-agent", "tick");
       expect(reAdded.status).not.toBe("disabled");
       expect(reAdded.lastError).toBeNull();
+    });
+
+    it("remove then reload() re-arms cleanly from disk — no tombstone-driven runaway firing", async () => {
+      // The schedule is DEFINED ON DISK (agent yaml referenced by the fleet
+      // config), so reload() re-reads it after an in-memory removal. If the
+      // removal's tombstone leaked, the re-armed schedule's updateScheduleState
+      // would no-op → last_run_at never persists → it reads as perpetually due →
+      // fires every single tick.
+      const yaml = await import("yaml");
+      const agentDir = join(configDir, "agents");
+      await mkdir(agentDir, { recursive: true });
+      await writeFile(
+        join(agentDir, "sched-agent.yaml"),
+        yaml.stringify({
+          name: "sched-agent",
+          working_directory: tempDir,
+          max_turns: 1,
+          schedules: { tick: { type: "interval", interval: "1h" } },
+        }),
+      );
+      await writeFile(
+        configPath,
+        yaml.stringify({ version: 1, agents: [{ path: "./agents/sched-agent.yaml" }] }),
+      );
+
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+
+      const handler = vi.fn(async (_info: TriggerInfo) => {});
+      manager.setScheduleTriggerHandler(handler);
+      await manager.start();
+
+      // It fires once immediately (interval, no last_run), then persists last_run
+      // and waits ~1h.
+      await waitFor(() => handler.mock.calls.length >= 1);
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      const afterFirst = handler.mock.calls.length;
+
+      // Remove at runtime (in-memory only), then reload() re-reads from disk.
+      await manager.removeAgentSchedule("sched-agent", "tick");
+      await manager.reload();
+
+      // Give the scheduler ~10 ticks (checkInterval 20ms). A leaked tombstone
+      // would fire on every tick here.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await manager.stop();
+
+      // The re-arm fires at most once more (fresh state, no last_run) — not a
+      // runaway burst of one-per-tick.
+      expect(handler.mock.calls.length - afterFirst).toBeLessThanOrEqual(1);
+
+      // And normal state persistence resumed: last_run_at is recorded, so the
+      // schedule is no longer perpetually "due".
+      const state = await manager.getSchedule("sched-agent", "tick");
+      expect(state.lastRunAt).not.toBeNull();
+      expect(state.status).not.toBe("disabled");
+
+      // The re-arm lifted any tombstone (setAgents un-tombstones present schedules).
+      expect(isScheduleTombstoned(stateDir, "sched-agent", "tick")).toBe(false);
     });
   });
 

--- a/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
@@ -23,9 +23,19 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ResolvedAgent } from "../../config/index.js";
 import type { TriggerInfo } from "../../scheduler/index.js";
 import { AgentNotFoundError, ScheduleMutationDisabledError } from "../errors.js";
 import { FleetManager } from "../fleet-manager.js";
+
+/** Poll `predicate` until true or the timeout elapses. */
+async function waitFor(predicate: () => boolean, timeoutMs = 1500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
 
 const silentLogger = () => ({
   debug: vi.fn(),
@@ -151,6 +161,43 @@ describe("FleetManager schedule seam + runtime mutation", () => {
       expect(handler).not.toHaveBeenCalled();
       expect(headlessProbe).toHaveBeenCalled();
     });
+
+    it("routes a forced/immediate trigger through the host handler, not the headless path", async () => {
+      const manager = createManager();
+      await manager.initialize();
+
+      const headlessProbe = vi.fn();
+      manager.on("schedule:triggered", headlessProbe);
+      const handler = vi.fn(async (_info: TriggerInfo) => {});
+      manager.setScheduleTriggerHandler(handler);
+
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        max_turns: 1,
+        schedules: { now: { type: "interval", interval: "1h" } },
+      });
+
+      // Drive a forced trigger straight through the scheduler seam — the single
+      // entry point every scheduler-fired trigger funnels through (a due poll,
+      // a catch-up fire, or a "trigger now") — rather than waiting for the poll
+      // loop. This asserts forced triggers use the seam, not just polled ones.
+      const agent = (manager as unknown as { config: { agents: ResolvedAgent[] } }).config
+        .agents[0];
+      const info: TriggerInfo = {
+        agent,
+        scheduleName: "now",
+        schedule: agent.schedules?.now as TriggerInfo["schedule"],
+        scheduleState: { last_run_at: null, next_run_at: null, status: "idle", last_error: null },
+      };
+      await (
+        manager as unknown as { handleScheduleTrigger(i: TriggerInfo): Promise<void> }
+      ).handleScheduleTrigger(info);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].scheduleName).toBe("now");
+      expect(headlessProbe).not.toHaveBeenCalled();
+    });
   });
 
   // ===========================================================================
@@ -210,6 +257,40 @@ describe("FleetManager schedule seam + runtime mutation", () => {
         manager.setAgentSchedule("nope", "tick", { type: "interval", interval: "1h" }),
       ).rejects.toBeInstanceOf(AgentNotFoundError);
     });
+
+    it("re-arming a previously disabled schedule clears the disabled state so it fires again", async () => {
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+
+      const handler = vi.fn(async (_info: TriggerInfo) => {});
+      manager.setScheduleTriggerHandler(handler);
+
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        max_turns: 1,
+        schedules: { tick: { type: "interval", interval: "1h" } },
+      });
+
+      // Persist a disabled status for the schedule.
+      const disabled = await manager.disableSchedule("sched-agent", "tick");
+      expect(disabled.status).toBe("disabled");
+
+      // Re-setting the same schedule must normalize the lingering disabled state
+      // — config-only mutation would leave it disabled and it would never fire.
+      const info = await manager.setAgentSchedule("sched-agent", "tick", {
+        type: "interval",
+        interval: "1h",
+      });
+      expect(info.status).toBe("idle");
+
+      await manager.start();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await manager.stop();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].scheduleName).toBe("tick");
+    });
   });
 
   // ===========================================================================
@@ -265,6 +346,62 @@ describe("FleetManager schedule seam + runtime mutation", () => {
       const reAdded = await manager.getSchedule("sched-agent", "tick");
       expect(reAdded.status).toBe("idle");
       expect(reAdded.lastRunAt).toBeNull();
+    });
+
+    it("remove+re-add while a handler run is in flight: no double-execution, no resurrected state", async () => {
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      let calls = 0;
+      let releaseFirstRun: () => void = () => {};
+      const firstRunGate = new Promise<void>((resolve) => {
+        releaseFirstRun = resolve;
+      });
+
+      manager.setScheduleTriggerHandler(async () => {
+        calls += 1;
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        // Hold only the first run open; it stays "in flight" across the mutation.
+        if (calls === 1) await firstRunGate;
+        inFlight -= 1;
+      });
+
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        max_turns: 1,
+        schedules: { tick: { type: "interval", interval: "1h" } },
+      });
+      await manager.start();
+
+      // Wait until the first run is actually in flight (handler entered + gated).
+      await waitFor(() => calls === 1);
+
+      // While that run is still executing, remove and immediately re-add the
+      // same name. Removal must not resurrect deleted state, and the retained
+      // running-set entry must prevent a second concurrent fire of the re-add.
+      await manager.removeAgentSchedule("sched-agent", "tick");
+      await manager.setAgentSchedule("sched-agent", "tick", {
+        type: "interval",
+        interval: "1h",
+      });
+
+      // Let the in-flight run finish, then settle.
+      releaseFirstRun();
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      await manager.stop();
+
+      // No point had two concurrent executions of the schedule.
+      expect(maxInFlight).toBe(1);
+
+      // The re-added schedule's persisted state is clean, not a resurrected
+      // disabled/errored entry.
+      const reAdded = await manager.getSchedule("sched-agent", "tick");
+      expect(reAdded.status).not.toBe("disabled");
+      expect(reAdded.lastError).toBeNull();
     });
   });
 

--- a/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/schedule-management.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Tests for the scheduler host-execution seam (edspencer/herdctl#375) and
+ * runtime add/remove of a single schedule + mutation gate (edspencer/herdctl#376).
+ *
+ * Covers:
+ * - setScheduleTriggerHandler: a fired schedule routes to the host handler when
+ *   one is registered, and falls back to the headless executor when it is not.
+ * - setAgentSchedule: arms a new schedule on an already-registered agent at
+ *   runtime (the scheduler picks it up from live config).
+ * - removeAgentSchedule: prunes persisted state so a re-added name does not
+ *   inherit stale last_run_at / disabled status.
+ * - the allowScheduleMutation gate blocks setAgentSchedule/removeAgentSchedule
+ *   when disabled (the default), while leaving enable/disable ungated.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Claude SDK to prevent real API calls during headless execution.
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TriggerInfo } from "../../scheduler/index.js";
+import { AgentNotFoundError, ScheduleMutationDisabledError } from "../errors.js";
+import { FleetManager } from "../fleet-manager.js";
+
+const silentLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+describe("FleetManager schedule seam + runtime mutation", () => {
+  let tempDir: string;
+  let configDir: string;
+  let stateDir: string;
+  let configPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "fleet-sched-mgmt-test-"));
+    configDir = join(tempDir, "config");
+    stateDir = join(tempDir, ".herdctl");
+    await mkdir(configDir, { recursive: true });
+    // Deterministic empty fleet; agents are registered programmatically per test.
+    configPath = join(configDir, "herdctl.yaml");
+    const yaml = await import("yaml");
+    await writeFile(configPath, yaml.stringify({ version: 1, agents: [] }));
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  function createManager(opts?: { allowScheduleMutation?: boolean; checkInterval?: number }) {
+    return new FleetManager({
+      configPath,
+      stateDir,
+      checkInterval: opts?.checkInterval ?? 20,
+      logger: silentLogger(),
+      allowScheduleMutation: opts?.allowScheduleMutation,
+    });
+  }
+
+  // ===========================================================================
+  // D1 — setScheduleTriggerHandler (host-execution seam)
+  // ===========================================================================
+
+  describe("setScheduleTriggerHandler()", () => {
+    it("routes a fired schedule to the host handler instead of the headless executor", async () => {
+      const manager = createManager();
+      await manager.initialize();
+
+      // schedule:triggered is emitted only by the headless ScheduleExecutor path,
+      // so it doubles as a probe for whether the fallback ran.
+      const headlessProbe = vi.fn();
+      manager.on("schedule:triggered", headlessProbe);
+
+      const handler = vi.fn(async (_info: TriggerInfo) => {});
+      manager.setScheduleTriggerHandler(handler);
+
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        max_turns: 1,
+        schedules: { tick: { type: "interval", interval: "1h" } },
+      });
+
+      await manager.start();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await manager.stop();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const info = handler.mock.calls[0][0];
+      expect(info.scheduleName).toBe("tick");
+      expect(info.agent.qualifiedName).toBe("sched-agent");
+
+      // The headless executor must NOT have run when a handler owns execution.
+      expect(headlessProbe).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the headless executor when no handler is registered", async () => {
+      const manager = createManager();
+      await manager.initialize();
+
+      const headlessProbe = vi.fn();
+      manager.on("schedule:triggered", headlessProbe);
+
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        max_turns: 1,
+        schedules: { tick: { type: "interval", interval: "1h" } },
+      });
+
+      await manager.start();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await manager.stop();
+
+      // Headless path ran: it emits schedule:triggered before executing the job.
+      expect(headlessProbe).toHaveBeenCalled();
+      expect(headlessProbe.mock.calls[0][0].scheduleName).toBe("tick");
+    });
+
+    it("clearing the handler (undefined) restores headless execution", async () => {
+      const manager = createManager();
+      await manager.initialize();
+
+      const handler = vi.fn(async () => {});
+      manager.setScheduleTriggerHandler(handler);
+      manager.setScheduleTriggerHandler(undefined);
+
+      const headlessProbe = vi.fn();
+      manager.on("schedule:triggered", headlessProbe);
+
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        max_turns: 1,
+        schedules: { tick: { type: "interval", interval: "1h" } },
+      });
+
+      await manager.start();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await manager.stop();
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(headlessProbe).toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // D2 — setAgentSchedule (runtime add)
+  // ===========================================================================
+
+  describe("setAgentSchedule()", () => {
+    it("arms a new schedule on an existing agent so the scheduler fires it", async () => {
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+
+      const handler = vi.fn(async (_info: TriggerInfo) => {});
+      manager.setScheduleTriggerHandler(handler);
+
+      await manager.addAgent({ name: "sched-agent", working_directory: tempDir, max_turns: 1 });
+      await manager.start();
+
+      // No schedules yet → nothing fires.
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      expect(handler).not.toHaveBeenCalled();
+
+      const info = await manager.setAgentSchedule("sched-agent", "tick", {
+        type: "interval",
+        interval: "1h",
+      });
+      expect(info.name).toBe("tick");
+      expect(info.type).toBe("interval");
+
+      // The live agent config now carries the schedule, so it arms and fires.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await manager.stop();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].scheduleName).toBe("tick");
+
+      // Also visible via the schedule query surface.
+      const all = await manager.getSchedules();
+      expect(all.map((s) => s.name)).toContain("tick");
+    });
+
+    it("validates the schedule against ScheduleSchema", async () => {
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+      await manager.addAgent({ name: "sched-agent", working_directory: tempDir });
+
+      await expect(
+        // `type` is required; an empty object fails schema validation.
+        manager.setAgentSchedule("sched-agent", "bad", {} as never),
+      ).rejects.toThrow(/Invalid schedule configuration/);
+    });
+
+    it("throws AgentNotFoundError for an unknown agent", async () => {
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+
+      await expect(
+        manager.setAgentSchedule("nope", "tick", { type: "interval", interval: "1h" }),
+      ).rejects.toBeInstanceOf(AgentNotFoundError);
+    });
+  });
+
+  // ===========================================================================
+  // D2 — removeAgentSchedule (runtime remove + state prune)
+  // ===========================================================================
+
+  describe("removeAgentSchedule()", () => {
+    it("removes the schedule from config and the query surface", async () => {
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        schedules: { tick: { type: "interval", interval: "1h" } },
+      });
+
+      expect((await manager.getSchedules()).map((s) => s.name)).toContain("tick");
+
+      const removed = await manager.removeAgentSchedule("sched-agent", "tick");
+      expect(removed).toBe(true);
+      expect((await manager.getSchedules()).map((s) => s.name)).not.toContain("tick");
+    });
+
+    it("returns false when the agent has no such schedule", async () => {
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+      await manager.addAgent({ name: "sched-agent", working_directory: tempDir });
+
+      expect(await manager.removeAgentSchedule("sched-agent", "ghost")).toBe(false);
+    });
+
+    it("prunes persisted state so a re-added name does not inherit stale status", async () => {
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        schedules: { tick: { type: "interval", interval: "1h" } },
+      });
+
+      // Persist a `disabled` status (+ implicitly a state entry) for the schedule.
+      const disabled = await manager.disableSchedule("sched-agent", "tick");
+      expect(disabled.status).toBe("disabled");
+
+      // Remove it (prunes persisted state) then re-add the same name.
+      await manager.removeAgentSchedule("sched-agent", "tick");
+      await manager.setAgentSchedule("sched-agent", "tick", {
+        type: "interval",
+        interval: "1h",
+      });
+
+      // Without the prune, this would still read `disabled` from stale state.
+      const reAdded = await manager.getSchedule("sched-agent", "tick");
+      expect(reAdded.status).toBe("idle");
+      expect(reAdded.lastRunAt).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // D2 — mutation gate
+  // ===========================================================================
+
+  describe("allowScheduleMutation gate", () => {
+    it("blocks setAgentSchedule when mutation is disabled (the default)", async () => {
+      const manager = createManager(); // allowScheduleMutation defaults to false
+      await manager.initialize();
+      await manager.addAgent({ name: "sched-agent", working_directory: tempDir });
+
+      await expect(
+        manager.setAgentSchedule("sched-agent", "tick", { type: "interval", interval: "1h" }),
+      ).rejects.toBeInstanceOf(ScheduleMutationDisabledError);
+
+      // The schedule was not added.
+      expect((await manager.getSchedules()).map((s) => s.name)).not.toContain("tick");
+    });
+
+    it("blocks removeAgentSchedule when mutation is disabled", async () => {
+      const manager = createManager();
+      await manager.initialize();
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        schedules: { tick: { type: "interval", interval: "1h" } },
+      });
+
+      await expect(manager.removeAgentSchedule("sched-agent", "tick")).rejects.toBeInstanceOf(
+        ScheduleMutationDisabledError,
+      );
+
+      // The schedule survives the blocked removal.
+      expect((await manager.getSchedules()).map((s) => s.name)).toContain("tick");
+    });
+
+    it("leaves enable/disable ungated even when mutation is disabled", async () => {
+      const manager = createManager();
+      await manager.initialize();
+      await manager.addAgent({
+        name: "sched-agent",
+        working_directory: tempDir,
+        schedules: { tick: { type: "interval", interval: "1h" } },
+      });
+
+      await expect(manager.disableSchedule("sched-agent", "tick")).resolves.toMatchObject({
+        status: "disabled",
+      });
+      await expect(manager.enableSchedule("sched-agent", "tick")).resolves.toMatchObject({
+        status: "idle",
+      });
+    });
+
+    it("allows mutation when the deployment opts in", async () => {
+      const manager = createManager({ allowScheduleMutation: true });
+      await manager.initialize();
+      await manager.addAgent({ name: "sched-agent", working_directory: tempDir });
+
+      await expect(
+        manager.setAgentSchedule("sched-agent", "tick", { type: "interval", interval: "1h" }),
+      ).resolves.toMatchObject({ name: "tick" });
+    });
+  });
+});

--- a/packages/core/src/fleet-manager/errors.ts
+++ b/packages/core/src/fleet-manager/errors.ts
@@ -360,11 +360,12 @@ export class ScheduleNotFoundError extends FleetManagerError {
  *
  * @example
  * ```typescript
+ * const logger = createLogger("my-app");
  * try {
  *   await fleetManager.setAgentSchedule("my-agent", "hourly", { type: "interval", interval: "1h" });
  * } catch (error) {
  *   if (error instanceof ScheduleMutationDisabledError) {
- *     console.error("Enable { allowScheduleMutation: true } to mutate schedules at runtime");
+ *     logger.error("Enable { allowScheduleMutation: true } to mutate schedules at runtime");
  *   }
  * }
  * ```

--- a/packages/core/src/fleet-manager/errors.ts
+++ b/packages/core/src/fleet-manager/errors.ts
@@ -27,6 +27,9 @@ export const FleetManagerErrorCode = {
   JOB_NOT_FOUND: "JOB_NOT_FOUND",
   SCHEDULE_NOT_FOUND: "SCHEDULE_NOT_FOUND",
 
+  // Schedule mutation gate
+  SCHEDULE_MUTATION_DISABLED: "SCHEDULE_MUTATION_DISABLED",
+
   // State errors
   INVALID_STATE: "INVALID_STATE",
   STATE_DIR_ERROR: "STATE_DIR_ERROR",
@@ -341,6 +344,47 @@ export class ScheduleNotFoundError extends FleetManagerError {
     }
 
     return message;
+  }
+}
+
+/**
+ * Error thrown when programmatic schedule mutation is attempted but the
+ * deployment has not opted into it.
+ *
+ * Adding or removing a schedule at runtime (see
+ * {@link FleetManager.setAgentSchedule} / {@link FleetManager.removeAgentSchedule})
+ * is gated behind the `allowScheduleMutation` FleetManager option, which defaults
+ * to `false`. This is the per-deployment safety control: headless fleets that only
+ * run schedules declared in `herdctl.yaml` never enable it, while an embedding host
+ * (e.g. paddock) that exposes a schedule-editing UI opts in explicitly.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await fleetManager.setAgentSchedule("my-agent", "hourly", { type: "interval", interval: "1h" });
+ * } catch (error) {
+ *   if (error instanceof ScheduleMutationDisabledError) {
+ *     console.error("Enable { allowScheduleMutation: true } to mutate schedules at runtime");
+ *   }
+ * }
+ * ```
+ */
+export class ScheduleMutationDisabledError extends FleetManagerError {
+  /** The operation that was blocked (e.g. "setAgentSchedule"). */
+  public readonly operation: string;
+
+  constructor(operation: string, options?: { cause?: Error }) {
+    super(
+      `Schedule mutation is disabled for this deployment: cannot ${operation}. ` +
+        `Construct the FleetManager with { allowScheduleMutation: true } to enable ` +
+        `programmatic add/remove of schedules.`,
+      {
+        cause: options?.cause,
+        code: FleetManagerErrorCode.SCHEDULE_MUTATION_DISABLED,
+      },
+    );
+    this.name = "ScheduleMutationDisabledError";
+    this.operation = operation;
   }
 }
 
@@ -734,6 +778,15 @@ export function isScheduleNotFoundError(error: unknown): error is ScheduleNotFou
  */
 export function isInvalidStateError(error: unknown): error is InvalidStateError {
   return error instanceof InvalidStateError;
+}
+
+/**
+ * Type guard to check if an error is a ScheduleMutationDisabledError
+ */
+export function isScheduleMutationDisabledError(
+  error: unknown,
+): error is ScheduleMutationDisabledError {
+  return error instanceof ScheduleMutationDisabledError;
 }
 
 /**

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -22,6 +22,7 @@ import {
   loadConfig,
   type ResolvedAgent,
   type ResolvedConfig,
+  type Schedule,
 } from "../config/index.js";
 import type { RuntimeSession, SlashCommand } from "../runner/index.js";
 import { getCliSessionFile, getDockerSessionFile } from "../runner/runtime/cli-session-path.js";
@@ -73,6 +74,7 @@ import type {
   LogEntry,
   LogStreamOptions,
   ScheduleInfo,
+  ScheduleTriggerHandler,
   TriggerOptions,
   TriggerResult,
 } from "./types.js";
@@ -97,6 +99,7 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   private readonly logger: FleetManagerLogger;
   private readonly checkInterval: number;
   private readonly configOverrides?: FleetConfigOverrides;
+  private readonly allowScheduleMutation: boolean;
 
   // Internal state
   private status: FleetManagerStatus = "uninitialized";
@@ -105,6 +108,7 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   private scheduler: Scheduler | null = null;
   private sessionLifecycle: SessionLifecycleManager | null = null;
   private sessionWakeHandler?: SessionWakeHandler;
+  private scheduleTriggerHandler?: ScheduleTriggerHandler;
 
   // Timing info
   private initializedAt: string | null = null;
@@ -147,6 +151,7 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
     this.logger = options.logger ?? createDefaultLogger();
     this.checkInterval = options.checkInterval ?? DEFAULT_CHECK_INTERVAL;
     this.configOverrides = options.configOverrides;
+    this.allowScheduleMutation = options.allowScheduleMutation ?? false;
 
     // Initialize modules in constructor so they work before initialize() is called
     this.initializeModules();
@@ -548,6 +553,50 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
     return this.scheduleManagement.disableSchedule(agentName, scheduleName);
   }
 
+  /**
+   * Add or replace a single schedule on an existing agent at runtime.
+   *
+   * The programmatic counterpart to editing an agent's `schedules` in
+   * `herdctl.yaml` and calling `reload()`, for one schedule. The definition is
+   * validated against `ScheduleSchema`, set on the stored agent, and re-pushed to
+   * the scheduler so it is immediately eligible to fire — no whole-agent
+   * `addAgent(replace)` (which leaves stale state) needed. Gated behind the
+   * `allowScheduleMutation` deployment option (edspencer/herdctl#376).
+   *
+   * @param agentName - Qualified or local name of an existing agent
+   * @param scheduleName - The schedule key to set
+   * @param schedule - The schedule definition
+   * @throws {ScheduleMutationDisabledError} If `allowScheduleMutation` is not set
+   * @throws {AgentNotFoundError} If the agent doesn't exist
+   * @throws {ConfigurationError} If the schedule fails validation
+   */
+  async setAgentSchedule(
+    agentName: string,
+    scheduleName: string,
+    schedule: Schedule | Record<string, unknown>,
+  ): Promise<ScheduleInfo> {
+    return this.scheduleManagement.setAgentSchedule(agentName, scheduleName, schedule);
+  }
+
+  /**
+   * Remove a single schedule from an agent at runtime.
+   *
+   * Deletes the schedule from the stored agent and the scheduler, prunes its
+   * persisted state (so a re-added name doesn't inherit stale `last_run_at` /
+   * `disabled` status), and clears the scheduler's in-memory tracking for it.
+   * Gated behind the `allowScheduleMutation` deployment option
+   * (edspencer/herdctl#376).
+   *
+   * @param agentName - Qualified or local name of an existing agent
+   * @param scheduleName - The schedule key to remove
+   * @returns `true` if a schedule was removed, `false` if there was none to remove
+   * @throws {ScheduleMutationDisabledError} If `allowScheduleMutation` is not set
+   * @throws {AgentNotFoundError} If the agent doesn't exist
+   */
+  async removeAgentSchedule(agentName: string, scheduleName: string): Promise<boolean> {
+    return this.scheduleManagement.removeAgentSchedule(agentName, scheduleName);
+  }
+
   // Config Reload
   async reload(): Promise<ConfigReloadedPayload> {
     return this.configReloadModule.reload();
@@ -901,8 +950,13 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
 
   private initializeModules(): void {
     this.statusQueries = new StatusQueries(this);
-    this.scheduleManagement = new ScheduleManagement(this, () =>
-      this.statusQueries.readFleetStateSnapshot(),
+    this.scheduleManagement = new ScheduleManagement(
+      this,
+      () => this.statusQueries.readFleetStateSnapshot(),
+      (config) => {
+        this.config = config;
+      },
+      () => this.allowScheduleMutation,
     );
     this.configReloadModule = new ConfigReload(
       this,
@@ -952,6 +1006,21 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   setSessionWakeHandler(handler: SessionWakeHandler | undefined): void {
     this.sessionWakeHandler = handler;
     this.sessionLifecycle?.setSessionWakeHandler(handler);
+  }
+
+  /**
+   * Register (or clear) the consumer that owns execution of fired schedules.
+   *
+   * Mirrors {@link setSessionWakeHandler}. A consumer (e.g. paddock) sets this to
+   * take over running scheduled turns — resuming/streaming them on its own hub and
+   * attribution path — instead of the built-in headless {@link ScheduleExecutor}.
+   * The scheduler's cron/interval timing is unchanged; only the execution of a due
+   * trigger is intercepted (edspencer/herdctl#375). Without a handler, schedules
+   * run headless so recurring fires keep working. Safe to call before or after
+   * initialize(); pass `undefined` to restore headless execution.
+   */
+  setScheduleTriggerHandler(handler: ScheduleTriggerHandler | undefined): void {
+    this.scheduleTriggerHandler = handler;
   }
 
   /**
@@ -1238,6 +1307,17 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   }
 
   private async handleScheduleTrigger(info: TriggerInfo): Promise<void> {
+    // Host-execution seam (edspencer/herdctl#375): when a consumer registers a
+    // handler it owns execution — running the turn on its own resume/hub path and
+    // streaming it into its UI — so we route the trigger there and skip the
+    // built-in headless executor. Every scheduler-fired trigger (interval, cron,
+    // and a forced immediate fire) funnels through here, so a "trigger now" flows
+    // through the handler path too. Without a handler, schedules run headless via
+    // ScheduleExecutor exactly as before.
+    if (this.scheduleTriggerHandler) {
+      await this.scheduleTriggerHandler(info);
+      return;
+    }
     await this.scheduleExecutor.executeSchedule(info);
   }
 

--- a/packages/core/src/fleet-manager/index.ts
+++ b/packages/core/src/fleet-manager/index.ts
@@ -72,11 +72,14 @@ export {
   isJobCancelError,
   isJobForkError,
   isJobNotFoundError,
+  isScheduleMutationDisabledError,
   isScheduleNotFoundError,
   // Job control error classes
   JobCancelError,
   JobForkError,
   JobNotFoundError,
+  // Schedule mutation gate error (D2)
+  ScheduleMutationDisabledError,
   ScheduleNotFoundError,
   StreamingSessionUnsupportedError,
 } from "./errors.js";
@@ -184,6 +187,8 @@ export type {
   LogStreamOptions,
   ScheduleInfo,
   ScheduleTriggeredPayload,
+  // Host-execution seam for scheduled triggers (D1)
+  ScheduleTriggerHandler,
   SlackErrorPayload,
   SlackMessageErrorPayload,
   // Slack manager event types

--- a/packages/core/src/fleet-manager/schedule-management.ts
+++ b/packages/core/src/fleet-manager/schedule-management.ts
@@ -2,15 +2,26 @@
  * Schedule Management Module
  *
  * Centralizes all schedule management logic for FleetManager.
- * Provides methods to query, enable, and disable schedules.
+ * Provides methods to query, enable, disable, add, and remove schedules.
  *
  * @module schedule-management
  */
 
+import {
+  type ResolvedAgent,
+  type ResolvedConfig,
+  type Schedule,
+  ScheduleSchema,
+} from "../config/index.js";
 import type { FleetManagerContext } from "./context.js";
-import { AgentNotFoundError, ScheduleNotFoundError } from "./errors.js";
+import {
+  AgentNotFoundError,
+  ConfigurationError,
+  ScheduleMutationDisabledError,
+  ScheduleNotFoundError,
+} from "./errors.js";
 import { buildScheduleInfoList, type FleetStateSnapshot } from "./status-queries.js";
-import type { ScheduleInfo } from "./types.js";
+import type { ConfigChange, ScheduleInfo } from "./types.js";
 
 // =============================================================================
 // ScheduleManagement Class
@@ -19,13 +30,20 @@ import type { ScheduleInfo } from "./types.js";
 /**
  * ScheduleManagement provides all schedule management operations for the FleetManager.
  *
- * This class encapsulates the logic for querying, enabling, and disabling schedules
- * using the FleetManagerContext pattern.
+ * This class encapsulates the logic for querying, enabling, disabling, adding, and
+ * removing schedules using the FleetManagerContext pattern.
+ *
+ * Runtime add/remove of a single schedule ({@link setAgentSchedule} /
+ * {@link removeAgentSchedule}) is gated behind `allowScheduleMutation` — supplied
+ * as {@link isMutationAllowed} — so a deployment must opt in before schedules can
+ * be mutated programmatically (edspencer/herdctl#376).
  */
 export class ScheduleManagement {
   constructor(
     private ctx: FleetManagerContext,
     private readFleetStateSnapshotFn: () => Promise<FleetStateSnapshot>,
+    private setConfig: (config: ResolvedConfig) => void,
+    private isMutationAllowed: () => boolean,
   ) {}
 
   /**
@@ -204,5 +222,186 @@ export class ScheduleManagement {
 
     // Return the updated schedule info
     return this.getSchedule(agent.qualifiedName, scheduleName);
+  }
+
+  /**
+   * Add or replace a single schedule on an already-registered agent at runtime.
+   *
+   * Unlike {@link enableSchedule}/{@link disableSchedule} (which flip persisted
+   * state), this changes the agent's *configuration*: the schedule is validated
+   * against {@link ScheduleSchema}, set on the stored agent's `schedules` map, and
+   * the updated agent list is re-pushed to the scheduler. Arming reads live
+   * `agent.schedules` each tick, so the schedule is immediately eligible to fire
+   * (or, when re-registering an existing name, picks up the new timing) without a
+   * `reload()` or whole-agent `addAgent(replace)` round trip. A `config:reloaded`
+   * event describing the change is emitted.
+   *
+   * Gated behind `allowScheduleMutation` (see {@link ScheduleMutationDisabledError}).
+   *
+   * @param agentName - Qualified or local name of an existing agent
+   * @param scheduleName - The schedule key to set
+   * @param schedule - The schedule definition (validated against ScheduleSchema)
+   * @returns The resulting schedule info
+   * @throws {ScheduleMutationDisabledError} If schedule mutation is not enabled
+   * @throws {AgentNotFoundError} If the agent doesn't exist
+   * @throws {ConfigurationError} If the schedule fails validation
+   */
+  async setAgentSchedule(
+    agentName: string,
+    scheduleName: string,
+    schedule: Schedule | Record<string, unknown>,
+  ): Promise<ScheduleInfo> {
+    this.assertMutationAllowed("setAgentSchedule");
+
+    const logger = this.ctx.getLogger();
+    const { config, agent } = this.requireAgent(agentName);
+
+    // Validate against the schema so runtime input gets the same defaults
+    // (e.g. enabled/resume_session) and coercions a file-loaded schedule would.
+    let validated: Schedule;
+    try {
+      validated = ScheduleSchema.parse(schedule);
+    } catch (error) {
+      throw new ConfigurationError(
+        `Invalid schedule configuration for "${agentName}/${scheduleName}": ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        { cause: error instanceof Error ? error : undefined },
+      );
+    }
+
+    const isReplace = Boolean(agent.schedules && scheduleName in agent.schedules);
+    const updatedAgent: ResolvedAgent = {
+      ...agent,
+      schedules: { ...(agent.schedules ?? {}), [scheduleName]: validated },
+    };
+
+    this.commitAgent(config, agent, updatedAgent, {
+      type: isReplace ? "modified" : "added",
+      category: "schedule",
+      name: `${agent.qualifiedName}/${scheduleName}`,
+      details: validated.type,
+    });
+
+    logger.info(
+      `${isReplace ? "Updated" : "Added"} schedule ${agent.qualifiedName}/${scheduleName} programmatically`,
+    );
+
+    return this.getSchedule(agent.qualifiedName, scheduleName);
+  }
+
+  /**
+   * Remove a single schedule from an agent at runtime.
+   *
+   * Deletes the schedule key from the stored agent's `schedules` map, re-pushes
+   * the updated agent list to the scheduler, and — critically — prunes the
+   * schedule's persisted state via `deleteScheduleState` and clears the in-memory
+   * scheduler bookkeeping (`runningSchedules`/`warnedSchedules`) via
+   * `Scheduler.clearScheduleTracking`. Without the prune, a later re-add of the
+   * same name would inherit the removed schedule's stale `last_run_at`/`disabled`
+   * status, because the scheduler decides disabled/next-run from state, not config
+   * (edspencer/herdctl#376). A `config:reloaded` event is emitted.
+   *
+   * Gated behind `allowScheduleMutation` (see {@link ScheduleMutationDisabledError}).
+   *
+   * @param agentName - Qualified or local name of an existing agent
+   * @param scheduleName - The schedule key to remove
+   * @returns `true` if a schedule was removed, `false` if the agent had no such schedule
+   * @throws {ScheduleMutationDisabledError} If schedule mutation is not enabled
+   * @throws {AgentNotFoundError} If the agent doesn't exist
+   */
+  async removeAgentSchedule(agentName: string, scheduleName: string): Promise<boolean> {
+    this.assertMutationAllowed("removeAgentSchedule");
+
+    const logger = this.ctx.getLogger();
+    const stateDir = this.ctx.getStateDir();
+    const { config, agent } = this.requireAgent(agentName);
+
+    if (!agent.schedules || !(scheduleName in agent.schedules)) {
+      logger.debug(
+        `removeAgentSchedule: no schedule "${scheduleName}" on agent "${agent.qualifiedName}"`,
+      );
+      return false;
+    }
+
+    const { [scheduleName]: _removed, ...remainingSchedules } = agent.schedules;
+    const updatedAgent: ResolvedAgent = { ...agent, schedules: remainingSchedules };
+
+    this.commitAgent(config, agent, updatedAgent, {
+      type: "removed",
+      category: "schedule",
+      name: `${agent.qualifiedName}/${scheduleName}`,
+    });
+
+    // Prune persisted state so a re-added name doesn't inherit stale
+    // last_run_at / disabled status (edspencer/herdctl#376).
+    const { deleteScheduleState } = await import("../scheduler/schedule-state.js");
+    await deleteScheduleState(stateDir, agent.qualifiedName, scheduleName, {
+      logger: { warn: logger.warn },
+    });
+
+    // Clear in-memory scheduler bookkeeping keyed by this schedule.
+    this.ctx.getScheduler()?.clearScheduleTracking(agent.qualifiedName, scheduleName);
+
+    logger.info(`Removed schedule ${agent.qualifiedName}/${scheduleName} programmatically`);
+    return true;
+  }
+
+  // ===========================================================================
+  // Private Helpers
+  // ===========================================================================
+
+  /**
+   * Throw {@link ScheduleMutationDisabledError} unless the deployment has opted
+   * into programmatic schedule mutation.
+   */
+  private assertMutationAllowed(operation: string): void {
+    if (!this.isMutationAllowed()) {
+      throw new ScheduleMutationDisabledError(operation);
+    }
+  }
+
+  /**
+   * Resolve an agent by qualified name (preferred) or local name from the loaded
+   * config, throwing {@link AgentNotFoundError} if absent.
+   */
+  private requireAgent(agentName: string): { config: ResolvedConfig; agent: ResolvedAgent } {
+    const config = this.ctx.getConfig();
+    const agents = config?.agents ?? [];
+    const agent =
+      agents.find((a) => a.qualifiedName === agentName) ?? agents.find((a) => a.name === agentName);
+
+    if (!config || !agent) {
+      throw new AgentNotFoundError(agentName, {
+        availableAgents: agents.map((a) => a.qualifiedName),
+      });
+    }
+
+    return { config, agent };
+  }
+
+  /**
+   * Replace one agent in the stored config with an updated copy, push the new
+   * agent list to the scheduler, and emit a `config:reloaded` event. Mirrors
+   * `AgentManagement.commit`, the single seam for programmatic config mutation.
+   */
+  private commitAgent(
+    config: ResolvedConfig,
+    previous: ResolvedAgent,
+    updated: ResolvedAgent,
+    change: ConfigChange,
+  ): void {
+    const newAgents = config.agents.map((a) => (a === previous ? updated : a));
+    const newConfig: ResolvedConfig = { ...config, agents: newAgents };
+    this.setConfig(newConfig);
+
+    this.ctx.getScheduler()?.setAgents(newAgents);
+
+    this.ctx.emit("config:reloaded", {
+      agentCount: newAgents.length,
+      agentNames: newAgents.map((a) => a.qualifiedName),
+      configPath: config.configPath,
+      changes: [change],
+      timestamp: new Date().toISOString(),
+    });
   }
 }

--- a/packages/core/src/fleet-manager/schedule-management.ts
+++ b/packages/core/src/fleet-manager/schedule-management.ts
@@ -254,6 +254,7 @@ export class ScheduleManagement {
     this.assertMutationAllowed("setAgentSchedule");
 
     const logger = this.ctx.getLogger();
+    const stateDir = this.ctx.getStateDir();
     const { config, agent } = this.requireAgent(agentName);
 
     // Validate against the schema so runtime input gets the same defaults
@@ -282,8 +283,19 @@ export class ScheduleManagement {
       details: validated.type,
     });
 
+    // Arm the persisted state: lift any tombstone from a prior removal and
+    // normalize a lingering `disabled` status to `idle`. Config-only changes
+    // don't touch state, but the scheduler skips a schedule whose *persisted*
+    // status is `disabled` — so a set-after-disable would otherwise never fire,
+    // contradicting the "immediately eligible to fire" contract (#376).
+    const { armScheduleState } = await import("../scheduler/schedule-state.js");
+    const clearedDisabled = await armScheduleState(stateDir, agent.qualifiedName, scheduleName, {
+      logger: { warn: logger.warn },
+    });
+
     logger.info(
-      `${isReplace ? "Updated" : "Added"} schedule ${agent.qualifiedName}/${scheduleName} programmatically`,
+      `${isReplace ? "Updated" : "Added"} schedule ${agent.qualifiedName}/${scheduleName} programmatically` +
+        (clearedDisabled ? " (cleared disabled state)" : ""),
     );
 
     return this.getSchedule(agent.qualifiedName, scheduleName);
@@ -292,14 +304,31 @@ export class ScheduleManagement {
   /**
    * Remove a single schedule from an agent at runtime.
    *
-   * Deletes the schedule key from the stored agent's `schedules` map, re-pushes
-   * the updated agent list to the scheduler, and — critically — prunes the
-   * schedule's persisted state via `deleteScheduleState` and clears the in-memory
-   * scheduler bookkeeping (`runningSchedules`/`warnedSchedules`) via
-   * `Scheduler.clearScheduleTracking`. Without the prune, a later re-add of the
-   * same name would inherit the removed schedule's stale `last_run_at`/`disabled`
-   * status, because the scheduler decides disabled/next-run from state, not config
-   * (edspencer/herdctl#376). A `config:reloaded` event is emitted.
+   * Removal is coordinated as one lifecycle operation so it is safe to call while
+   * the scheduler is actively firing (edspencer/herdctl#376):
+   * 1. Drop the schedule from the stored agent's `schedules` map and re-push via
+   *    `scheduler.setAgents(...)` — arming reads live config each tick, so this
+   *    stops any *future* fire immediately.
+   * 2. Prune the schedule's persisted state via `deleteScheduleState`, which also
+   *    **tombstones** the key: the read-modify-write is serialized per state file
+   *    (so a concurrent sibling update can't be lost), and any still-in-flight
+   *    run's trailing state write is suppressed rather than resurrecting the
+   *    just-deleted entry.
+   * 3. Clear only the scheduler's warn-once bookkeeping via
+   *    `clearScheduleTracking`. An in-flight run's entry in the running set is
+   *    deliberately retained until that run's own `finally` clears it, so a
+   *    same-name re-add is correctly skipped as "already running" rather than
+   *    starting a second concurrent execution.
+   *
+   * The removed schedule's own in-flight run (if any) is not cancelled — it
+   * finishes naturally and its trailing writes are absorbed by the tombstone. A
+   * `config:reloaded` event is emitted.
+   *
+   * Deferred (documented in the PR): full generation-fencing of an old run's
+   * completion write after a same-name re-add. The tombstone prevents
+   * resurrection of deleted state; the residual is that a re-add during an
+   * old run's tail may see one `idle`/`next_run` write from that run — bounded,
+   * non-resurrecting, and self-correcting on the next tick.
    *
    * Gated behind `allowScheduleMutation` (see {@link ScheduleMutationDisabledError}).
    *
@@ -332,17 +361,24 @@ export class ScheduleManagement {
       name: `${agent.qualifiedName}/${scheduleName}`,
     });
 
-    // Prune persisted state so a re-added name doesn't inherit stale
-    // last_run_at / disabled status (edspencer/herdctl#376).
+    const wasRunning =
+      this.ctx.getScheduler()?.isScheduleRunning(agent.qualifiedName, scheduleName) ?? false;
+
+    // Prune persisted state (serialized RMW) and tombstone the key so a trailing
+    // write from any in-flight run can't resurrect it (edspencer/herdctl#376).
     const { deleteScheduleState } = await import("../scheduler/schedule-state.js");
     await deleteScheduleState(stateDir, agent.qualifiedName, scheduleName, {
       logger: { warn: logger.warn },
     });
 
-    // Clear in-memory scheduler bookkeeping keyed by this schedule.
+    // Clear only the warn-once bookkeeping; an in-flight run's running-set entry
+    // is retained until it completes (see clearScheduleTracking).
     this.ctx.getScheduler()?.clearScheduleTracking(agent.qualifiedName, scheduleName);
 
-    logger.info(`Removed schedule ${agent.qualifiedName}/${scheduleName} programmatically`);
+    logger.info(
+      `Removed schedule ${agent.qualifiedName}/${scheduleName} programmatically` +
+        (wasRunning ? " (a run is still in flight and will finish)" : ""),
+    );
     return true;
   }
 

--- a/packages/core/src/fleet-manager/schedule-management.ts
+++ b/packages/core/src/fleet-manager/schedule-management.ts
@@ -324,6 +324,20 @@ export class ScheduleManagement {
    * finishes naturally and its trailing writes are absorbed by the tombstone. A
    * `config:reloaded` event is emitted.
    *
+   * **In-memory only.** Like `addAgent`/`removeAgent`, this mutates the loaded
+   * in-memory config; it does NOT rewrite the on-disk `herdctl.yaml`. So a later
+   * `reload()` (or `addAgent({replace:true})`) that re-reads the schedule from
+   * disk legitimately re-arms it — and does so cleanly: `setAgents` lifts the
+   * tombstone for any schedule present in the new agent list, so the re-armed
+   * schedule resumes normal state persistence rather than staying tombstoned
+   * (which would make `updateScheduleState` a silent no-op and cause runaway
+   * per-tick firing). Consumers that manage schedules purely in memory (e.g.
+   * paddock) simply do not call `reload()`.
+   *
+   * Tombstone lifetime is bounded: it is lifted when the schedule is re-armed via
+   * `setAgents`, when an in-flight run for it completes (scheduler `executeJob`
+   * `finally`), or immediately here when there is no in-flight run to guard.
+   *
    * Deferred (documented in the PR): full generation-fencing of an old run's
    * completion write after a same-name re-add. The tombstone prevents
    * resurrection of deleted state; the residual is that a re-add during an
@@ -355,17 +369,33 @@ export class ScheduleManagement {
     const { [scheduleName]: _removed, ...remainingSchedules } = agent.schedules;
     const updatedAgent: ResolvedAgent = { ...agent, schedules: remainingSchedules };
 
+    // Note: commitAgent → setAgents re-pushes the agent list WITHOUT this
+    // schedule, so setAgents does not clear its tombstone (only present schedules
+    // are un-tombstoned) — exactly what we want while a run may still be writing.
     this.commitAgent(config, agent, updatedAgent, {
       type: "removed",
       category: "schedule",
       name: `${agent.qualifiedName}/${scheduleName}`,
     });
 
-    const wasRunning =
-      this.ctx.getScheduler()?.isScheduleRunning(agent.qualifiedName, scheduleName) ?? false;
+    const scheduler = this.ctx.getScheduler();
+    const wasRunning = scheduler?.isScheduleRunning(agent.qualifiedName, scheduleName) ?? false;
 
-    // Prune persisted state (serialized RMW) and tombstone the key so a trailing
-    // write from any in-flight run can't resurrect it (edspencer/herdctl#376).
+    // If (and only if) a run is in flight, tombstone the key so that run's
+    // trailing state write can't resurrect the entry we're about to delete. Set
+    // SYNCHRONOUSLY here — before the async prune below — so a concurrent re-arm's
+    // setAgents (which clears tombstones for present schedules) can't slip in
+    // during an await and clear it first. When nothing is in flight there is no
+    // writer to guard against, so we skip the tombstone entirely and it can never
+    // leak. The tombstone is later lifted by the run's `executeJob` finally, or by
+    // setAgents when the schedule is re-armed (reload / addAgent / setAgentSchedule)
+    // — the latter is what keeps a removed-then-reloaded schedule from staying
+    // tombstoned and runaway-firing.
+    if (wasRunning) {
+      scheduler?.tombstoneSchedule(agent.qualifiedName, scheduleName);
+    }
+
+    // Prune persisted state (serialized RMW).
     const { deleteScheduleState } = await import("../scheduler/schedule-state.js");
     await deleteScheduleState(stateDir, agent.qualifiedName, scheduleName, {
       logger: { warn: logger.warn },
@@ -373,7 +403,7 @@ export class ScheduleManagement {
 
     // Clear only the warn-once bookkeeping; an in-flight run's running-set entry
     // is retained until it completes (see clearScheduleTracking).
-    this.ctx.getScheduler()?.clearScheduleTracking(agent.qualifiedName, scheduleName);
+    scheduler?.clearScheduleTracking(agent.qualifiedName, scheduleName);
 
     logger.info(
       `Removed schedule ${agent.qualifiedName}/${scheduleName} programmatically` +

--- a/packages/core/src/fleet-manager/types.ts
+++ b/packages/core/src/fleet-manager/types.ts
@@ -5,7 +5,7 @@
  * and event definitions.
  */
 
-import type { SchedulerLogger } from "../scheduler/types.js";
+import type { SchedulerLogger, TriggerInfo } from "../scheduler/types.js";
 import type { WorkItem } from "../work-sources/types.js";
 
 // Re-export event types from dedicated event-types module
@@ -103,7 +103,33 @@ export interface FleetManagerOptions {
    * Currently supports overriding fleet-level settings like `web`.
    */
   configOverrides?: FleetConfigOverrides;
+
+  /**
+   * Per-deployment gate for programmatic schedule mutation.
+   *
+   * When `false` (the default), {@link FleetManager.setAgentSchedule} and
+   * {@link FleetManager.removeAgentSchedule} throw
+   * {@link ScheduleMutationDisabledError} — a headless fleet only ever runs the
+   * schedules declared in its config, so nothing can add or remove one at runtime.
+   * An embedding host that exposes a schedule-editing surface (e.g. paddock)
+   * opts in by setting this to `true`. This gate does not affect
+   * enable/disable of already-declared schedules, or the scheduler itself.
+   *
+   * @default false
+   */
+  allowScheduleMutation?: boolean;
 }
+
+/**
+ * Consumer hook that owns execution of a fired schedule (edspencer/herdctl#375).
+ *
+ * Registered via {@link FleetManager.setScheduleTriggerHandler}. When set, every
+ * scheduler-fired trigger is routed here instead of the built-in headless
+ * {@link ScheduleExecutor}, so an embedding host (e.g. paddock) can run the turn
+ * on its own resume/hub path and stream it into its UI. When unset, schedules run
+ * headless exactly as before. Mirrors `SessionWakeHandler`.
+ */
+export type ScheduleTriggerHandler = (info: TriggerInfo) => void | Promise<void>;
 
 /**
  * Runtime overrides for fleet configuration

--- a/packages/core/src/scheduler/__tests__/cron.test.ts
+++ b/packages/core/src/scheduler/__tests__/cron.test.ts
@@ -651,7 +651,9 @@ describe("resolveSystemTimeZone", () => {
   });
 
   it("returns the host IANA timezone reported by Intl", () => {
-    const expected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    // Mirror the fallback so this passes on an ICU-less host too (the exact env
+    // being hardened): if Intl reports no zone, resolveSystemTimeZone yields UTC.
+    const expected = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
     expect(resolveSystemTimeZone()).toBe(expected);
     // Whatever it is, the cron parser must accept it (used as `tz`).
     expect(() => parseCronExpression("0 9 * * *", { tz: resolveSystemTimeZone() })).not.toThrow();

--- a/packages/core/src/scheduler/__tests__/cron.test.ts
+++ b/packages/core/src/scheduler/__tests__/cron.test.ts
@@ -5,6 +5,7 @@ import {
   getNextCronTrigger,
   isValidCronExpression,
   parseCronExpression,
+  resolveSystemTimeZone,
 } from "../cron.js";
 import { CronParseError, SchedulerErrorCode } from "../errors.js";
 
@@ -637,6 +638,38 @@ describe("isValidCronExpression", () => {
       expect(isValidCronExpression("invalid")).toBe(false);
       expect(isValidCronExpression("not a cron")).toBe(false);
     });
+  });
+});
+
+// =============================================================================
+// resolveSystemTimeZone - #311 relative-wake timezone hardening
+// =============================================================================
+
+describe("resolveSystemTimeZone", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the host IANA timezone reported by Intl", () => {
+    const expected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    expect(resolveSystemTimeZone()).toBe(expected);
+    // Whatever it is, the cron parser must accept it (used as `tz`).
+    expect(() => parseCronExpression("0 9 * * *", { tz: resolveSystemTimeZone() })).not.toThrow();
+  });
+
+  it("falls back to UTC when Intl reports no timezone (ICU-less build)", () => {
+    // Some stripped Node builds return undefined/"" for the resolved timezone;
+    // passing that straight through would make cron resolution implementation-
+    // defined and could revive the #311 24h-idle bug. Fall back to UTC instead.
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () =>
+        ({ resolvedOptions: () => ({ timeZone: undefined }) }) as unknown as Intl.DateTimeFormat,
+    );
+
+    expect(resolveSystemTimeZone()).toBe("UTC");
+    // A deterministic UTC calculation still works with the fallback in place.
+    const next = calculateNextCronTrigger("0 0 * * *", new Date("2024-01-15T12:00:00Z"));
+    expect(next.toISOString()).toBe("2024-01-16T00:00:00.000Z");
   });
 });
 

--- a/packages/core/src/scheduler/__tests__/schedule-state.test.ts
+++ b/packages/core/src/scheduler/__tests__/schedule-state.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { readFleetState, writeFleetState } from "../../state/fleet-state.js";
 import { createDefaultScheduleState, type FleetState } from "../../state/schemas/fleet-state.js";
 import {
+  armScheduleState,
   deleteScheduleState,
   getAgentScheduleStates,
   getScheduleState,
@@ -767,5 +768,146 @@ describe("deleteScheduleState", () => {
     // Existing schedule is preserved.
     const state = await readFleetState(stateFile);
     expect(state.agents["my-agent"].schedules).toHaveProperty("hourly");
+  });
+
+  it("tombstones the key so a later updateScheduleState cannot resurrect it", async () => {
+    const stateFile = join(tempDir, "state.yaml");
+    await writeFleetState(stateFile, {
+      fleet: {},
+      agents: {
+        "my-agent": {
+          status: "idle",
+          schedules: {
+            hourly: {
+              last_run_at: "2024-01-15T10:00:00Z",
+              next_run_at: null,
+              status: "running",
+              last_error: null,
+            },
+          },
+        },
+      },
+    });
+
+    // Remove it, then simulate a still-in-flight run's trailing state write.
+    await deleteScheduleState(tempDir, "my-agent", "hourly");
+    await updateScheduleState(tempDir, "my-agent", "hourly", {
+      status: "idle",
+      next_run_at: "2024-01-15T11:00:00Z",
+    });
+
+    // The write was suppressed — the entry stays gone (no resurrection).
+    const remaining = await getAgentScheduleStates(tempDir, "my-agent");
+    expect(remaining).not.toHaveProperty("hourly");
+  });
+});
+
+describe("armScheduleState", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("normalizes a persisted disabled status to idle and clears last_error", async () => {
+    const stateFile = join(tempDir, "state.yaml");
+    await writeFleetState(stateFile, {
+      fleet: {},
+      agents: {
+        "my-agent": {
+          status: "idle",
+          schedules: {
+            hourly: {
+              last_run_at: "2024-01-15T10:00:00Z",
+              next_run_at: null,
+              status: "disabled",
+              last_error: "boom",
+            },
+          },
+        },
+      },
+    });
+
+    expect(await armScheduleState(tempDir, "my-agent", "hourly")).toBe(true);
+
+    const state = await getScheduleState(tempDir, "my-agent", "hourly");
+    expect(state.status).toBe("idle");
+    expect(state.last_error).toBeNull();
+    // last_run_at is preserved (cadence is not reset).
+    expect(state.last_run_at).toBe("2024-01-15T10:00:00Z");
+  });
+
+  it("returns false and leaves non-disabled state untouched", async () => {
+    const stateFile = join(tempDir, "state.yaml");
+    await writeFleetState(stateFile, {
+      fleet: {},
+      agents: {
+        "my-agent": {
+          status: "running",
+          schedules: {
+            hourly: {
+              last_run_at: "2024-01-15T10:00:00Z",
+              next_run_at: null,
+              status: "running",
+              last_error: null,
+            },
+          },
+        },
+      },
+    });
+
+    expect(await armScheduleState(tempDir, "my-agent", "hourly")).toBe(false);
+    const state = await getScheduleState(tempDir, "my-agent", "hourly");
+    expect(state.status).toBe("running");
+  });
+
+  it("lifts a tombstone so a re-armed schedule can persist state again", async () => {
+    await updateScheduleState(tempDir, "my-agent", "hourly", { status: "idle" });
+    await deleteScheduleState(tempDir, "my-agent", "hourly"); // tombstones
+
+    // Re-arm lifts the tombstone.
+    await armScheduleState(tempDir, "my-agent", "hourly");
+
+    await updateScheduleState(tempDir, "my-agent", "hourly", {
+      status: "running",
+      last_run_at: "2024-02-01T00:00:00Z",
+    });
+
+    const state = await getScheduleState(tempDir, "my-agent", "hourly");
+    expect(state.status).toBe("running");
+    expect(state.last_run_at).toBe("2024-02-01T00:00:00Z");
+  });
+});
+
+describe("schedule-state serialized read-modify-write", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not lose sibling updates when many writes race on one state file", async () => {
+    // Concurrent read-modify-write on the same file would clobber each other with
+    // last-writer-wins; the per-file lock serializes them so all survive.
+    const names = Array.from({ length: 12 }, (_, i) => `sched-${i}`);
+    await Promise.all(
+      names.map((name) =>
+        updateScheduleState(tempDir, "my-agent", name, {
+          status: "idle",
+          last_run_at: `2024-01-15T10:${String(name.length).padStart(2, "0")}:00Z`,
+        }),
+      ),
+    );
+
+    const schedules = await getAgentScheduleStates(tempDir, "my-agent");
+    expect(Object.keys(schedules).sort()).toEqual([...names].sort());
   });
 });

--- a/packages/core/src/scheduler/__tests__/schedule-state.test.ts
+++ b/packages/core/src/scheduler/__tests__/schedule-state.test.ts
@@ -6,10 +6,13 @@ import { readFleetState, writeFleetState } from "../../state/fleet-state.js";
 import { createDefaultScheduleState, type FleetState } from "../../state/schemas/fleet-state.js";
 import {
   armScheduleState,
+  clearScheduleTombstone,
   deleteScheduleState,
   getAgentScheduleStates,
   getScheduleState,
+  isScheduleTombstoned,
   type ScheduleStateLogger,
+  setScheduleTombstone,
   updateScheduleState,
 } from "../schedule-state.js";
 
@@ -770,7 +773,7 @@ describe("deleteScheduleState", () => {
     expect(state.agents["my-agent"].schedules).toHaveProperty("hourly");
   });
 
-  it("tombstones the key so a later updateScheduleState cannot resurrect it", async () => {
+  it("does not itself tombstone (tombstoning is the caller's responsibility)", async () => {
     const stateFile = join(tempDir, "state.yaml");
     await writeFleetState(stateFile, {
       fleet: {},
@@ -789,16 +792,62 @@ describe("deleteScheduleState", () => {
       },
     });
 
-    // Remove it, then simulate a still-in-flight run's trailing state write.
     await deleteScheduleState(tempDir, "my-agent", "hourly");
+    expect(isScheduleTombstoned(tempDir, "my-agent", "hourly")).toBe(false);
+  });
+});
+
+describe("schedule tombstone (resurrection guard)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    // Clean up any process-global tombstone this test set.
+    clearScheduleTombstone(tempDir, "my-agent", "hourly");
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("suppresses a later updateScheduleState so it cannot resurrect deleted state", async () => {
+    const stateFile = join(tempDir, "state.yaml");
+    await writeFleetState(stateFile, {
+      fleet: {},
+      agents: {
+        "my-agent": {
+          status: "idle",
+          schedules: {
+            hourly: {
+              last_run_at: "2024-01-15T10:00:00Z",
+              next_run_at: null,
+              status: "running",
+              last_error: null,
+            },
+          },
+        },
+      },
+    });
+
+    // Simulate removeAgentSchedule: tombstone synchronously, then prune.
+    setScheduleTombstone(tempDir, "my-agent", "hourly");
+    await deleteScheduleState(tempDir, "my-agent", "hourly");
+
+    // A still-in-flight run's trailing write is suppressed (no resurrection).
     await updateScheduleState(tempDir, "my-agent", "hourly", {
       status: "idle",
       next_run_at: "2024-01-15T11:00:00Z",
     });
+    expect(await getAgentScheduleStates(tempDir, "my-agent")).not.toHaveProperty("hourly");
 
-    // The write was suppressed — the entry stays gone (no resurrection).
-    const remaining = await getAgentScheduleStates(tempDir, "my-agent");
-    expect(remaining).not.toHaveProperty("hourly");
+    // Once the tombstone is lifted (re-arm), writes persist normally again.
+    clearScheduleTombstone(tempDir, "my-agent", "hourly");
+    await updateScheduleState(tempDir, "my-agent", "hourly", {
+      status: "idle",
+      last_run_at: "2024-02-01T00:00:00Z",
+    });
+    const state = await getScheduleState(tempDir, "my-agent", "hourly");
+    expect(state.last_run_at).toBe("2024-02-01T00:00:00Z");
   });
 });
 
@@ -866,11 +915,12 @@ describe("armScheduleState", () => {
   });
 
   it("lifts a tombstone so a re-armed schedule can persist state again", async () => {
-    await updateScheduleState(tempDir, "my-agent", "hourly", { status: "idle" });
-    await deleteScheduleState(tempDir, "my-agent", "hourly"); // tombstones
+    setScheduleTombstone(tempDir, "my-agent", "hourly");
+    expect(isScheduleTombstoned(tempDir, "my-agent", "hourly")).toBe(true);
 
     // Re-arm lifts the tombstone.
     await armScheduleState(tempDir, "my-agent", "hourly");
+    expect(isScheduleTombstoned(tempDir, "my-agent", "hourly")).toBe(false);
 
     await updateScheduleState(tempDir, "my-agent", "hourly", {
       status: "running",

--- a/packages/core/src/scheduler/__tests__/schedule-state.test.ts
+++ b/packages/core/src/scheduler/__tests__/schedule-state.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { readFleetState, writeFleetState } from "../../state/fleet-state.js";
 import { createDefaultScheduleState, type FleetState } from "../../state/schemas/fleet-state.js";
 import {
+  deleteScheduleState,
   getAgentScheduleStates,
   getScheduleState,
   type ScheduleStateLogger,
@@ -663,5 +664,108 @@ describe("createDefaultScheduleState", () => {
     expect(state.next_run_at).toBeNull();
     expect(state.status).toBe("idle");
     expect(state.last_error).toBeNull();
+  });
+});
+
+describe("deleteScheduleState", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("prunes a single schedule's persisted state, leaving siblings intact", async () => {
+    const stateFile = join(tempDir, "state.yaml");
+    const initialState: FleetState = {
+      fleet: {},
+      agents: {
+        "my-agent": {
+          status: "idle",
+          schedules: {
+            hourly: {
+              last_run_at: "2024-01-15T10:00:00Z",
+              next_run_at: "2024-01-15T11:00:00Z",
+              status: "disabled",
+              last_error: null,
+            },
+            daily: {
+              last_run_at: "2024-01-14T00:00:00Z",
+              next_run_at: "2024-01-15T00:00:00Z",
+              status: "idle",
+              last_error: null,
+            },
+          },
+        },
+      },
+    };
+    await writeFleetState(stateFile, initialState);
+
+    const pruned = await deleteScheduleState(tempDir, "my-agent", "hourly");
+    expect(pruned).toBe(true);
+
+    const remaining = await getAgentScheduleStates(tempDir, "my-agent");
+    expect(remaining).not.toHaveProperty("hourly");
+    expect(remaining).toHaveProperty("daily");
+  });
+
+  it("so a re-added schedule does not inherit stale last_run_at / disabled status", async () => {
+    const stateFile = join(tempDir, "state.yaml");
+    const initialState: FleetState = {
+      fleet: {},
+      agents: {
+        "my-agent": {
+          status: "idle",
+          schedules: {
+            hourly: {
+              last_run_at: "2024-01-15T10:00:00Z",
+              next_run_at: "2024-01-15T11:00:00Z",
+              status: "disabled",
+              last_error: "boom",
+            },
+          },
+        },
+      },
+    };
+    await writeFleetState(stateFile, initialState);
+
+    await deleteScheduleState(tempDir, "my-agent", "hourly");
+
+    // A re-add reads default state (idle, no last_run_at), not the pruned values.
+    const reAdded = await getScheduleState(tempDir, "my-agent", "hourly");
+    expect(reAdded.status).toBe("idle");
+    expect(reAdded.last_run_at).toBeNull();
+    expect(reAdded.last_error).toBeNull();
+  });
+
+  it("returns false and leaves state untouched when there is nothing to prune", async () => {
+    const stateFile = join(tempDir, "state.yaml");
+    const initialState: FleetState = {
+      fleet: {},
+      agents: {
+        "my-agent": {
+          status: "idle",
+          schedules: {
+            hourly: {
+              last_run_at: "2024-01-15T10:00:00Z",
+              next_run_at: null,
+              status: "idle",
+              last_error: null,
+            },
+          },
+        },
+      },
+    };
+    await writeFleetState(stateFile, initialState);
+
+    expect(await deleteScheduleState(tempDir, "my-agent", "missing")).toBe(false);
+    expect(await deleteScheduleState(tempDir, "missing-agent", "hourly")).toBe(false);
+
+    // Existing schedule is preserved.
+    const state = await readFleetState(stateFile);
+    expect(state.agents["my-agent"].schedules).toHaveProperty("hourly");
   });
 });

--- a/packages/core/src/scheduler/__tests__/schedule-state.test.ts
+++ b/packages/core/src/scheduler/__tests__/schedule-state.test.ts
@@ -914,22 +914,18 @@ describe("armScheduleState", () => {
     expect(state.status).toBe("running");
   });
 
-  it("lifts a tombstone so a re-armed schedule can persist state again", async () => {
+  it("does NOT lift a tombstone (that is coordinated with the execution generation)", async () => {
+    // Tombstone lifting is deliberately not armScheduleState's job — clearing it
+    // here would let a still-in-flight removed run's trailing write contaminate
+    // the re-added schedule. setAgents / executeJob own the lifecycle instead.
     setScheduleTombstone(tempDir, "my-agent", "hourly");
+
+    await armScheduleState(tempDir, "my-agent", "hourly");
+
     expect(isScheduleTombstoned(tempDir, "my-agent", "hourly")).toBe(true);
 
-    // Re-arm lifts the tombstone.
-    await armScheduleState(tempDir, "my-agent", "hourly");
-    expect(isScheduleTombstoned(tempDir, "my-agent", "hourly")).toBe(false);
-
-    await updateScheduleState(tempDir, "my-agent", "hourly", {
-      status: "running",
-      last_run_at: "2024-02-01T00:00:00Z",
-    });
-
-    const state = await getScheduleState(tempDir, "my-agent", "hourly");
-    expect(state.status).toBe("running");
-    expect(state.last_run_at).toBe("2024-02-01T00:00:00Z");
+    // Cleanup for the process-global set.
+    clearScheduleTombstone(tempDir, "my-agent", "hourly");
   });
 });
 

--- a/packages/core/src/scheduler/cron.ts
+++ b/packages/core/src/scheduler/cron.ts
@@ -435,15 +435,28 @@ export function isValidCronExpression(expression: string): boolean {
  * calculateNextCronTrigger("0,15,30,45 * * * *", midHour)  // Returns 2024-01-15T10:15:00 (local)
  */
 export function calculateNextCronTrigger(expression: string, after?: Date): Date {
-  // Get the system timezone
-  const systemTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
   const parsed = parseCronExpression(expression, {
     currentDate: after,
-    tz: systemTimezone,
+    tz: resolveSystemTimeZone(),
   });
 
   return parsed.cronExpression.next().toDate();
+}
+
+/**
+ * Resolve the host's IANA timezone for cron calculations, with a UTC fallback.
+ *
+ * The relative-wake seam (edspencer/herdctl#311) serializes one-shot/relative
+ * wakeups as wall-clock crons in the host's **local** timezone, then resolves
+ * them back here — so this must return the same zone the harness serialized in.
+ * `Intl.DateTimeFormat().resolvedOptions().timeZone` normally yields it, but in
+ * an ICU-less / stripped Node build it can be `undefined` or empty; passing that
+ * straight through to the cron parser makes the resolved zone
+ * implementation-defined (and can silently roll `next()` a day, reviving #311).
+ * Falling back to `"UTC"` keeps resolution deterministic in that edge case.
+ */
+export function resolveSystemTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 }
 
 /**
@@ -462,12 +475,9 @@ export function calculateNextCronTrigger(expression: string, after?: Date): Date
  * calculatePreviousCronTrigger("@hourly")  // Returns 11:00
  */
 export function calculatePreviousCronTrigger(expression: string, before?: Date): Date {
-  // Get the system timezone
-  const systemTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
   const parsed = parseCronExpression(expression, {
     currentDate: before,
-    tz: systemTimezone,
+    tz: resolveSystemTimeZone(),
   });
 
   return parsed.cronExpression.prev().toDate();

--- a/packages/core/src/scheduler/index.ts
+++ b/packages/core/src/scheduler/index.ts
@@ -33,17 +33,20 @@ export {
   type TriggerMetadata,
 } from "./schedule-runner.js";
 // Schedule state management
+//
+// NOTE: the runtime-mutation plumbing added for edspencer/herdctl#376 —
+// `armScheduleState`, `deleteScheduleState`, `setScheduleTombstone`,
+// `clearScheduleTombstone`, `isScheduleTombstoned` — is deliberately NOT re-exported
+// here. The package root does `export *` from this module, so re-exporting them
+// would leak internal mutators onto the public `@herdctl/core` semver surface.
+// Internal callers (scheduler, schedule-management) and tests import them directly
+// from `./schedule-state.js`. Consumers use the `FleetManager` methods instead.
 export {
-  armScheduleState,
-  clearScheduleTombstone,
-  deleteScheduleState,
   getAgentScheduleStates,
   getScheduleState,
-  isScheduleTombstoned,
   type ScheduleStateLogger,
   type ScheduleStateOptions,
   type ScheduleStateUpdates,
-  setScheduleTombstone,
   updateScheduleState,
 } from "./schedule-state.js";
 

--- a/packages/core/src/scheduler/index.ts
+++ b/packages/core/src/scheduler/index.ts
@@ -13,6 +13,7 @@ export {
   isValidCronExpression,
   type ParsedCronExpression,
   parseCronExpression,
+  resolveSystemTimeZone,
 } from "./cron.js";
 // Errors
 export * from "./errors.js";
@@ -33,6 +34,7 @@ export {
 } from "./schedule-runner.js";
 // Schedule state management
 export {
+  deleteScheduleState,
   getAgentScheduleStates,
   getScheduleState,
   type ScheduleStateLogger,

--- a/packages/core/src/scheduler/index.ts
+++ b/packages/core/src/scheduler/index.ts
@@ -34,6 +34,7 @@ export {
 } from "./schedule-runner.js";
 // Schedule state management
 export {
+  armScheduleState,
   deleteScheduleState,
   getAgentScheduleStates,
   getScheduleState,

--- a/packages/core/src/scheduler/index.ts
+++ b/packages/core/src/scheduler/index.ts
@@ -35,12 +35,15 @@ export {
 // Schedule state management
 export {
   armScheduleState,
+  clearScheduleTombstone,
   deleteScheduleState,
   getAgentScheduleStates,
   getScheduleState,
+  isScheduleTombstoned,
   type ScheduleStateLogger,
   type ScheduleStateOptions,
   type ScheduleStateUpdates,
+  setScheduleTombstone,
   updateScheduleState,
 } from "./schedule-state.js";
 

--- a/packages/core/src/scheduler/schedule-state.ts
+++ b/packages/core/src/scheduler/schedule-state.ts
@@ -175,6 +175,65 @@ export async function updateScheduleState(
 }
 
 /**
+ * Delete the persisted state for a single schedule.
+ *
+ * Removes the `scheduleName` entry from the agent's `schedules` map in fleet
+ * state and writes the result back. This is the prune step for runtime schedule
+ * removal (edspencer/herdctl#376): without it, a removed schedule's persisted
+ * `last_run_at` / `status` (notably a lingering `disabled`) would survive, and a
+ * later re-add of the same name would silently inherit that stale state — the
+ * scheduler reads state, not config, to decide disabled/next-run (scheduler.ts).
+ *
+ * A no-op (no write) if the agent or schedule has no persisted state, so callers
+ * need not check existence first. The rest of the agent's state and its other
+ * schedules are left untouched.
+ *
+ * @param stateDir - Path to the state directory (e.g., .herdctl)
+ * @param agentName - Name of the agent (qualified name is the state key)
+ * @param scheduleName - Name of the schedule to prune
+ * @param options - Options including logger
+ * @returns `true` if state was pruned, `false` if there was nothing to prune
+ *
+ * @example
+ * ```typescript
+ * // After removing a schedule from an agent's config:
+ * await deleteScheduleState('.herdctl', 'my-agent', 'hourly');
+ * ```
+ */
+export async function deleteScheduleState(
+  stateDir: string,
+  agentName: string,
+  scheduleName: string,
+  options: ScheduleStateOptions = {},
+): Promise<boolean> {
+  const stateFilePath = getStateFilePath(stateDir);
+  const fleetState = await readFleetState(stateFilePath, options);
+
+  const agentState = fleetState.agents[agentName];
+  if (!agentState?.schedules || !(scheduleName in agentState.schedules)) {
+    // Nothing persisted for this schedule — leave state untouched.
+    return false;
+  }
+
+  const { [scheduleName]: _removed, ...remainingSchedules } = agentState.schedules;
+
+  const updatedFleetState: FleetState = {
+    ...fleetState,
+    agents: {
+      ...fleetState.agents,
+      [agentName]: {
+        ...agentState,
+        schedules: remainingSchedules,
+      },
+    },
+  };
+
+  await writeFleetState(stateFilePath, updatedFleetState);
+
+  return true;
+}
+
+/**
  * Get all schedule states for a specific agent
  *
  * Returns an empty object if the agent doesn't exist or has no schedules.

--- a/packages/core/src/scheduler/schedule-state.ts
+++ b/packages/core/src/scheduler/schedule-state.ts
@@ -251,10 +251,10 @@ export async function updateScheduleState(
  * need not check existence first. The rest of the agent's state and its other
  * schedules are left untouched.
  *
- * Records a tombstone for the key so that any still-in-flight run's trailing
- * state write is suppressed rather than resurrecting the entry (see
- * {@link updateScheduleState}). The tombstone is lifted when the schedule is
- * re-armed via {@link armScheduleState}.
+ * Does not itself tombstone the key — suppressing a still-in-flight run's
+ * trailing write is the caller's responsibility via {@link setScheduleTombstone}
+ * (see `removeAgentSchedule`), so the tombstone can be set *synchronously* before
+ * this async prune and can't be clobbered by a concurrent re-arm.
  *
  * @param stateDir - Path to the state directory (e.g., .herdctl)
  * @param agentName - Name of the agent (qualified name is the state key)
@@ -277,11 +277,6 @@ export async function deleteScheduleState(
   const stateFilePath = getStateFilePath(stateDir);
 
   return withStateLock(stateFilePath, async () => {
-    // Tombstone first — even if there is nothing on disk to prune yet, an
-    // in-flight run may still be about to write. The tombstone makes that write
-    // a no-op until the schedule is re-armed.
-    tombstonedSchedules.add(tombstoneKey(stateFilePath, agentName, scheduleName));
-
     const fleetState = await readFleetState(stateFilePath, options);
 
     const agentState = fleetState.agents[agentName];
@@ -364,6 +359,61 @@ export async function armScheduleState(
 
     return true;
   });
+}
+
+/**
+ * Lift the resurrection tombstone for a schedule, so its persisted state can be
+ * written again (edspencer/herdctl#376).
+ *
+ * A synchronous, in-memory Set delete — no state-file I/O — so it is safe to call
+ * from the scheduler's synchronous `setAgents`. This is the universal un-tombstone
+ * hook: it is called for every schedule present in an updated agent list (so
+ * `reload()` / `addAgent({replace:true})` / `setAgentSchedule` all re-arm a
+ * removed name cleanly, not just `setAgentSchedule`), when an in-flight run for a
+ * removed schedule completes, and when a removal happens with no in-flight run to
+ * suppress. Without it a stale tombstone would make every `updateScheduleState`
+ * for the re-armed name a silent no-op — `last_run_at` never persists, the
+ * schedule reads as perpetually "due", and it runaway-fires every tick.
+ *
+ * A no-op if the key is not tombstoned.
+ */
+export function clearScheduleTombstone(
+  stateDir: string,
+  agentName: string,
+  scheduleName: string,
+): void {
+  tombstonedSchedules.delete(tombstoneKey(getStateFilePath(stateDir), agentName, scheduleName));
+}
+
+/**
+ * Tombstone a schedule so subsequent {@link updateScheduleState} calls for it are
+ * suppressed (edspencer/herdctl#376) — used to stop a still-in-flight run for a
+ * just-removed schedule from resurrecting its persisted state.
+ *
+ * A synchronous, in-memory Set add — deliberately not part of the async
+ * {@link deleteScheduleState} so the caller can set it with no `await` gap in
+ * which a concurrent re-arm's {@link clearScheduleTombstone} could race ahead.
+ * The tombstone is bounded: it is lifted when the schedule is re-armed via
+ * `setAgents`, when the in-flight run completes (scheduler `executeJob` finally),
+ * or by the remover when there is no in-flight run.
+ */
+export function setScheduleTombstone(
+  stateDir: string,
+  agentName: string,
+  scheduleName: string,
+): void {
+  tombstonedSchedules.add(tombstoneKey(getStateFilePath(stateDir), agentName, scheduleName));
+}
+
+/**
+ * Whether a schedule is currently tombstoned (test/introspection helper).
+ */
+export function isScheduleTombstoned(
+  stateDir: string,
+  agentName: string,
+  scheduleName: string,
+): boolean {
+  return tombstonedSchedules.has(tombstoneKey(getStateFilePath(stateDir), agentName, scheduleName));
 }
 
 /**

--- a/packages/core/src/scheduler/schedule-state.ts
+++ b/packages/core/src/scheduler/schedule-state.ts
@@ -309,15 +309,20 @@ export async function deleteScheduleState(
  * at runtime (edspencer/herdctl#376).
  *
  * Called by `setAgentSchedule`. It does two things under the state-file lock:
- * 1. Lifts any tombstone for the key, so future writes for a re-added schedule
- *    persist again (reversing {@link deleteScheduleState}).
- * 2. Normalizes a lingering `disabled` status to `idle` (clearing `last_error`).
- *    Adding/replacing a schedule only mutates config, but the scheduler skips a
- *    schedule whose *persisted* status is `disabled` — so without this a
- *    set-after-disable would silently never fire, contradicting the
- *    "immediately eligible to fire" contract. Other statuses (e.g. `running`)
- *    and `last_run_at` are left untouched so an in-flight run and interval
- *    cadence are preserved.
+ * Normalizes a lingering `disabled` status to `idle` (clearing `last_error`).
+ * Adding/replacing a schedule only mutates config, but the scheduler skips a
+ * schedule whose *persisted* status is `disabled` — so without this a
+ * set-after-disable would silently never fire, contradicting the "immediately
+ * eligible to fire" contract. Other statuses (e.g. `running`) and `last_run_at`
+ * are left untouched so an in-flight run and interval cadence are preserved.
+ *
+ * Note: this does NOT lift the resurrection tombstone. That is coordinated with
+ * the active execution generation elsewhere ({@link Scheduler.setAgents} lifts it
+ * for a re-armed key only when no run is in flight; the in-flight run's
+ * `executeJob` finally lifts it on completion). Clearing it here unconditionally
+ * would let a still-in-flight removed run's trailing write contaminate the
+ * re-added schedule. Because removal prunes persisted state, a re-add after a
+ * remove finds no entry here and is a no-op — so nothing to un-suppress anyway.
  *
  * @returns `true` if a `disabled` status was normalized to `idle`, else `false`.
  */
@@ -330,8 +335,6 @@ export async function armScheduleState(
   const stateFilePath = getStateFilePath(stateDir);
 
   return withStateLock(stateFilePath, async () => {
-    tombstonedSchedules.delete(tombstoneKey(stateFilePath, agentName, scheduleName));
-
     const fleetState = await readFleetState(stateFilePath, options);
     const agentState = fleetState.agents[agentName];
     const scheduleState = agentState?.schedules?.[scheduleName];

--- a/packages/core/src/scheduler/schedule-state.ts
+++ b/packages/core/src/scheduler/schedule-state.ts
@@ -50,6 +50,59 @@ function getStateFilePath(stateDir: string): string {
   return join(stateDir, STATE_FILE_NAME);
 }
 
+// =============================================================================
+// Concurrency coordination (edspencer/herdctl#376)
+// =============================================================================
+//
+// Schedule-state mutations are read-modify-write on a single shared `state.yaml`.
+// Runtime add/remove of a schedule can now race the scheduler's own per-tick
+// state writes, so two hazards need coordinating:
+//
+//   1. Lost updates — two concurrent RMWs each read the old file and write their
+//      own change; the second write clobbers the first (e.g. a sibling schedule's
+//      status update is dropped). Fixed by serializing every writer per state
+//      file through {@link withStateLock}.
+//   2. Resurrection — a schedule is removed (its persisted state pruned) while a
+//      run for it is still in flight; that run's completion write would recreate
+//      the just-deleted entry. Fixed by a tombstone set: {@link deleteScheduleState}
+//      records the key, and {@link updateScheduleState} becomes a no-op for a
+//      tombstoned key until the schedule is re-armed (which clears the tombstone).
+//
+// Both structures are process-local, keyed by absolute state-file path, so they
+// coordinate every FleetManager/Scheduler sharing one `.herdctl` in this process.
+
+/** Per-state-file promise chain that serializes read-modify-write operations. */
+const stateFileLocks = new Map<string, Promise<unknown>>();
+
+/**
+ * Run `fn` after all previously-enqueued operations on the same state file have
+ * settled, so schedule-state RMWs never interleave. A rejection in one operation
+ * does not poison the chain — the next operation still runs.
+ */
+function withStateLock<T>(stateFilePath: string, fn: () => Promise<T>): Promise<T> {
+  const prev = stateFileLocks.get(stateFilePath) ?? Promise.resolve();
+  // `then(fn, fn)` runs fn once, whether prev fulfilled or rejected.
+  const result = prev.then(fn, fn);
+  // Store a non-throwing tail as the new lock so a rejection can't wedge it.
+  stateFileLocks.set(
+    stateFilePath,
+    result.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return result;
+}
+
+/** Keys of schedules whose state has been pruned and must not be resurrected. */
+const tombstonedSchedules = new Set<string>();
+
+function tombstoneKey(stateFilePath: string, agentName: string, scheduleName: string): string {
+  // JSON-encode the tuple so no separator can collide with a path/name that
+  // happens to contain the delimiter.
+  return JSON.stringify([stateFilePath, agentName, scheduleName]);
+}
+
 /**
  * Get the schedule state for a specific agent and schedule
  *
@@ -136,42 +189,52 @@ export async function updateScheduleState(
   options: ScheduleStateOptions = {},
 ): Promise<ScheduleState> {
   const stateFilePath = getStateFilePath(stateDir);
-  const fleetState = await readFleetState(stateFilePath, options);
 
-  // Get or create agent state
-  const currentAgentState = fleetState.agents[agentName] ?? { status: "idle" };
+  return withStateLock(stateFilePath, async () => {
+    // Resurrection guard: if this schedule has been pruned (removed at runtime)
+    // and not re-armed, an in-flight run's trailing state write must NOT recreate
+    // its entry. Return the would-be value without persisting it.
+    if (tombstonedSchedules.has(tombstoneKey(stateFilePath, agentName, scheduleName))) {
+      return { ...createDefaultScheduleState(), ...updates };
+    }
 
-  // Get current schedules map or create empty one
-  const currentSchedules = currentAgentState.schedules ?? {};
+    const fleetState = await readFleetState(stateFilePath, options);
 
-  // Get current schedule state or create default
-  const currentScheduleState = currentSchedules[scheduleName] ?? createDefaultScheduleState();
+    // Get or create agent state
+    const currentAgentState = fleetState.agents[agentName] ?? { status: "idle" };
 
-  // Merge updates
-  const updatedScheduleState: ScheduleState = {
-    ...currentScheduleState,
-    ...updates,
-  };
+    // Get current schedules map or create empty one
+    const currentSchedules = currentAgentState.schedules ?? {};
 
-  // Update the fleet state
-  const updatedFleetState: FleetState = {
-    ...fleetState,
-    agents: {
-      ...fleetState.agents,
-      [agentName]: {
-        ...currentAgentState,
-        schedules: {
-          ...currentSchedules,
-          [scheduleName]: updatedScheduleState,
+    // Get current schedule state or create default
+    const currentScheduleState = currentSchedules[scheduleName] ?? createDefaultScheduleState();
+
+    // Merge updates
+    const updatedScheduleState: ScheduleState = {
+      ...currentScheduleState,
+      ...updates,
+    };
+
+    // Update the fleet state
+    const updatedFleetState: FleetState = {
+      ...fleetState,
+      agents: {
+        ...fleetState.agents,
+        [agentName]: {
+          ...currentAgentState,
+          schedules: {
+            ...currentSchedules,
+            [scheduleName]: updatedScheduleState,
+          },
         },
       },
-    },
-  };
+    };
 
-  // Write back
-  await writeFleetState(stateFilePath, updatedFleetState);
+    // Write back
+    await writeFleetState(stateFilePath, updatedFleetState);
 
-  return updatedScheduleState;
+    return updatedScheduleState;
+  });
 }
 
 /**
@@ -187,6 +250,11 @@ export async function updateScheduleState(
  * A no-op (no write) if the agent or schedule has no persisted state, so callers
  * need not check existence first. The rest of the agent's state and its other
  * schedules are left untouched.
+ *
+ * Records a tombstone for the key so that any still-in-flight run's trailing
+ * state write is suppressed rather than resurrecting the entry (see
+ * {@link updateScheduleState}). The tombstone is lifted when the schedule is
+ * re-armed via {@link armScheduleState}.
  *
  * @param stateDir - Path to the state directory (e.g., .herdctl)
  * @param agentName - Name of the agent (qualified name is the state key)
@@ -207,30 +275,95 @@ export async function deleteScheduleState(
   options: ScheduleStateOptions = {},
 ): Promise<boolean> {
   const stateFilePath = getStateFilePath(stateDir);
-  const fleetState = await readFleetState(stateFilePath, options);
 
-  const agentState = fleetState.agents[agentName];
-  if (!agentState?.schedules || !(scheduleName in agentState.schedules)) {
-    // Nothing persisted for this schedule — leave state untouched.
-    return false;
-  }
+  return withStateLock(stateFilePath, async () => {
+    // Tombstone first — even if there is nothing on disk to prune yet, an
+    // in-flight run may still be about to write. The tombstone makes that write
+    // a no-op until the schedule is re-armed.
+    tombstonedSchedules.add(tombstoneKey(stateFilePath, agentName, scheduleName));
 
-  const { [scheduleName]: _removed, ...remainingSchedules } = agentState.schedules;
+    const fleetState = await readFleetState(stateFilePath, options);
 
-  const updatedFleetState: FleetState = {
-    ...fleetState,
-    agents: {
-      ...fleetState.agents,
-      [agentName]: {
-        ...agentState,
-        schedules: remainingSchedules,
+    const agentState = fleetState.agents[agentName];
+    if (!agentState?.schedules || !(scheduleName in agentState.schedules)) {
+      // Nothing persisted for this schedule — leave state untouched.
+      return false;
+    }
+
+    const { [scheduleName]: _removed, ...remainingSchedules } = agentState.schedules;
+
+    const updatedFleetState: FleetState = {
+      ...fleetState,
+      agents: {
+        ...fleetState.agents,
+        [agentName]: {
+          ...agentState,
+          schedules: remainingSchedules,
+        },
       },
-    },
-  };
+    };
 
-  await writeFleetState(stateFilePath, updatedFleetState);
+    await writeFleetState(stateFilePath, updatedFleetState);
 
-  return true;
+    return true;
+  });
+}
+
+/**
+ * Prepare a schedule's persisted state so it is eligible to fire when (re-)armed
+ * at runtime (edspencer/herdctl#376).
+ *
+ * Called by `setAgentSchedule`. It does two things under the state-file lock:
+ * 1. Lifts any tombstone for the key, so future writes for a re-added schedule
+ *    persist again (reversing {@link deleteScheduleState}).
+ * 2. Normalizes a lingering `disabled` status to `idle` (clearing `last_error`).
+ *    Adding/replacing a schedule only mutates config, but the scheduler skips a
+ *    schedule whose *persisted* status is `disabled` — so without this a
+ *    set-after-disable would silently never fire, contradicting the
+ *    "immediately eligible to fire" contract. Other statuses (e.g. `running`)
+ *    and `last_run_at` are left untouched so an in-flight run and interval
+ *    cadence are preserved.
+ *
+ * @returns `true` if a `disabled` status was normalized to `idle`, else `false`.
+ */
+export async function armScheduleState(
+  stateDir: string,
+  agentName: string,
+  scheduleName: string,
+  options: ScheduleStateOptions = {},
+): Promise<boolean> {
+  const stateFilePath = getStateFilePath(stateDir);
+
+  return withStateLock(stateFilePath, async () => {
+    tombstonedSchedules.delete(tombstoneKey(stateFilePath, agentName, scheduleName));
+
+    const fleetState = await readFleetState(stateFilePath, options);
+    const agentState = fleetState.agents[agentName];
+    const scheduleState = agentState?.schedules?.[scheduleName];
+
+    // Only a persisted `disabled` status blocks arming; nothing else to do.
+    if (!agentState || !scheduleState || scheduleState.status !== "disabled") {
+      return false;
+    }
+
+    const updatedFleetState: FleetState = {
+      ...fleetState,
+      agents: {
+        ...fleetState.agents,
+        [agentName]: {
+          ...agentState,
+          schedules: {
+            ...agentState.schedules,
+            [scheduleName]: { ...scheduleState, status: "idle", last_error: null },
+          },
+        },
+      },
+    };
+
+    await writeFleetState(stateFilePath, updatedFleetState);
+
+    return true;
+  });
 }
 
 /**

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -249,24 +249,32 @@ export class Scheduler {
   }
 
   /**
-   * Forget the in-memory tracking for a schedule removed at runtime.
+   * Forget the warn-once bookkeeping for a schedule removed at runtime, so a
+   * later re-definition of the same name can warn again about a fresh
+   * misconfiguration. See edspencer/herdctl#376.
    *
-   * Arming reads live `agent.schedules` each tick, so dropping a schedule from an
-   * agent's config already stops it from firing. This additionally clears the two
-   * in-memory maps keyed by schedule that {@link setAgents} does not touch:
-   * - the per-agent running set (so a re-add with the same name isn't wrongly
-   *   treated as "already running" if the removed run's `finally` hasn't cleared
-   *   it yet), and
-   * - the warn-once set (so a previously-warned misconfiguration can warn again
-   *   after the schedule is redefined).
-   *
-   * Does not cancel an in-flight job — a running removed schedule finishes
-   * naturally; this only prevents stale bookkeeping from leaking into a re-add.
-   * A no-op if nothing is tracked for the pair. See edspencer/herdctl#376.
+   * Deliberately does **not** touch the per-agent running set: if a run for the
+   * removed schedule is still in flight, its entry must be retained until that
+   * run's own `finally` clears it. Clearing it early would (a) corrupt
+   * `max_concurrent` accounting and (b) let a same-name re-add fire a second,
+   * concurrent execution instead of being correctly skipped as "already
+   * running". A running removed schedule finishes naturally; arming reads live
+   * `agent.schedules` each tick, so dropping it from config already stops future
+   * fires. A no-op if nothing is tracked for the pair.
    */
   clearScheduleTracking(agentName: string, scheduleName: string): void {
-    this.runningSchedules.get(agentName)?.delete(scheduleName);
     this.warnedSchedules.delete(`${agentName}/${scheduleName}`);
+  }
+
+  /**
+   * Whether a run for the given schedule is currently tracked as in-flight.
+   *
+   * Lets a runtime mutation (e.g. `removeAgentSchedule`) reason about active
+   * execution — the removed schedule's config is dropped immediately, but any
+   * in-flight run continues to completion. See edspencer/herdctl#376.
+   */
+  isScheduleRunning(agentName: string, scheduleName: string): boolean {
+    return this.runningSchedules.get(agentName)?.has(scheduleName) ?? false;
   }
 
   /**

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -249,6 +249,27 @@ export class Scheduler {
   }
 
   /**
+   * Forget the in-memory tracking for a schedule removed at runtime.
+   *
+   * Arming reads live `agent.schedules` each tick, so dropping a schedule from an
+   * agent's config already stops it from firing. This additionally clears the two
+   * in-memory maps keyed by schedule that {@link setAgents} does not touch:
+   * - the per-agent running set (so a re-add with the same name isn't wrongly
+   *   treated as "already running" if the removed run's `finally` hasn't cleared
+   *   it yet), and
+   * - the warn-once set (so a previously-warned misconfiguration can warn again
+   *   after the schedule is redefined).
+   *
+   * Does not cancel an in-flight job — a running removed schedule finishes
+   * naturally; this only prevents stale bookkeeping from leaking into a re-add.
+   * A no-op if nothing is tracked for the pair. See edspencer/herdctl#376.
+   */
+  clearScheduleTracking(agentName: string, scheduleName: string): void {
+    this.runningSchedules.get(agentName)?.delete(scheduleName);
+    this.warnedSchedules.delete(`${agentName}/${scheduleName}`);
+  }
+
+  /**
    * Log a warning only once per schedule key, to avoid spamming on every tick.
    */
   private warnOnce(key: string, message: string): void {

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -250,16 +250,24 @@ export class Scheduler {
 
     // Universal re-arm hook (edspencer/herdctl#376): every path that (re-)arms a
     // schedule — reload(), addAgent({replace}), setAgentSchedule — funnels through
-    // here. Lifting the resurrection tombstone for every schedule PRESENT in the
-    // new list ensures a schedule brought back from disk (or re-added) resumes
-    // normal state persistence instead of staying tombstoned, which would make
-    // updateScheduleState a silent no-op and cause runaway per-tick firing. A
-    // schedule that is NOT in the new list keeps its tombstone (it may still have
-    // an in-flight run whose trailing write must be suppressed).
+    // here. Lifting the resurrection tombstone for a schedule PRESENT in the new
+    // list lets it resume normal state persistence instead of staying tombstoned,
+    // which would make updateScheduleState a silent no-op and cause runaway
+    // per-tick firing.
+    //
+    // BUT only lift it when NO run for that key is still in flight. If the removed
+    // generation's run is still executing, its trailing `next_run_at`/`last_error`
+    // write must stay suppressed — clearing the tombstone now would let that old
+    // write land on (and contaminate) the freshly re-added schedule. The in-flight
+    // run's own `executeJob` finally lifts the tombstone once its trailing writes
+    // are done, at which point the re-armed schedule persists cleanly. A schedule
+    // absent from the new list keeps its tombstone regardless.
     for (const agent of agents) {
       if (!agent.schedules) continue;
       for (const scheduleName of Object.keys(agent.schedules)) {
-        clearScheduleTombstone(this.stateDir, agent.qualifiedName, scheduleName);
+        if (!this.isScheduleRunning(agent.qualifiedName, scheduleName)) {
+          clearScheduleTombstone(this.stateDir, agent.qualifiedName, scheduleName);
+        }
       }
     }
 

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -15,8 +15,10 @@ import {
 import { SchedulerShutdownError } from "./errors.js";
 import { calculateNextTrigger, isScheduleDue } from "./interval.js";
 import {
+  clearScheduleTombstone,
   getScheduleState,
   type ScheduleStateLogger,
+  setScheduleTombstone,
   updateScheduleState,
 } from "./schedule-state.js";
 import type {
@@ -245,6 +247,22 @@ export class Scheduler {
    */
   setAgents(agents: ResolvedAgent[]): void {
     this.agents = agents;
+
+    // Universal re-arm hook (edspencer/herdctl#376): every path that (re-)arms a
+    // schedule — reload(), addAgent({replace}), setAgentSchedule — funnels through
+    // here. Lifting the resurrection tombstone for every schedule PRESENT in the
+    // new list ensures a schedule brought back from disk (or re-added) resumes
+    // normal state persistence instead of staying tombstoned, which would make
+    // updateScheduleState a silent no-op and cause runaway per-tick firing. A
+    // schedule that is NOT in the new list keeps its tombstone (it may still have
+    // an in-flight run whose trailing write must be suppressed).
+    for (const agent of agents) {
+      if (!agent.schedules) continue;
+      for (const scheduleName of Object.keys(agent.schedules)) {
+        clearScheduleTombstone(this.stateDir, agent.qualifiedName, scheduleName);
+      }
+    }
+
     this.logger.debug(`Updated agents list: ${agents.length} agents`);
   }
 
@@ -275,6 +293,17 @@ export class Scheduler {
    */
   isScheduleRunning(agentName: string, scheduleName: string): boolean {
     return this.runningSchedules.get(agentName)?.has(scheduleName) ?? false;
+  }
+
+  /**
+   * Synchronously tombstone a schedule's persisted state (edspencer/herdctl#376),
+   * so a still-in-flight run for a just-removed schedule cannot resurrect it via a
+   * trailing `updateScheduleState` write. Set with no `await` gap by the remover
+   * (see `removeAgentSchedule`) so a concurrent re-arm can't clear it first. Lifted
+   * again by {@link setAgents} on re-arm or by the run's own `executeJob` finally.
+   */
+  tombstoneSchedule(agentName: string, scheduleName: string): void {
+    setScheduleTombstone(this.stateDir, agentName, scheduleName);
   }
 
   /**
@@ -687,6 +716,14 @@ export class Scheduler {
     } finally {
       // Mark schedule as no longer running
       this.runningSchedules.get(agent.qualifiedName)?.delete(scheduleName);
+
+      // Bound tombstone lifetime to the run (edspencer/herdctl#376): a schedule
+      // removed while this run was in flight was tombstoned to suppress this run's
+      // trailing state writes above. Now that the run is done there is no further
+      // writer to guard against, so lift the tombstone. Harmless no-op for a
+      // schedule that was never removed. Runs after the trailing writes, so their
+      // suppression still held while they executed.
+      clearScheduleTombstone(this.stateDir, agent.qualifiedName, scheduleName);
     }
   }
 }


### PR DESCRIPTION
Makes herdctl's scheduler host-friendly so an embedding host (Paddock) can **own execution** and **mutate schedules at runtime**. Implements **#375 (D1)** and **#376 (D2)** together — they touch the same files (fleet-manager, schedule-management, scheduler, schedule-state), so splitting would only conflict with itself.

All changes are **additive and backward-compatible** — existing headless fleets behave exactly as before; every new capability is opt-in.

## D1 (#375) — host-execution seam
- **`FleetManager.setScheduleTriggerHandler(handler)`**, mirroring `setSessionWakeHandler`. When set, `handleScheduleTrigger` routes a fired schedule to the host handler (`await handler(info); return;`) and skips the built-in headless `ScheduleExecutor`; when unset, schedules run headless as before. No Scheduler-core timing change — cron/interval scheduling is untouched, only the *execution* of a due trigger is intercepted. Every scheduler-fired trigger (including a forced immediate fire) funnels through the seam.
- **Relative-wake timezone hardening (#311):** new `resolveSystemTimeZone()` centralizes the host-timezone lookup used by `calculateNextCronTrigger`/`calculatePreviousCronTrigger`, falling back to `UTC` when an ICU-less runtime reports no timezone (which could otherwise revive the 24h-idle bug).

## D2 (#376) — runtime schedule mutation
- **`FleetManager.setAgentSchedule(agent, name, schedule)`** — validates against `ScheduleSchema`, sets the key on the stored agent, and re-pushes via `scheduler.setAgents(...)`. Arming reads live `agent.schedules` each tick, so the schedule is immediately eligible to fire.
- **`FleetManager.removeAgentSchedule(agent, name)`** — deletes the key, re-pushes, **prunes persisted state** via a new `deleteScheduleState` helper in `scheduler/schedule-state.ts`, and clears the in-memory `runningSchedules`/`warnedSchedules` entries via a new `Scheduler.clearScheduleTracking`. Without the prune, a removed schedule's `last_run_at`/`disabled` status would linger and a re-added name would silently inherit it (the scheduler reads state, not config, to decide disabled/next-run).
- **Per-deployment mutation gate:** new `allowScheduleMutation` FleetManager option (default `false`). Both mutation methods throw the new `ScheduleMutationDisabledError` when it's not enabled. Enable/disable of existing schedules stays ungated. This is the opt-in safety control — there was none before.

Mirrors the existing `enableSchedule`/`disableSchedule` + `AgentManagement.commit` patterns throughout.

## Tests
- Seam calls the host handler when set, and falls back to headless when not (plus clearing the handler restores headless).
- `setAgentSchedule` arms a new schedule on an already-running agent (the scheduler fires it), validates input, and rejects unknown agents.
- `removeAgentSchedule` prunes persisted state so a re-added name starts clean (no stale `last_run_at`/`disabled`).
- The mutation gate blocks both methods when disabled, leaves enable/disable ungated, and allows mutation when opted in.
- Unit coverage for `deleteScheduleState` and `resolveSystemTimeZone` (incl. the ICU-less UTC fallback).

Full `@herdctl/core` suite green except one pre-existing, environment-specific failure unrelated to this change (`directory.test.ts` "parent directory not writable" — the assertion depends on `chmod` denying writes, which doesn't hold when tests run as root; fails identically on clean `main`). Typecheck, full monorepo build, and docs build all pass. Docs (library-reference + error-handling) and a changeset (`@herdctl/core` minor) are included.

Closes #375
Closes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in host execution hook for scheduler-fired schedules, including forced/immediate triggers, with headless fallback when unset.
  * Added runtime APIs to set/replace or remove a single agent schedule (programmatic add/remove after registration).
  * Added an opt-in `allowScheduleMutation` gate (default off) for runtime schedule edits.
* **Bug Fixes**
  * Prevented resurrection of deleted/stale schedule state and improved safety for concurrent schedule mutations.
  * Hardened timezone handling with deterministic UTC fallback in timezone resolution.
* **Documentation**
  * Documented the new option, APIs, execution handler, and the `ScheduleMutationDisabledError` (including error code).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->