### PR TITLE
feat(core,chat): stream partial assistant-text deltas on the SDK runtime

### DIFF
--- a/.changeset/stream-partial-assistant-text.md
+++ b/.changeset/stream-partial-assistant-text.md
@@ -1,0 +1,19 @@
+---
+"@herdctl/core": minor
+"@herdctl/chat": minor
+---
+
+Stream partial assistant-text deltas on the SDK runtime.
+
+- **@herdctl/core:** add an opt-in `includePartialMessages` flag on
+  `ChatSessionOptions` / `RuntimeExecuteOptions` (and `SDKQueryOptions`), threaded
+  from `openChatSession` down to the SDK `query()`. When set, the SDK emits
+  `stream_event` / `text_delta` chunks so callers can stream assistant text
+  token-by-token. Default off — batch/one-shot and non-opting session callers are
+  unchanged.
+- **@herdctl/chat:** `SDKMessageTranslator` now handles `stream_event` messages,
+  emitting incremental `onText(delta)` calls for `content_block_delta` /
+  `text_delta` events, and suppresses the terminal whole-`assistant` text re-emit
+  when its text already streamed as deltas (the `onText` contract stays "deltas,
+  in order"). Boundary and tool-call semantics are preserved; the partials-off
+  path is byte-for-byte unchanged (one `onText` per assistant content block).

--- a/packages/chat/src/__tests__/sdk-message-translator.test.ts
+++ b/packages/chat/src/__tests__/sdk-message-translator.test.ts
@@ -99,6 +99,36 @@ function subagentToolUse(
   } as unknown as SDKMessage;
 }
 
