### PR TITLE
feat(core): add spawned trigger type (#377)

### DIFF
--- a/.changeset/trigger-type-spawned-377.md
+++ b/.changeset/trigger-type-spawned-377.md
@@ -1,0 +1,19 @@
+---
+"@herdctl/core": minor
+"@herdctl/web": minor
+---
+
+Add `spawned` trigger type (#377)
+
+Extend `TriggerTypeSchema` with an explicit `spawned` value so a host (e.g. paddock)
+can persist run provenance for agent-spawned jobs as a first-class enum rather than
+inferring it. Additive and backward-compatible — existing headless fleets are
+unchanged.
+
+- **core:** `spawned` added to `TriggerTypeSchema` (and therefore the `TriggerType`
+  type). `schedule` already covers scheduled runs, so no separate `scheduled` value
+  is introduced.
+- **web:** the job-history trigger-type icon/label map renders `spawned` with a
+  `Bot` icon labelled "Spawned".
+
+Supports paddock#267 (provenance badges).

--- a/packages/core/src/state/__tests__/job-metadata-schema.test.ts
+++ b/packages/core/src/state/__tests__/job-metadata-schema.test.ts
@@ -32,6 +32,10 @@ describe("TriggerTypeSchema", () => {
     expect(TriggerTypeSchema.parse("webhook")).toBe("webhook");
     expect(TriggerTypeSchema.parse("chat")).toBe("chat");
     expect(TriggerTypeSchema.parse("fork")).toBe("fork");
+    expect(TriggerTypeSchema.parse("discord")).toBe("discord");
+    expect(TriggerTypeSchema.parse("slack")).toBe("slack");
+    expect(TriggerTypeSchema.parse("web")).toBe("web");
+    expect(TriggerTypeSchema.parse("spawned")).toBe("spawned");
   });
 
   it("rejects invalid trigger types", () => {
@@ -230,6 +234,27 @@ describe("JobMetadataSchema", () => {
       const result = JobMetadataSchema.parse(forkedJob);
       expect(result.trigger_type).toBe("fork");
       expect(result.forked_from).toBe("job-2024-01-15-abc123");
+    });
+
+    it("parses a spawned job", () => {
+      const spawnedJob: JobMetadata = {
+        id: "job-2024-01-15-spawn1",
+        agent: "test-agent",
+        schedule: null,
+        trigger_type: "spawned",
+        status: "running",
+        exit_reason: null,
+        session_id: "session-spawn",
+        forked_from: null,
+        started_at: "2024-01-15T11:00:00Z",
+        finished_at: null,
+        duration_seconds: null,
+        prompt: "Handle the spawned task",
+        summary: null,
+        output_file: null,
+      };
+      const result = JobMetadataSchema.parse(spawnedJob);
+      expect(result.trigger_type).toBe("spawned");
     });
   });
 });

--- a/packages/core/src/state/schemas/job-metadata.ts
+++ b/packages/core/src/state/schemas/job-metadata.ts
@@ -28,6 +28,7 @@ export const TriggerTypeSchema = z.enum([
   "slack",
   "web",
   "fork",
+  "spawned",
 ]);
 
 /**

--- a/packages/web/src/client/src/components/jobs/JobHistory.tsx
+++ b/packages/web/src/client/src/components/jobs/JobHistory.tsx
@@ -6,6 +6,7 @@
  */
 
 import {
+  Bot,
   CalendarClock,
   ChevronLeft,
   ChevronRight,
@@ -146,6 +147,7 @@ function TriggerTypeIcon({ type }: { type?: TriggerType }) {
     webhook: { icon: <Webhook className={iconClass} />, label: "Webhook" },
     chat: { icon: <MessageSquare className={iconClass} />, label: "Chat" },
     fork: { icon: <GitFork className={iconClass} />, label: "Fork" },
+    spawned: { icon: <Bot className={iconClass} />, label: "Spawned" },
   };
 
   const { icon, label } = map[t] ?? map.manual;

--- a/packages/web/src/client/src/lib/types.ts
+++ b/packages/web/src/client/src/lib/types.ts
@@ -145,7 +145,8 @@ export type TriggerType =
   | "discord"
   | "slack"
   | "web"
-  | "fork";
+  | "fork"
+  | "spawned";
 
 export interface JobSummary {
   jobId: string;


### PR DESCRIPTION
## Summary

Closes #377 (**E2**). Adds an explicit `spawned` value to `TriggerTypeSchema` so a host (e.g. paddock) can persist run provenance for agent-spawned jobs as a first-class enum rather than inferring it. Additive and backward-compatible — no behaviour change for existing headless fleets.

## `scheduled` vs `schedule`

The ticket asks for `spawned` and, *if not already covered*, a distinct `scheduled`. The existing enum already has `schedule`, which is exactly the "triggered by a schedule" provenance — so a separate `scheduled` would be redundant. **Only `spawned` is added.**

## Changes

- **`@herdctl/core`** — `spawned` added to `TriggerTypeSchema` (and therefore the exported `TriggerType`).
- **`@herdctl/web`** — the job-history trigger-type icon/label map (`JobHistory.tsx`) renders `spawned` with a `Bot` icon labelled "Spawned"; the client `TriggerType` union in `types.ts` gains the value.
- **tests** — extend the `TriggerTypeSchema` enum test to cover `spawned` (plus the previously-untested `discord`/`slack`/`web`), and add a full-schema parse of a spawned job.
- **changeset** — minor bump for `@herdctl/core` + `@herdctl/web`.

## Verification

- `pnpm typecheck` — all 11 packages pass (includes the web build).
- `vitest run` on `job-metadata-schema.test.ts` — 40 tests pass.
- `biome check` — clean.

Supports paddock#267 (provenance badges).