### PR TITLE
fix(core): re-establish injected MCP servers on session wakes (#390)

### DIFF
--- a/.changeset/wake-injected-mcp-390.md
+++ b/.changeset/wake-injected-mcp-390.md
@@ -1,0 +1,27 @@
+---
+"@herdctl/core": patch
+---
+
+Re-establish injected MCP servers on session wake-fired turns (#390).
+
+Under session drive-mode, in-process `injectedMcpServers` were dropped on every
+wake-driven turn (`ScheduleWakeup` / `/loop` / `CronCreate` re-fires): the reaper
+closes the idle session and the wake registry re-opens it without the in-process
+servers, so the resumed subprocess still lists the injected `mcp__…__*` patterns
+in `--allowedTools` but has no server behind them — the tools vanish from the
+model's catalog for the whole autonomous stretch (durably so across restarts).
+
+- **@herdctl/core:** add an optional `resolveInjectedMcpServers(entry)` factory to
+  `SessionLifecycleManagerOptions` (and a `setResolveInjectedMcpServers` setter on
+  both `SessionLifecycleManager` and `FleetManager`). When registered, the wake
+  `fire()` path consults it and threads the resolved servers into the resumed
+  session via a new optional `injectedMcpServers` field on
+  `SessionWakeChatOptions`. Injection *policy* stays in the consumer; herdctl owns
+  the *wiring*. Fully backward-compatible — with no resolver registered, wakes fire
+  with no injection exactly as before, and a throwing resolver is logged and
+  degrades to no-injection rather than wedging the wake.
+
+- **@herdctl/core (secondary):** stop `allowedTools` from accumulating duplicate
+  `mcp__…__*` wildcards across turns. `toSDKOptions` now copies the agent's
+  `allowed_tools` array instead of aliasing it, and the SDK runtime de-dupes
+  injected tool patterns before appending them.

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -27,7 +27,11 @@ import {
 import type { RuntimeSession, SlashCommand } from "../runner/index.js";
 import { getCliSessionFile, getDockerSessionFile } from "../runner/runtime/cli-session-path.js";
 import { Scheduler, type TriggerInfo } from "../scheduler/index.js";
-import { SessionLifecycleManager, type SessionWakeHandler } from "../session/index.js";
+import {
+  type ResolveInjectedMcpServers,
+  SessionLifecycleManager,
+  type SessionWakeHandler,
+} from "../session/index.js";
 import {
   type ChatMessage,
   type DiscoveredSession,
@@ -108,6 +112,7 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   private scheduler: Scheduler | null = null;
   private sessionLifecycle: SessionLifecycleManager | null = null;
   private sessionWakeHandler?: SessionWakeHandler;
+  private resolveInjectedMcpServers?: ResolveInjectedMcpServers;
   private scheduleTriggerHandler?: ScheduleTriggerHandler;
 
   // Timing info
@@ -993,6 +998,7 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
       stateDir: this.stateDir,
       openChatSession: (agent, opts) => this.openChatSession(agent, opts),
       sessionWakeHandler: this.sessionWakeHandler,
+      resolveInjectedMcpServers: this.resolveInjectedMcpServers,
     });
   }
 
@@ -1006,6 +1012,26 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   setSessionWakeHandler(handler: SessionWakeHandler | undefined): void {
     this.sessionWakeHandler = handler;
     this.sessionLifecycle?.setSessionWakeHandler(handler);
+  }
+
+  /**
+   * Register (or clear) the factory that re-supplies a session wake's in-process
+   * injected MCP servers.
+   *
+   * herdctl does not persist the per-call `injectedMcpServers` a consumer passes
+   * into {@link openChatSession}, so when the reaper closes an idle session and
+   * the wake registry re-fires it, the resumed `claude` subprocess loses those
+   * in-process servers — the injected `mcp__…__*` tools stay in `--allowedTools`
+   * but have no server behind them and vanish from the model's catalog for the
+   * whole autonomous stretch (edspencer/herdctl#390). A consumer (e.g. Paddock)
+   * registers this factory alongside {@link setSessionWakeHandler}, keyed off the
+   * wake's agent + sessionId, to rebuild the same servers on each fire. Without
+   * it, wakes fire with no injection (the pre-existing behavior). Safe to call
+   * before or after initialize().
+   */
+  setResolveInjectedMcpServers(resolve: ResolveInjectedMcpServers | undefined): void {
+    this.resolveInjectedMcpServers = resolve;
+    this.sessionLifecycle?.setResolveInjectedMcpServers(resolve);
   }
 
   /**

--- a/packages/core/src/runner/__tests__/sdk-adapter.test.ts
+++ b/packages/core/src/runner/__tests__/sdk-adapter.test.ts
@@ -127,6 +127,21 @@ describe("toSDKOptions", () => {
       expect(result.allowedTools).toEqual(["Read", "Write", "Edit"]);
     });
 
+    // Regression: edspencer/herdctl#390 — allowedTools must be a COPY, not an
+    // alias of the long-lived agent's array. The SDK runtime pushes injected
+    // `mcp__…__*` patterns onto it per turn; aliasing accumulated duplicates on
+    // the persistent agent across turns.
+    it("returns a fresh allowedTools array, not aliased to agent.allowed_tools", () => {
+      const agent = createTestAgent({
+        allowed_tools: ["Read", "Write"],
+      });
+      const result = toSDKOptions(agent);
+      expect(result.allowedTools).not.toBe(agent.allowed_tools);
+      // Mutating the returned array must not leak back into the persistent agent.
+      result.allowedTools!.push("mcp__paddock-self__*");
+      expect(agent.allowed_tools).toEqual(["Read", "Write"]);
+    });
+
     it("passes denied_tools as disallowedTools (SDK option name)", () => {
       const agent = createTestAgent({
         denied_tools: ["Bash(rm *)", "WebFetch"],

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-allowed-tools.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-allowed-tools.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression: edspencer/herdctl#390 (secondary) — the injected `mcp__…__*` tool
+ * patterns must not accumulate on `allowedTools` across turns.
+ *
+ * Two compounding bugs caused `--allowedTools` to grow unbounded (the same
+ * wildcard repeated 2×/3×/4×…):
+ *  1. `toSDKOptions` aliased the long-lived agent's `allowed_tools` array by
+ *     reference, so the runtime's per-turn push mutated the persistent agent.
+ *  2. The runtime pushed `mcp__<name>__*` without checking whether it was
+ *     already present.
+ * The fixes: copy the array in the adapter and de-dupe before pushing. This test
+ * drives the real `execute()` path (with a mocked SDK `query()`) to prove the
+ * captured `allowedTools` stays stable turn-over-turn and never duplicates.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Capture the options every query() receives.
+const queryCalls: Array<Record<string, unknown>> = [];
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn((args: { options?: Record<string, unknown> }) => {
+    queryCalls.push(args.options ?? {});
+    return (async function* () {})();
+  }),
+  createSdkMcpServer: vi.fn(() => ({})),
+  tool: vi.fn(() => ({})),
+}));
+
+import type { ResolvedAgent } from "../../../config/index.js";
+import type { InjectedMcpServerDef } from "../../types.js";
+import type { RuntimeExecuteOptions } from "../interface.js";
+import { SDKRuntime } from "../sdk-runtime.js";
+
+function makeAgent(allowedTools: string[]): ResolvedAgent {
+  return {
+    name: "keeper",
+    qualifiedName: "keeper",
+    allowed_tools: allowedTools,
+  } as unknown as ResolvedAgent;
+}
+
+const injected: Record<string, InjectedMcpServerDef> = {
+  "paddock-self": { name: "paddock-self", tools: [] },
+};
+
+async function drain(iter: AsyncIterable<unknown>): Promise<void> {
+  for await (const _ of iter) {
+    // no messages yielded by the mocked query()
+  }
+}
+
+function baseOptions(overrides: Partial<RuntimeExecuteOptions> = {}): RuntimeExecuteOptions {
+  return { prompt: "hi", agent: makeAgent(["Read", "Write"]), ...overrides };
+}
+
+afterEach(() => {
+  queryCalls.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("SDKRuntime allowedTools + injected MCP patterns (#390)", () => {
+  it("adds the injected wildcard once and does not mutate the agent's array", async () => {
+    const agent = makeAgent(["Read", "Write"]);
+    const runtime = new SDKRuntime();
+
+    await drain(runtime.execute(baseOptions({ agent, injectedMcpServers: injected })));
+
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0].allowedTools).toEqual(["Read", "Write", "mcp__paddock-self__*"]);
+    // The persistent agent's own array must be untouched (no aliasing).
+    expect(agent.allowed_tools).toEqual(["Read", "Write"]);
+  });
+
+  it("does not accumulate duplicates when the same agent runs multiple turns", async () => {
+    const agent = makeAgent(["Read", "Write"]);
+    const runtime = new SDKRuntime();
+
+    // Three turns reusing the same long-lived agent object + injected servers.
+    await drain(runtime.execute(baseOptions({ agent, injectedMcpServers: injected })));
+    await drain(runtime.execute(baseOptions({ agent, injectedMcpServers: injected })));
+    await drain(runtime.execute(baseOptions({ agent, injectedMcpServers: injected })));
+
+    expect(queryCalls).toHaveLength(3);
+    for (const call of queryCalls) {
+      // Each turn's allowedTools is identical — the wildcard appears exactly once.
+      expect(call.allowedTools).toEqual(["Read", "Write", "mcp__paddock-self__*"]);
+      const wildcards = (call.allowedTools as string[]).filter((t) => t === "mcp__paddock-self__*");
+      expect(wildcards).toHaveLength(1);
+    }
+    // The agent never accreted the pattern.
+    expect(agent.allowed_tools).toEqual(["Read", "Write"]);
+  });
+
+  it("de-dupes when the agent already lists the injected wildcard explicitly", async () => {
+    const agent = makeAgent(["Read", "mcp__paddock-self__*"]);
+    const runtime = new SDKRuntime();
+
+    await drain(runtime.execute(baseOptions({ agent, injectedMcpServers: injected })));
+
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0].allowedTools).toEqual(["Read", "mcp__paddock-self__*"]);
+  });
+});

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -288,10 +288,18 @@ export class SDKRuntime implements RuntimeInterface {
       sdkOptions.mcpServers = { ...configServers, ...injectedServers } as any;
 
       // Auto-add injected MCP server tool patterns to allowedTools
-      // Without this, agents with an allowedTools list can't call injected tools
+      // Without this, agents with an allowedTools list can't call injected tools.
+      // De-dupe before pushing: `sdkOptions.allowedTools` can be re-derived from
+      // the same agent across turns, and blindly pushing would grow the list with
+      // duplicate `mcp__…__*` patterns each turn (edspencer/herdctl#390).
       if (sdkOptions.allowedTools?.length) {
+        const existing = new Set(sdkOptions.allowedTools);
         for (const name of Object.keys(options.injectedMcpServers)) {
-          sdkOptions.allowedTools.push(`mcp__${name}__*`);
+          const pattern = `mcp__${name}__*`;
+          if (!existing.has(pattern)) {
+            sdkOptions.allowedTools.push(pattern);
+            existing.add(pattern);
+          }
         }
       }
 

--- a/packages/core/src/runner/sdk-adapter.ts
+++ b/packages/core/src/runner/sdk-adapter.ts
@@ -157,8 +157,12 @@ export function toSDKOptions(
   result.permissionMode = agent.permission_mode ?? DEFAULT_PERMISSION_MODE;
 
   // Allowed and denied tools (direct passthrough to SDK)
+  // Copy the array rather than aliasing the long-lived ResolvedAgent's own
+  // `allowed_tools`: the SDK runtime pushes injected `mcp__…__*` patterns onto
+  // `allowedTools` per turn, and mutating the shared reference would accumulate
+  // duplicates on the persistent agent across turns (edspencer/herdctl#390).
   if (agent.allowed_tools?.length) {
-    result.allowedTools = agent.allowed_tools;
+    result.allowedTools = [...agent.allowed_tools];
   }
 
   // The SDK option is named `disallowedTools` (not `deniedTools`)

--- a/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
+++ b/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeSession } from "../../runner/runtime/interface.js";
+import type { InjectedMcpServerDef } from "../../runner/types.js";
 import { FleetStateWakePersistence } from "../fleet-state-wake-persistence.js";
 import {
   defaultResolveNextRun,
@@ -115,6 +116,101 @@ describe("SessionLifecycleManager", () => {
     slm.setSessionWakeHandler(handler);
     await slm.dispatchDue(NOW);
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: edspencer/herdctl#390 — the wake fire path dropped the
+  // in-process injectedMcpServers, so a resumed autonomous turn lost its
+  // `mcp__…__*` tools for the whole stretch. A registered resolver must re-supply
+  // them into openChatSession on every wake fire.
+  it("re-supplies injectedMcpServers into openChatSession via a registered resolver", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([dueWake({ id: "w-inj" })]);
+    const injected: Record<string, InjectedMcpServerDef> = {
+      "paddock-self": { name: "paddock-self", tools: [] },
+    };
+    const calls: Array<[string, SessionWakeChatOptions]> = [];
+    const openChatSession = vi.fn(async (agent: string, opts: SessionWakeChatOptions) => {
+      calls.push([agent, opts]);
+      return fakeSession();
+    });
+    const resolveInjectedMcpServers = vi.fn((_entry: SessionWakeEntry) => injected);
+
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession,
+      resolveNextRun,
+      resolveInjectedMcpServers,
+    });
+    await slm.dispatchDue(NOW);
+
+    // The resolver was consulted with the fired entry...
+    expect(resolveInjectedMcpServers).toHaveBeenCalledTimes(1);
+    expect(resolveInjectedMcpServers.mock.calls[0][0]).toMatchObject({ id: "w-inj" });
+    // ...and the resolved servers reached openChatSession unchanged.
+    expect(calls).toHaveLength(1);
+    expect(calls[0][1].injectedMcpServers).toBe(injected);
+    expect(calls[0][1]).toMatchObject({
+      resume: "sess-1",
+      prompt: "WAKE-CONTINUE",
+      manageLifecycle: true,
+    });
+  });
+
+  it("fires without injection (no crash) when no resolver is registered", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([dueWake({ id: "w-noinj" })]);
+    const calls: SessionWakeChatOptions[] = [];
+    const openChatSession = vi.fn(async (_agent: string, opts: SessionWakeChatOptions) => {
+      calls.push(opts);
+      return fakeSession();
+    });
+
+    const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
+    const dispatched = await slm.dispatchDue(NOW);
+
+    expect(dispatched.map((e) => e.id)).toEqual(["w-noinj"]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].injectedMcpServers).toBeUndefined();
+  });
+
+  it("setResolveInjectedMcpServers swaps the resolver at runtime", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([dueWake({ id: "w-swap" })]);
+    const injected: Record<string, InjectedMcpServerDef> = {
+      later: { name: "later", tools: [] },
+    };
+    const calls: SessionWakeChatOptions[] = [];
+    const openChatSession = vi.fn(async (_agent: string, opts: SessionWakeChatOptions) => {
+      calls.push(opts);
+      return fakeSession();
+    });
+    const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
+
+    slm.setResolveInjectedMcpServers(() => injected);
+    await slm.dispatchDue(NOW);
+
+    expect(calls[0].injectedMcpServers).toBe(injected);
+  });
+
+  it("fires without injection when the resolver throws (does not wedge the wake)", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([dueWake({ id: "w-throw" })]);
+    const calls: SessionWakeChatOptions[] = [];
+    const openChatSession = vi.fn(async (_agent: string, opts: SessionWakeChatOptions) => {
+      calls.push(opts);
+      return fakeSession();
+    });
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession,
+      resolveNextRun,
+      resolveInjectedMcpServers: () => {
+        throw new Error("resolver boom");
+      },
+    });
+
+    const dispatched = await slm.dispatchDue(NOW);
+
+    // The wake still fired; injection was simply omitted.
+    expect(dispatched.map((e) => e.id)).toEqual(["w-throw"]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].injectedMcpServers).toBeUndefined();
   });
 
   it("does not fire wakes that are not yet due", async () => {

--- a/packages/core/src/session/session-lifecycle-manager.ts
+++ b/packages/core/src/session/session-lifecycle-manager.ts
@@ -10,6 +10,7 @@
  */
 
 import type { RuntimeSession } from "../runner/runtime/interface.js";
+import type { InjectedMcpServerDef } from "../runner/types.js";
 import { calculateNextCronTrigger } from "../scheduler/cron.js";
 import { createLogger } from "../utils/logger.js";
 import { FleetStateWakePersistence } from "./fleet-state-wake-persistence.js";
@@ -25,7 +26,34 @@ export interface SessionWakeChatOptions {
   resume: string;
   prompt: string;
   manageLifecycle: true;
+  /**
+   * In-process MCP servers to re-establish on the resumed turn.
+   *
+   * These are per-call runtime values (in-memory `createSdkMcpServer` handlers)
+   * that the original human/consumer-driven turn supplied but that herdctl does
+   * not persist. Without them, the resumed `claude` subprocess still lists the
+   * injected `mcp__…__*` patterns in `--allowedTools` but has no server behind
+   * them, so the tools vanish from the model's catalog for the whole autonomous
+   * stretch (edspencer/herdctl#390). Populated by
+   * {@link SessionLifecycleManagerOptions.resolveInjectedMcpServers} when a
+   * consumer registers one; otherwise omitted (the pre-existing behavior).
+   */
+  injectedMcpServers?: Record<string, InjectedMcpServerDef>;
 }
+
+/**
+ * Reconstructs the in-process injected MCP servers for a wake-fired turn.
+ *
+ * A consumer (e.g. Paddock) registers this so that when herdctl re-fires an idle
+ * session's wake it can re-supply the same in-process `createSdkMcpServer`
+ * servers the original turn had — keyed off the wake's agent + sessionId. This
+ * keeps injection *policy* (depth/gating/builders) in the consumer while herdctl
+ * owns the *wiring*. Returning `undefined` (or leaving it unregistered) preserves
+ * the original no-injection wake behavior. See edspencer/herdctl#390.
+ */
+export type ResolveInjectedMcpServers = (
+  entry: SessionWakeEntry,
+) => Record<string, InjectedMcpServerDef> | undefined;
 
 /**
  * Drives the woken turn. If a consumer (e.g. Paddock) registers one, it receives
@@ -52,6 +80,14 @@ export interface SessionLifecycleManagerOptions {
   resolveNextRun?: NextRunResolver;
   /** Consumer hook for delivering the woken turn (attribution/hub path). */
   sessionWakeHandler?: SessionWakeHandler;
+  /**
+   * Consumer factory that re-supplies a wake's in-process injected MCP servers.
+   * Called by `fire()` before opening the resumed session so its injected
+   * `mcp__…__*` tools stay backed across autonomous wake turns
+   * (edspencer/herdctl#390). Omit to preserve the pre-existing behavior (no
+   * injection re-established on wakes).
+   */
+  resolveInjectedMcpServers?: ResolveInjectedMcpServers;
   logger?: Logger;
   onReap?: (info: { agent: string; sessionId: string }) => void;
   onKeepAlive?: (info: {
@@ -90,11 +126,13 @@ export class SessionLifecycleManager {
   ) => Promise<RuntimeSession>;
   private readonly logger: Logger;
   private sessionWakeHandler?: SessionWakeHandler;
+  private resolveInjectedMcpServers?: ResolveInjectedMcpServers;
 
   constructor(options: SessionLifecycleManagerOptions) {
     this.openChatSession = options.openChatSession;
     this.logger = options.logger ?? createLogger("session-lifecycle");
     this.sessionWakeHandler = options.sessionWakeHandler;
+    this.resolveInjectedMcpServers = options.resolveInjectedMcpServers;
 
     // The registry needs `isSessionLive` from the reaper, and the reaper needs
     // the registry — build the registry first with a late-bound reference.
@@ -130,16 +168,41 @@ export class SessionLifecycleManager {
   }
 
   /**
+   * Register (or clear) the factory that re-supplies a wake's injected MCP
+   * servers. Mirrors {@link setSessionWakeHandler}; see edspencer/herdctl#390.
+   */
+  setResolveInjectedMcpServers(resolve: ResolveInjectedMcpServers | undefined): void {
+    this.resolveInjectedMcpServers = resolve;
+  }
+
+  /**
    * Resume the wake's session and inject its prompt, then either hand the live
    * session to the registered consumer or drain it to completion. The resumed
    * session is opened with `manageLifecycle`, so its own Stop hook re-captures
    * any new wakeups and reaps it when idle.
    */
   private async fire(entry: SessionWakeEntry): Promise<void> {
+    // Re-establish the in-process injected MCP servers this session had, if a
+    // consumer registered a resolver. herdctl doesn't persist these per-call
+    // servers, so without this the resumed subprocess lists the injected
+    // `mcp__…__*` patterns in `--allowedTools` but has nothing behind them and
+    // the tools vanish for the whole autonomous stretch (edspencer/herdctl#390).
+    let injectedMcpServers: Record<string, InjectedMcpServerDef> | undefined;
+    try {
+      injectedMcpServers = this.resolveInjectedMcpServers?.(entry);
+    } catch (error) {
+      // A resolver throw must not wedge the wake — fire without injection, as a
+      // consumer that registered none would.
+      this.logger.warn(
+        `resolveInjectedMcpServers threw for ${entry.agent} (${entry.sessionId}): ${(error as Error).message}`,
+      );
+    }
+
     const session = await this.openChatSession(entry.agent, {
       resume: entry.sessionId,
       prompt: entry.prompt,
       manageLifecycle: true,
+      injectedMcpServers,
     });
 
     if (this.sessionWakeHandler) {


### PR DESCRIPTION
Fixes #390.

## The bug

Under session drive-mode (SDK runtime), in-process **`injectedMcpServers`** (in-memory `createSdkMcpServer` servers, e.g. a consumer's self-management/file-sender MCP) are dropped on every **wake-driven** turn — `ScheduleWakeup` / `/loop` / `CronCreate` re-fires.

The human/first turn passes them through `openChatSession` → `openSession` and the tools work. But when the session goes idle the reaper closes it, and the wake registry re-fires it **without** `injectedMcpServers`: the resumed `claude` subprocess still lists the injected `mcp__…__*` patterns in `--allowedTools` but has **no server behind them**, so the tools vanish from the model's catalog for the entire autonomous stretch (observed multi-hour episodes). Because the wake set is durable, after a process restart the surviving wakes re-fire the same MCP-less way → the loss is effectively permanent for that chat until a fresh injected (human/consumer) turn.

A registered `sessionWakeHandler` can't repair it: `fire()` opens the session **before** invoking the handler, so the handler only receives an already-MCP-less session. And `injectedMcpServers` was never persisted anywhere the wake path could reconstruct it from.

## The fix (shape chosen: resolver factory)

I went with the **resolver/factory** shape rather than cache-at-first-open, because it's the more general and testable one and keeps injection *policy* (depth/gating, the actual server builders) in the consumer while herdctl owns the *wiring*. Cache-at-first-open would have needed `injectedMcpServers` plumbed into `manage()` (the first open happens outside the lifecycle manager), a more invasive change for no extra generality.

- Add an optional `resolveInjectedMcpServers?: (entry: SessionWakeEntry) => Record<string, InjectedMcpServerDef> | undefined` to `SessionLifecycleManagerOptions`, plus a `setResolveInjectedMcpServers` setter on both `SessionLifecycleManager` and `FleetManager` (mirrors the existing `setSessionWakeHandler` wiring).
- `fire()` consults the resolver (keyed off the wake's agent + sessionId) and threads the result into `openChatSession` via a new optional `injectedMcpServers` field on `SessionWakeChatOptions` — which flows straight through to `openSession`.

**Backward-compatible:** with no resolver registered, wakes fire with no injection exactly as before. A resolver that throws is logged and degrades to no-injection rather than wedging the wake.

## Secondary fix — `allowedTools` wildcard accumulation

The injected `mcp__…__*` patterns were accumulating on `--allowedTools` (repeated 2×/3×/4× per turn) because:

- `sdk-adapter.ts` assigned `result.allowedTools = agent.allowed_tools` **by reference** — a live pointer to the long-lived `ResolvedAgent`'s array. Now copied: `[...agent.allowed_tools]`.
- `sdk-runtime.ts` **pushed** `mcp__${name}__*` onto that array in place each turn. Now de-dupes before pushing.

## Tests

- **`session-lifecycle-manager.test.ts`** — wake fire forwards resolved `injectedMcpServers` into `openChatSession`; fires without injection (no crash) when no resolver is registered; `setResolveInjectedMcpServers` swaps at runtime; a throwing resolver degrades to no-injection without wedging the wake.
- **`sdk-runtime-allowed-tools.test.ts`** (new) — drives the real `execute()` path (mocked SDK `query()`): the injected wildcard is added exactly once, does not accumulate across repeated turns on the same agent object, does not mutate the persistent agent's array, and is de-duped when the agent already lists it.
- **`sdk-adapter.test.ts`** — `toSDKOptions` returns a fresh `allowedTools` array (not aliased to `agent.allowed_tools`).

Full `@herdctl/core` suite is green (one pre-existing, environment-only failure in `state/directory.test.ts` that asserts a non-writable-parent mkdir rejects — it fails identically on unmodified `main` when the suite runs as root, since root bypasses the permission; unrelated to this change and passes in CI). Added a changeset (`@herdctl/core` patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored in-process MCP server availability when sessions resume after wake-triggered turns.
  * Preserved MCP tools during autonomous periods and across restarts.
  * Prevented duplicate MCP tool entries from accumulating across turns.
  * Wake operations now continue safely without MCP injection if resolution fails.

* **New Features**
  * Added support for dynamically resolving MCP servers when waking sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->