+/**
+ * A partial-message text delta, as the SDK emits it when
+ * `includePartialMessages` is on: `type: "stream_event"` wrapping a
+ * `content_block_delta` whose `delta` is a `text_delta`.
+ */
+function textDelta(text: string, parentToolUseId: string | null = null): SDKMessage {
+  return {
+    type: "stream_event",
+    parent_tool_use_id: parentToolUseId,
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text },
+    },
+  } as unknown as SDKMessage;
+}
+
+/** A non-text stream event (e.g. a tool input-json delta) the translator ignores. */
+function inputJsonDelta(partialJson: string): SDKMessage {
+  return {
+    type: "stream_event",
+    parent_tool_use_id: null,
+    event: {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: partialJson },
+    },
+  } as unknown as SDKMessage;
+}
+
 /** A subagent's `tool_result` user message (carries `parent_tool_use_id`). */
 function subagentToolResult(
   toolUseId: string,
@@ -593,6 +623,120 @@ describe("SDKMessageTranslator", () => {
       await t.handle(toolResult("t1", "late"));
       expect(calls[0].toolName).toBe("Tool");
     });
+  });
+});
+
+describe("partial-message text streaming (stream_event / text_delta)", () => {
+  it("emits ordered incremental onText for each text_delta", async () => {
+    const chunks: string[] = [];
+    const t = new SDKMessageTranslator({ onText: (text) => void chunks.push(text) });
+
+    await t.handle(textDelta("Hel"));
+    await t.handle(textDelta("lo, "));
+    await t.handle(textDelta("world"));
+
+    expect(chunks).toEqual(["Hel", "lo, ", "world"]);
+  });
+
+  it("threads agent attribution from the partial message onto each delta", async () => {
+    const onText = vi.fn();
+    const t = new SDKMessageTranslator({ onText });
+
+    await t.handle(textDelta("sub", "task-1"));
+
+    expect(onText).toHaveBeenCalledWith("sub", { parentToolUseId: "task-1" });
+  });
+
+  it("does NOT re-emit the terminal assistant text once it streamed as deltas", async () => {
+    const chunks: string[] = [];
+    const t = new SDKMessageTranslator({ onText: (text) => void chunks.push(text) });
+
+    // Deltas for one assistant message, then the terminal whole assistant message
+    // carrying the fully-assembled text (as the SDK sends it after the stream).
+    await t.handle(textDelta("Hello "));
+    await t.handle(textDelta("world"));
+    await t.handle(assistantText("Hello world"));
+
+    // Only the two deltas — the terminal whole-text emit is suppressed.
+    expect(chunks).toEqual(["Hello ", "world"]);
+  });
+
+  it("still tracks tool_use on the terminal assistant message after streaming text", async () => {
+    const chunks: string[] = [];
+    const starts: TranslatedToolStart[] = [];
+    const calls: TranslatedToolCall[] = [];
+    const t = new SDKMessageTranslator({
+      onText: (text) => void chunks.push(text),
+      onToolStart: (s) => void starts.push(s),
+      onToolCall: (c) => void calls.push(c),
+    });
+
+    // Assistant streams text, then the terminal message carries BOTH the text and
+    // a tool_use block; the tool must still be surfaced and paired.
+    await t.handle(textDelta("Let me read "));
+    await t.handle(textDelta("that file."));
+    await t.handle({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Let me read that file." },
+          { type: "tool_use", id: "t1", name: "Read", input: { file_path: "/a" } },
+        ],
+      },
+    } as unknown as SDKMessage);
+    await t.handle(toolResult("t1", "file contents"));
+
+    expect(chunks).toEqual(["Let me read ", "that file."]);
+    expect(starts[0]).toMatchObject({ toolName: "Read", toolUseId: "t1" });
+    expect(calls[0]).toMatchObject({ toolName: "Read", output: "file contents" });
+  });
+
+  it("ignores non-text stream events (tool input-json deltas)", async () => {
+    const onText = vi.fn();
+    const t = new SDKMessageTranslator({ onText });
+
+    await t.handle(inputJsonDelta('{"command":"l'));
+    await t.handle(inputJsonDelta('s"}'));
+
+    expect(onText).not.toHaveBeenCalled();
+  });
+
+  it("emits a boundary between two streamed assistant turns, once, on the first delta", async () => {
+    const order: string[] = [];
+    const t = new SDKMessageTranslator({
+      onText: (text) => void order.push(`text:${text}`),
+      onBoundary: () => void order.push("boundary"),
+    });
+
+    // First streamed message.
+    await t.handle(textDelta("first "));
+    await t.handle(textDelta("turn"));
+    await t.handle(assistantText("first turn"));
+    // Second streamed message, no tool call in between → one boundary, on delta 1.
+    await t.handle(textDelta("second "));
+    await t.handle(textDelta("turn"));
+    await t.handle(assistantText("second turn"));
+
+    expect(order).toEqual(["text:first ", "text:turn", "boundary", "text:second ", "text:turn"]);
+  });
+
+  it("does not emit a boundary for streamed text immediately after a tool result", async () => {
+    const onBoundary = vi.fn();
+    const t = new SDKMessageTranslator({
+      onText: vi.fn(),
+      onBoundary,
+      onToolCall: vi.fn(),
+    });
+
+    await t.handle(textDelta("before "));
+    await t.handle(textDelta("tool"));
+    await t.handle(assistantText("before tool"));
+    await t.handle(assistantToolUse("t1", "Read", { file_path: "/a" }));
+    await t.handle(toolResult("t1", "contents"));
+    // Streamed text right after the tool result — a fresh bubble, no boundary.
+    await t.handle(textDelta("after tool"));
+
+    expect(onBoundary).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/chat/src/message-extraction.ts
+++ b/packages/chat/src/message-extraction.ts
@@ -52,6 +52,58 @@ export interface SDKMessage {
      */
     model?: string;
   };
+  /**
+   * Present on `type: "stream_event"` partial-assistant messages (emitted only
+   * when the SDK runs with `includePartialMessages`). Carries a raw Anthropic
+   * message-stream event; the translator reads `content_block_delta` events whose
+   * `delta.type === "text_delta"` to stream assistant text token-by-token. A
+   * minimal structural shape is defined here to avoid depending on the full
+   * Anthropic SDK.
+   */
+  event?: StreamEvent;
+}
+
+/**
+ * A raw Anthropic message-stream event, as carried by an SDK
+ * `SDKPartialAssistantMessage` (`type: "stream_event"`). Only the
+ * `content_block_delta` → `text_delta` shape is consumed by the translator;
+ * other event types (message_start/stop, tool input deltas, thinking deltas,
+ * etc.) are ignored. Minimal by design.
+ */
+export interface StreamEvent {
+  type: string;
+  /** Present on `content_block_delta` events. */
+  delta?: {
+    type: string;
+    /** Present on a `text_delta` delta. */
+    text?: string;
+    [key: string]: unknown;
+  };
+  /** Content-block index the delta applies to. */
+  index?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Extract the incremental assistant text from a partial-message stream event.
+ *
+ * Returns the delta text for a `content_block_delta` carrying a `text_delta`,
+ * or `undefined` for any other event (message boundaries, tool input-json
+ * deltas, thinking deltas, empty text, …) so callers can ignore it.
+ *
+ * @param event - The `event` payload of a `type: "stream_event"` SDK message
+ * @returns The text delta to append, or `undefined` if this event carries none
+ */
+export function extractTextDelta(event: StreamEvent | undefined): string | undefined {
+  if (
+    event?.type === "content_block_delta" &&
+    event.delta?.type === "text_delta" &&
+    typeof event.delta.text === "string" &&
+    event.delta.text.length > 0
+  ) {
+    return event.delta.text;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/chat/src/sdk-message-translator.ts
+++ b/packages/chat/src/sdk-message-translator.ts
@@ -21,6 +21,7 @@
 import {
   type AgentAttribution,
   extractMessageContent,
+  extractTextDelta,
   getAgentAttribution,
   isSyntheticMessage,
   type SDKMessage,
@@ -237,6 +238,14 @@ export class SDKMessageTranslator {
   private readonly pendingToolUses = new Map<string, PendingToolUse>();
   /** Whether the current assistant turn has already emitted text */
   private hasAssistantText = false;
+  /**
+   * Whether the current assistant message already streamed its text via partial
+   * `stream_event` / `text_delta` chunks. Set as deltas arrive; consumed when the
+   * terminal whole `assistant` message lands so its text is NOT re-emitted (the
+   * `onText` contract stays "deltas, in order"). Only ever true when the SDK runs
+   * with `includePartialMessages`; the whole-message path is untouched otherwise.
+   */
+  private streamedTextInMessage = false;
 
   constructor(handlers: SDKMessageHandlers, options?: SDKMessageTranslatorOptions) {
     this.handlers = handlers;
@@ -253,7 +262,9 @@ export class SDKMessageTranslator {
    * @param message - One message from the trigger's `onMessage` stream
    */
   async handle(message: SDKMessage): Promise<void> {
-    if (message.type === "assistant") {
+    if (message.type === "stream_event") {
+      await this.handleStreamEvent(message);
+    } else if (message.type === "assistant") {
       await this.handleAssistant(message);
     } else if (message.type === "user") {
       await this.handleUser(message);
@@ -267,9 +278,45 @@ export class SDKMessageTranslator {
   reset(): void {
     this.pendingToolUses.clear();
     this.hasAssistantText = false;
+    this.streamedTextInMessage = false;
   }
 
   // ---------------------------------------------------------------------------
+
+  /**
+   * Handle a partial-message `stream_event` (emitted only when the SDK runs with
+   * `includePartialMessages`). Surfaces incremental assistant text: a
+   * `content_block_delta` carrying a `text_delta` is emitted as an ordered
+   * `onText(delta)` call, so consumers stream token-by-token. All other stream
+   * events (message start/stop, tool input-json deltas, thinking deltas, …) are
+   * ignored here — the terminal whole `assistant` message still drives tool
+   * tracking and boundaries.
+   *
+   * Boundary parity with the whole-message path: the FIRST text delta of a new
+   * assistant message applies the same "new turn after prior text → boundary"
+   * rule as {@link handleAssistant}; later deltas of the same message just
+   * append. The terminal `assistant` message then suppresses its (already
+   * streamed) text via {@link streamedTextInMessage}.
+   */
+  private async handleStreamEvent(message: SDKMessage): Promise<void> {
+    const text = extractTextDelta(message.event);
+    if (text === undefined) return;
+
+    const attribution = getAgentAttribution(message);
+
+    // First text delta of this assistant message: apply boundary semantics once,
+    // exactly as the whole-message path does before its single onText.
+    if (!this.streamedTextInMessage) {
+      if (this.hasAssistantText) {
+        this.hasAssistantText = false;
+        await this.handlers.onBoundary?.(attribution);
+      }
+      this.streamedTextInMessage = true;
+      this.hasAssistantText = true;
+    }
+
+    await this.handlers.onText?.(text, attribution);
+  }
 
   private async handleAssistant(message: SDKMessage): Promise<void> {
     // The Claude Code CLI emits synthetic placeholder turns (model
@@ -283,8 +330,15 @@ export class SDKMessageTranslator {
     // separate main vs. subagent lanes.
     const attribution = getAgentAttribution(message);
 
+    // If this message's text already streamed as `text_delta` chunks (partials
+    // enabled), consume that flag and suppress the whole-text re-emit — the
+    // deltas already carried it, and `hasAssistantText`/boundary state was set as
+    // they streamed. Tool tracking below still runs on the terminal message.
+    const alreadyStreamed = this.streamedTextInMessage;
+    this.streamedTextInMessage = false;
+
     const content = extractMessageContent(message);
-    if (content) {
+    if (content && !alreadyStreamed) {
       // A new assistant turn after a previous one produced text → boundary.
       if (this.hasAssistantText) {
         this.hasAssistantText = false;

--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -412,6 +412,7 @@ export class JobControl {
       resume: sessionId,
       injectedMcpServers: options?.injectedMcpServers,
       systemPromptAppend: options?.systemPromptAppend,
+      includePartialMessages: options?.includePartialMessages,
       onLifecycleSignal,
     });
 

--- a/packages/core/src/fleet-manager/types.ts
+++ b/packages/core/src/fleet-manager/types.ts
@@ -722,6 +722,18 @@ export interface ChatSessionOptions {
   systemPromptAppend?: string;
 
   /**
+   * Opt in to partial (streaming) assistant messages for this session.
+   *
+   * When `true`, `includePartialMessages` is set on the underlying SDK
+   * `query()`, so the session stream carries incremental `stream_event` /
+   * `text_delta` chunks in addition to the terminal whole `assistant` message.
+   * A stream translator (e.g. `@herdctl/chat`'s `SDKMessageTranslator`) turns
+   * these into token-by-token assistant text for the UI. Defaults to off —
+   * whole-message behavior is preserved for callers that don't opt in.
+   */
+  includePartialMessages?: boolean;
+
+  /**
    * Opt in to herdctl-managed session lifecycle (edspencer/herdctl#307).
    *
    * When `true` and the fleet has a session-lifecycle manager, the session is

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-partials.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-partials.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests that the SDK runtime forwards the `includePartialMessages` opt-in to the
+ * SDK `query()` — on for callers that request partial (streaming) assistant
+ * messages, and left unset (SDK default: off) otherwise, so batch/one-shot and
+ * non-opting session callers are unchanged.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Capture the options every query() receives.
+const queryCalls: Array<Record<string, unknown>> = [];
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  // execute() consumes the returned iterable; yield nothing.
+  query: vi.fn((args: { options?: Record<string, unknown> }) => {
+    queryCalls.push(args.options ?? {});
+    return (async function* () {})();
+  }),
+  createSdkMcpServer: vi.fn(() => ({})),
+  tool: vi.fn(() => ({})),
+}));
+
+import type { ResolvedAgent } from "../../../config/index.js";
+import type { RuntimeExecuteOptions } from "../interface.js";
+import { SDKRuntime } from "../sdk-runtime.js";
+
+const agent = { name: "keeper", qualifiedName: "keeper" } as unknown as ResolvedAgent;
+
+function baseOptions(overrides: Partial<RuntimeExecuteOptions> = {}): RuntimeExecuteOptions {
+  return { prompt: "hi", agent, ...overrides };
+}
+
+afterEach(() => {
+  queryCalls.length = 0;
+});
+
+describe("SDKRuntime includePartialMessages", () => {
+  describe("execute()", () => {
+    it("sets includePartialMessages on query() when opted in", async () => {
+      const runtime = new SDKRuntime();
+      // Drain the generator so query() actually runs.
+      for await (const _ of runtime.execute(baseOptions({ includePartialMessages: true }))) {
+        // no messages yielded
+      }
+
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].includePartialMessages).toBe(true);
+    });
+
+    it("does NOT set includePartialMessages by default", async () => {
+      const runtime = new SDKRuntime();
+      for await (const _ of runtime.execute(baseOptions())) {
+        // no messages yielded
+      }
+
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].includePartialMessages).toBeUndefined();
+    });
+  });
+
+  describe("openSession()", () => {
+    it("sets includePartialMessages on query() when opted in", () => {
+      const runtime = new SDKRuntime();
+      runtime.openSession(baseOptions({ includePartialMessages: true }));
+
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].includePartialMessages).toBe(true);
+    });
+
+    it("does NOT set includePartialMessages by default", () => {
+      const runtime = new SDKRuntime();
+      runtime.openSession(baseOptions());
+
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].includePartialMessages).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/runner/runtime/interface.ts
+++ b/packages/core/src/runner/runtime/interface.ts
@@ -49,6 +49,18 @@ export interface RuntimeExecuteOptions {
   systemPromptAppend?: string;
 
   /**
+   * Request partial (streaming) assistant messages from the SDK.
+   *
+   * When `true`, `includePartialMessages` is set on the SDK `query()` options so
+   * the stream carries incremental `stream_event` / `text_delta` chunks in
+   * addition to the terminal whole `assistant` message. Consumers that translate
+   * the stream (e.g. `@herdctl/chat`'s `SDKMessageTranslator`) can then surface
+   * assistant text token-by-token. Default off, so batch/one-shot callers and
+   * existing session callers are unchanged; streaming-session callers opt in.
+   */
+  includePartialMessages?: boolean;
+
+  /**
    * Streaming sessions only: observe the session's background-work lifecycle.
    *
    * Called at each turn boundary (the SDK main-agent `Stop` hook) and when

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -245,6 +245,15 @@ export class SDKRuntime implements RuntimeInterface {
       fork: options.fork,
     });
 
+    // Opt in to partial (streaming) assistant messages when the caller requested
+    // it. This makes the SDK query() emit `stream_event` / `text_delta` chunks so
+    // consumers can stream assistant text token-by-token. Left unset (SDK default:
+    // off) for batch/one-shot and non-opting session callers, so their streams
+    // still carry only whole `assistant` messages.
+    if (options.includePartialMessages) {
+      sdkOptions.includePartialMessages = true;
+    }
+
     // Apply system prompt append if provided (e.g., concise mode for chat platforms)
     if (options.systemPromptAppend) {
       const current = sdkOptions.systemPrompt;

--- a/packages/core/src/runner/types.ts
+++ b/packages/core/src/runner/types.ts
@@ -250,6 +250,15 @@ export interface SDKQueryOptions {
   /** Model to use for the session */
   model?: string;
   /**
+   * Request partial (streaming) assistant messages. When `true`, the SDK
+   * `query()` emits `stream_event` messages carrying incremental
+   * `content_block_delta` / `text_delta` chunks in addition to the terminal
+   * whole `assistant` message. Default off — set only by streaming-session
+   * callers that opt in (see `ChatSessionOptions.includePartialMessages`); batch
+   * / one-shot callers are unaffected.
+   */
+  includePartialMessages?: boolean;
+  /**
    * SDK lifecycle hooks (`Stop`, `SubagentStop`, …). Not set by `toSDKOptions`;
    * injected by the SDK runtime for streaming sessions to observe turn
    * boundaries. Typed against the SDK's own `Options["hooks"]`.


### PR DESCRIPTION
## Summary

Fixes #382 — the SDK runtime and the `@herdctl/chat` translator surface assistant text only as **whole `assistant` messages**, so consumers (e.g. Paddock's chat UI) render each reply in one drop rather than streaming token-by-token. This adds true streaming of partial assistant text through the stack, behind an opt-in flag.

Two independent gaps, both fixed:

### 1. SDK runtime never requested partials (`@herdctl/core`)
- New opt-in `includePartialMessages` on `ChatSessionOptions` → `RuntimeExecuteOptions` → `SDKQueryOptions`, threaded from `openChatSession` into the SDK `query()` in `SDKRuntime.buildSdkOptions()`.
- **Default off.** Batch/one-shot (`execute`) and existing session callers that don't opt in are byte-for-byte unchanged — the SDK still yields whole `assistant` messages only.

### 2. Translator dropped stream events (`@herdctl/chat`)
- `SDKMessageTranslator.handle()` now routes `type: "stream_event"` messages to a new `handleStreamEvent()`, which emits **incremental** `onText(delta)` for `content_block_delta` / `text_delta` events (other events — message start/stop, tool input-json deltas, thinking deltas — are ignored).
- The terminal whole-`assistant` message **suppresses** its text re-emit when that text already streamed as deltas (tracked per-message), so the `onText` contract stays "deltas, in order" and consumers never receive the text twice. Tool tracking (`onToolStart`/`onToolCall`) still runs on the terminal message.
- **Boundary parity:** the first text delta of a new assistant message applies the same "new turn after prior text → boundary" rule as the whole-message path; a tool result still resets the run so post-tool text starts a fresh bubble with no boundary.
- **Partials-off path is unchanged** (no `stream_event` messages arrive, so state never engages).

Verified against the installed `@anthropic-ai/claude-agent-sdk@0.3.205` types: `SDKPartialAssistantMessage = { type: "stream_event", event: BetaRawMessageStreamEvent, parent_tool_use_id, … }`, where a `BetaRawContentBlockDeltaEvent` (`type: "content_block_delta"`) carries a `BetaTextDelta` (`{ type: "text_delta", text }`).

## Tests

- **core** (`sdk-runtime-partials.test.ts`): `query()` receives `includePartialMessages: true` when opted in via `execute()`/`openSession()`, and it's unset by default.
- **chat** (`sdk-message-translator.test.ts`): `text_delta` events produce ordered incremental `onText`; the terminal assistant message does not re-emit already-streamed text; tool tracking still fires on the terminal message; non-text stream events are ignored; boundary parity across streamed turns and after tool results; attribution threading.

All core (3352 pass; the lone `directory.test.ts` "unwritable dir" failure is the known pre-existing root-only one) and chat (289 pass) suites green; typecheck + build clean.

## Consumer

Paddock consumes this to stream keeper replies token-by-token (companion ticket edspencer/paddock#315).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in partial assistant message streaming for token-by-token text updates.
  * Streaming responses now preserve text order, tool attribution, and message boundaries.
  * Existing behavior remains unchanged unless partial message streaming is enabled.

* **Bug Fixes**
  * Prevented streamed assistant text from being emitted again when the final message arrives.
  * Ignored unrelated streaming events that do not contain assistant text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->