### PR TITLE
feat: inline agent & tool-returned images (preserve image blocks + serve workspace files) (#385, #386)

### DIFF
--- a/.changeset/inline-agent-images.md
+++ b/.changeset/inline-agent-images.md
@@ -1,0 +1,13 @@
+---
+"@herdctl/core": minor
+"@herdctl/chat": minor
+"@herdctl/web": minor
+---
+
+Preserve non-text image content blocks and serve workspace files for inline image display
+
+Two complementary changes that together enable inline display of agent-produced and MCP-tool-returned images in a consuming web UI:
+
+- **`@herdctl/core` / `@herdctl/chat` (#385):** message extraction and the SDK message translator no longer silently drop non-text content blocks when flattening a result to a plain string. Image blocks an agent emits inline, or that an MCP tool returns (e.g. a Playwright `browser_take_screenshot`), are now preserved. New `ExtractedImage` type and `normalizeImageBlock` / `isImageContentBlock` / `imageToDataUrl` helpers; `ToolResult.images` and `TranslatedToolCall.images` carry tool-returned images; `extractImageBlocks` / `hasImageContent` surface agent-emitted images and a new `onImages` translator handler exposes them. The text-only fallback is unchanged for consumers that don't handle images.
+
+- **`@herdctl/web` (#386):** new guarded `GET /files/:agentName/*` route serves files from an agent's resolved working directory, with `realpath` containment protection against `..` traversal and symlink escapes. An agent can write an image into its working directory and emit markdown `![](/files/<agent>/<path>)`, which the dashboard's `MarkdownRenderer` now renders inline. Adds `FleetManager.getAgentWorkingDirectory(name)`.

--- a/packages/chat/src/__tests__/message-extraction.test.ts
+++ b/packages/chat/src/__tests__/message-extraction.test.ts
@@ -4,13 +4,18 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  extractImageBlocks,
   extractMessageContent,
   getAgentAttribution,
+  hasImageContent,
   hasTextContent,
   isSyntheticMessage,
   isTextContentBlock,
   type SDKMessage,
 } from "../message-extraction.js";
+
+const PNG_1x1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 
 describe("message-extraction", () => {
   describe("extractMessageContent", () => {
@@ -229,6 +234,64 @@ describe("message-extraction", () => {
         message: { content: "hi" },
       };
       expect(getAgentAttribution(message)).toEqual({ parentToolUseId: "task_abc" });
+    });
+  });
+
+  describe("extractImageBlocks (issue #385)", () => {
+    it("extracts image blocks from an assistant message, preserving order", () => {
+      const message: SDKMessage = {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "Here is the chart:" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: PNG_1x1 } },
+            { type: "image", source: { type: "url", url: "https://example.com/b.png" } },
+          ],
+        },
+      };
+
+      expect(extractImageBlocks(message)).toEqual([
+        { kind: "base64", mediaType: "image/png", data: PNG_1x1 },
+        { kind: "url", mediaType: undefined, url: "https://example.com/b.png" },
+      ]);
+    });
+
+    it("returns [] for flat-string and text-only messages", () => {
+      expect(extractImageBlocks({ type: "assistant", content: "hi" })).toEqual([]);
+      expect(extractImageBlocks({ type: "assistant", message: { content: "hi" } })).toEqual([]);
+      expect(
+        extractImageBlocks({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "no images" }] },
+        }),
+      ).toEqual([]);
+    });
+
+    it("keeps text extraction and image extraction independent for a mixed message", () => {
+      const message: SDKMessage = {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "look: " },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: PNG_1x1 } },
+          ],
+        },
+      };
+
+      // Text-only fallback still works (backward compatible)…
+      expect(extractMessageContent(message)).toBe("look: ");
+      // …and the image survives.
+      expect(hasImageContent(message)).toBe(true);
+      expect(extractImageBlocks(message)).toHaveLength(1);
+    });
+
+    it("hasImageContent is false when there are no image blocks", () => {
+      expect(
+        hasImageContent({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "just words" }] },
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/packages/chat/src/__tests__/sdk-message-translator.test.ts
+++ b/packages/chat/src/__tests__/sdk-message-translator.test.ts
@@ -740,6 +740,96 @@ describe("partial-message text streaming (stream_event / text_delta)", () => {
   });
 });
 
+describe("image content blocks (issue #385)", () => {
+  const PNG_1x1 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+  function imageToolResult(toolUseId: string, withText: boolean): SDKMessage {
+    const content: unknown[] = [];
+    if (withText) content.push({ type: "text", text: "Screenshot captured" });
+    content.push({
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: PNG_1x1 },
+    });
+    return {
+      type: "user",
+      message: {
+        content: [{ type: "tool_result", tool_use_id: toolUseId, content }],
+      },
+    } as unknown as SDKMessage;
+  }
+
+  function assistantWithImage(): SDKMessage {
+    return {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Here you go:" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: PNG_1x1 } },
+        ],
+      },
+    } as unknown as SDKMessage;
+  }
+
+  it("carries a tool-returned image onto the TranslatedToolCall", async () => {
+    const calls: TranslatedToolCall[] = [];
+    const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+    await t.handle(assistantToolUse("t1", "browser_take_screenshot"));
+    await t.handle(imageToolResult("t1", true));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].output).toBe("Screenshot captured");
+    expect(calls[0].images).toEqual([{ kind: "base64", mediaType: "image/png", data: PNG_1x1 }]);
+  });
+
+  it("still emits a tool call for an image-only result (empty output)", async () => {
+    const calls: TranslatedToolCall[] = [];
+    const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+    await t.handle(assistantToolUse("t1", "browser_take_screenshot"));
+    await t.handle(imageToolResult("t1", false));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].output).toBe("");
+    expect(calls[0].images).toHaveLength(1);
+  });
+
+  it("omits images on a text-only tool call", async () => {
+    const calls: TranslatedToolCall[] = [];
+    const t = new SDKMessageTranslator({ onToolCall: (c) => void calls.push(c) });
+
+    await t.handle(assistantToolUse("t1", "Read", { file_path: "/f" }));
+    await t.handle(toolResult("t1", "contents"));
+
+    expect(calls[0].images).toBeUndefined();
+  });
+
+  it("fires onImages for an inline assistant image, with attribution", async () => {
+    const onText = vi.fn();
+    const onImages = vi.fn();
+    const t = new SDKMessageTranslator({ onText, onImages });
+
+    await t.handle(assistantWithImage());
+
+    expect(onText).toHaveBeenCalledWith("Here you go:", { parentToolUseId: null });
+    expect(onImages).toHaveBeenCalledTimes(1);
+    expect(onImages).toHaveBeenCalledWith(
+      [{ kind: "base64", mediaType: "image/png", data: PNG_1x1 }],
+      { parentToolUseId: null },
+    );
+  });
+
+  it("does not fire onImages for a text-only assistant message", async () => {
+    const onImages = vi.fn();
+    const t = new SDKMessageTranslator({ onImages });
+
+    await t.handle(assistantText("no pictures here"));
+
+    expect(onImages).not.toHaveBeenCalled();
+  });
+});
+
 describe("createSDKMessageHandler", () => {
   it("returns an onMessage handler driving a fresh translator", async () => {
     const onText = vi.fn();

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -99,8 +99,10 @@ export {
 export {
   type AgentAttribution,
   type ContentBlock,
+  extractImageBlocks,
   extractMessageContent,
   getAgentAttribution,
+  hasImageContent,
   hasTextContent,
   isSyntheticMessage,
   isTextContentBlock,
@@ -114,11 +116,15 @@ export {
 // =============================================================================
 
 export {
+  type ExtractedImage,
   extractToolResultContent,
   extractToolResults,
   // Functions
   extractToolUseBlocks,
   getToolInputSummary,
+  imageToDataUrl,
+  isImageContentBlock,
+  normalizeImageBlock,
   // Constants
   TOOL_EMOJIS,
   type ToolResult,

--- a/packages/chat/src/message-extraction.ts
+++ b/packages/chat/src/message-extraction.ts
@@ -5,6 +5,8 @@
  * This is 100% identical between Discord and Slack managers.
  */
 
+import { type ExtractedImage, normalizeImageBlock } from "@herdctl/core";
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -222,6 +224,42 @@ export function extractMessageContent(message: SDKMessage): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Extract non-text image content blocks from an SDK assistant message.
+ *
+ * The Claude Agent SDK can emit `image` content blocks alongside text in an
+ * assistant message. {@link extractMessageContent} deliberately keeps only text
+ * (a plain-string fallback for consumers that don't handle images); this
+ * companion surfaces the image blocks so a consumer can render them inline.
+ *
+ * Only the nested `message.message.content[]` array shape can carry image
+ * blocks; the flat string shapes never do, so those return `[]`.
+ *
+ * @param message - SDK message object
+ * @returns Normalized image blocks in order, or `[]` if the message has none
+ */
+export function extractImageBlocks(message: SDKMessage): ExtractedImage[] {
+  const content = message.message?.content;
+  if (!Array.isArray(content)) return [];
+
+  const images: ExtractedImage[] = [];
+  for (const block of content) {
+    const image = normalizeImageBlock(block);
+    if (image) images.push(image);
+  }
+  return images;
+}
+
+/**
+ * Whether an SDK assistant message carries any non-text image content blocks.
+ *
+ * @param message - SDK message object
+ * @returns true if the message contains at least one image block
+ */
+export function hasImageContent(message: SDKMessage): boolean {
+  return extractImageBlocks(message).length > 0;
 }
 
 /**

--- a/packages/chat/src/sdk-message-translator.ts
+++ b/packages/chat/src/sdk-message-translator.ts
@@ -20,6 +20,7 @@
 
 import {
   type AgentAttribution,
+  extractImageBlocks,
   extractMessageContent,
   extractTextDelta,
   getAgentAttribution,
@@ -27,6 +28,7 @@ import {
   type SDKMessage,
 } from "./message-extraction.js";
 import {
+  type ExtractedImage,
   extractToolResults,
   extractToolUseBlocks,
   getToolInputSummary,
@@ -47,6 +49,13 @@ export interface TranslatedToolCall {
   inputSummary?: string;
   /** Tool output text (may be empty) */
   output: string;
+  /**
+   * Non-text image blocks the tool returned (e.g. a Playwright
+   * `browser_take_screenshot` result), preserved so a consumer can render them
+   * inline. Absent when the result carried no image blocks; {@link output}
+   * stays populated for text-only consumers.
+   */
+  images?: ExtractedImage[];
   /** Whether the tool reported an error */
   isError: boolean;
   /** Wall-clock duration between the tool_use and its result, in milliseconds */
@@ -96,6 +105,14 @@ export interface SDKMessageHandlers {
    * lanes. Existing handlers that ignore the second argument keep working.
    */
   onText?: (text: string, attribution: AgentAttribution) => void | Promise<void>;
+  /**
+   * Called when an assistant message carries non-text `image` content blocks —
+   * an image the agent emitted inline (as opposed to one a tool returned, which
+   * arrives via {@link onToolCall}'s `images`). Fires once per assistant
+   * message that has images, after its text. Optional and backward compatible;
+   * consumers that don't render images can ignore it.
+   */
+  onImages?: (images: ExtractedImage[], attribution: AgentAttribution) => void | Promise<void>;
   /**
    * Called when a new assistant turn begins after a previous one produced text,
    * so transports can split bubbles. A tool-call interruption alone does NOT
@@ -348,6 +365,16 @@ export class SDKMessageTranslator {
       await this.handlers.onText?.(content, attribution);
     }
 
+    // Surface any inline image content blocks the agent emitted. These are
+    // independent of text (an assistant message may carry both) and of the
+    // partial-streaming path (image blocks only appear on the whole message).
+    if (this.handlers.onImages) {
+      const images = extractImageBlocks(message);
+      if (images.length > 0) {
+        await this.handlers.onImages(images, attribution);
+      }
+    }
+
     // Track tool_use blocks so we can pair them with results later. We track
     // even when toolResults is disabled so boundary handling stays correct.
     for (const block of extractToolUseBlocks(message)) {
@@ -407,6 +434,7 @@ export class SDKMessageTranslator {
         toolName: toolUse?.name ?? "Tool",
         inputSummary: toolUse ? getToolInputSummary(toolUse.name, toolUse.input) : undefined,
         output: result.output,
+        ...(result.images && result.images.length > 0 ? { images: result.images } : {}),
         isError: result.isError,
         durationMs: toolUse ? this.now() - toolUse.startTime : undefined,
         toolUseId: result.toolUseId,

--- a/packages/chat/src/tool-parsing.ts
+++ b/packages/chat/src/tool-parsing.ts
@@ -1,9 +1,13 @@
 // Re-export from @herdctl/core for backwards compatibility
 export {
+  type ExtractedImage,
   extractToolResultContent,
   extractToolResults,
   extractToolUseBlocks,
   getToolInputSummary,
+  imageToDataUrl,
+  isImageContentBlock,
+  normalizeImageBlock,
   TOOL_EMOJIS,
   type ToolResult,
   type ToolUseBlock,

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -705,6 +705,25 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   }
 
   /**
+   * Resolve an agent's configured working directory to an absolute path.
+   *
+   * Normalizes the `working_directory` config (string or `{ root }`) the same
+   * way session access does, so consumers (e.g. the web dashboard's file-
+   * serving route) can map an agent name to its on-disk working directory
+   * without reaching into config internals.
+   *
+   * @param name - The agent qualified name or local name
+   * @returns The absolute working directory, or `undefined` if the agent has
+   *   none configured
+   * @throws {InvalidStateError} If the fleet manager is not yet initialized
+   * @throws {AgentNotFoundError} If no agent with that name exists
+   */
+  getAgentWorkingDirectory(name: string): string | undefined {
+    const { workingDirectory } = this.resolveAgentForSessions(name, "getAgentWorkingDirectory");
+    return workingDirectory;
+  }
+
+  /**
    * Get the parsed chat messages for one of an agent's sessions.
    *
    * Derives the working directory and Docker mode from the loaded config.

--- a/packages/core/src/state/__tests__/tool-parsing.test.ts
+++ b/packages/core/src/state/__tests__/tool-parsing.test.ts
@@ -8,8 +8,15 @@ import {
   extractToolResults,
   extractToolUseBlocks,
   getToolInputSummary,
+  imageToDataUrl,
+  isImageContentBlock,
+  normalizeImageBlock,
   TOOL_EMOJIS,
 } from "../tool-parsing.js";
+
+// A tiny 1x1 transparent PNG, base64-encoded — enough to assert round-tripping.
+const PNG_1x1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 
 describe("tool-parsing", () => {
   // ===========================================================================
@@ -368,6 +375,171 @@ describe("tool-parsing", () => {
 
     it("has lowercase bash variant", () => {
       expect(TOOL_EMOJIS.bash).toBe(TOOL_EMOJIS.Bash);
+    });
+  });
+
+  // ===========================================================================
+  // Image content blocks (issue #385)
+  // ===========================================================================
+
+  describe("normalizeImageBlock", () => {
+    it("normalizes a base64 image block (snake_case media_type)", () => {
+      expect(
+        normalizeImageBlock({
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1x1 },
+        }),
+      ).toEqual({ kind: "base64", mediaType: "image/png", data: PNG_1x1 });
+    });
+
+    it("normalizes a url image block", () => {
+      expect(
+        normalizeImageBlock({
+          type: "image",
+          source: { type: "url", url: "https://example.com/a.png" },
+        }),
+      ).toEqual({ kind: "url", mediaType: undefined, url: "https://example.com/a.png" });
+    });
+
+    it("reads a camelCase mediaType fallback", () => {
+      expect(
+        normalizeImageBlock({
+          type: "image",
+          source: { type: "base64", mediaType: "image/jpeg", data: PNG_1x1 },
+        }),
+      ).toMatchObject({ kind: "base64", mediaType: "image/jpeg" });
+    });
+
+    it("returns undefined for non-image or malformed blocks", () => {
+      expect(normalizeImageBlock({ type: "text", text: "hi" })).toBeUndefined();
+      expect(normalizeImageBlock({ type: "image" })).toBeUndefined();
+      expect(normalizeImageBlock({ type: "image", source: { type: "base64" } })).toBeUndefined();
+      expect(
+        normalizeImageBlock({ type: "image", source: { type: "base64", data: "" } }),
+      ).toBeUndefined();
+      expect(normalizeImageBlock(null)).toBeUndefined();
+      expect(normalizeImageBlock("nope")).toBeUndefined();
+    });
+  });
+
+  describe("isImageContentBlock", () => {
+    it("is true for a well-formed image block, false otherwise", () => {
+      expect(
+        isImageContentBlock({
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1x1 },
+        }),
+      ).toBe(true);
+      expect(isImageContentBlock({ type: "text", text: "hi" })).toBe(false);
+    });
+  });
+
+  describe("imageToDataUrl", () => {
+    it("builds a data URI for a base64 image", () => {
+      expect(imageToDataUrl({ kind: "base64", mediaType: "image/png", data: PNG_1x1 })).toBe(
+        `data:image/png;base64,${PNG_1x1}`,
+      );
+    });
+
+    it("defaults the media type when unknown", () => {
+      expect(imageToDataUrl({ kind: "base64", data: PNG_1x1 })).toBe(
+        `data:image/png;base64,${PNG_1x1}`,
+      );
+    });
+
+    it("returns the url directly for a url image", () => {
+      expect(imageToDataUrl({ kind: "url", url: "https://example.com/a.png" })).toBe(
+        "https://example.com/a.png",
+      );
+    });
+  });
+
+  describe("extractToolResults preserves image blocks", () => {
+    it("keeps an image block alongside text in a nested tool_result", () => {
+      const results = extractToolResults({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_img",
+              content: [
+                { type: "text", text: "Screenshot captured" },
+                {
+                  type: "image",
+                  source: { type: "base64", media_type: "image/png", data: PNG_1x1 },
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].output).toBe("Screenshot captured");
+      expect(results[0].toolUseId).toBe("toolu_img");
+      expect(results[0].images).toEqual([
+        { kind: "base64", mediaType: "image/png", data: PNG_1x1 },
+      ]);
+    });
+
+    it("surfaces an image-only tool_result (empty text) instead of dropping it", () => {
+      const results = extractToolResults({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_shot",
+              content: [
+                {
+                  type: "image",
+                  source: { type: "base64", media_type: "image/png", data: PNG_1x1 },
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].output).toBe("");
+      expect(results[0].images).toHaveLength(1);
+    });
+
+    it("omits images when the result is text-only", () => {
+      const results = extractToolResults({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_txt",
+              content: [{ type: "text", text: "just text" }],
+            },
+          ],
+        },
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].images).toBeUndefined();
+    });
+
+    it("preserves images on the top-level tool_use_result shape", () => {
+      const result = extractToolResultContent({
+        content: [
+          { type: "text", text: "done" },
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: PNG_1x1 },
+          },
+        ],
+        tool_use_id: "toolu_top",
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.output).toBe("done");
+      expect(result?.images).toEqual([{ kind: "base64", mediaType: "image/png", data: PNG_1x1 }]);
     });
   });
 });

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -116,10 +116,14 @@ export {
 } from "./session-validation.js";
 // Re-export tool parsing functions
 export {
+  type ExtractedImage,
   extractToolResultContent,
   extractToolResults,
   extractToolUseBlocks,
   getToolInputSummary,
+  imageToDataUrl,
+  isImageContentBlock,
+  normalizeImageBlock,
   TOOL_EMOJIS,
   type ToolResult,
   type ToolUseBlock,

--- a/packages/core/src/state/tool-parsing.ts
+++ b/packages/core/src/state/tool-parsing.ts
@@ -32,6 +32,33 @@ export interface ToolResult {
   isError: boolean;
   /** ID of the tool_use this result corresponds to */
   toolUseId?: string;
+  /**
+   * Non-text image content blocks returned by the tool, preserved so a
+   * consuming UI can render them inline (e.g. a Playwright
+   * `browser_take_screenshot` result). Absent when the result carried no
+   * image blocks. The text-only {@link output} is always populated for
+   * consumers that don't handle images.
+   */
+  images?: ExtractedImage[];
+}
+
+/**
+ * A non-text image content block, normalized out of an Anthropic-style
+ * `{ type: "image", source: … }` block.
+ *
+ * The two `source` shapes the SDK/CLI emit are collapsed into one structure:
+ * base64-inlined bytes (`kind: "base64"`) or a direct URL (`kind: "url"`). Use
+ * {@link imageToDataUrl} to turn one into a browser-renderable `src`.
+ */
+export interface ExtractedImage {
+  /** How the image bytes are carried. */
+  kind: "base64" | "url";
+  /** MIME type when known (e.g. "image/png"). */
+  mediaType?: string;
+  /** Base64-encoded image bytes; present when `kind === "base64"`. */
+  data?: string;
+  /** Direct image URL; present when `kind === "url"`. */
+  url?: string;
 }
 
 /**
@@ -132,10 +159,115 @@ export function getToolInputSummary(name: string, input?: unknown): string | und
 }
 
 /**
+ * Normalize an Anthropic-style `{ type: "image", source: … }` content block
+ * into an {@link ExtractedImage}, or return `undefined` if the block is not a
+ * well-formed image block.
+ *
+ * Accepts both `source` shapes emitted by the SDK/CLI:
+ * - `{ type: "base64", media_type, data }`
+ * - `{ type: "url", url }`
+ *
+ * `media_type` (Anthropic's snake_case) and a camelCase `mediaType` fallback are
+ * both read so the helper is robust across transports.
+ *
+ * @param block - A candidate content block
+ * @returns The normalized image, or `undefined` if not an image block
+ */
+export function normalizeImageBlock(block: unknown): ExtractedImage | undefined {
+  if (!block || typeof block !== "object" || !("type" in block)) return undefined;
+  if ((block as { type?: unknown }).type !== "image") return undefined;
+
+  const source = (block as { source?: unknown }).source;
+  if (!source || typeof source !== "object") return undefined;
+  const src = source as Record<string, unknown>;
+
+  const mediaType =
+    typeof src.media_type === "string"
+      ? src.media_type
+      : typeof src.mediaType === "string"
+        ? src.mediaType
+        : undefined;
+
+  if (src.type === "base64" && typeof src.data === "string" && src.data.length > 0) {
+    return { kind: "base64", mediaType, data: src.data };
+  }
+  if (src.type === "url" && typeof src.url === "string" && src.url.length > 0) {
+    return { kind: "url", mediaType, url: src.url };
+  }
+  return undefined;
+}
+
+/**
+ * Type guard: whether a content block is a well-formed image block.
+ *
+ * @param block - Content block to check
+ * @returns true if {@link normalizeImageBlock} can parse it
+ */
+export function isImageContentBlock(block: unknown): boolean {
+  return normalizeImageBlock(block) !== undefined;
+}
+
+/**
+ * Turn an {@link ExtractedImage} into a browser-renderable `src`.
+ *
+ * Returns the URL directly for `kind: "url"`, or a `data:` URI for
+ * `kind: "base64"` (defaulting the MIME type to `image/png` when unknown).
+ *
+ * @param image - The normalized image
+ * @returns A string usable as an `<img src>`, or `undefined` if empty
+ */
+export function imageToDataUrl(image: ExtractedImage): string | undefined {
+  if (image.kind === "url") return image.url;
+  if (image.kind === "base64" && image.data) {
+    return `data:${image.mediaType ?? "image/png"};base64,${image.data}`;
+  }
+  return undefined;
+}
+
+/**
+ * Split an array of content blocks into text parts and normalized image blocks.
+ *
+ * Shared by the tool-result parsers so both the nested `content[]` and the
+ * top-level `tool_use_result` shapes preserve images identically. Unknown block
+ * types are ignored (their text/image payloads, if any, don't match).
+ *
+ * @param content - Array of content blocks
+ * @returns Collected text parts and images
+ */
+function collectContentBlocks(content: unknown[]): {
+  text: string[];
+  images: ExtractedImage[];
+} {
+  const text: string[] = [];
+  const images: ExtractedImage[] = [];
+
+  for (const part of content) {
+    if (!part || typeof part !== "object" || !("type" in part)) continue;
+    const type = (part as { type?: unknown }).type;
+
+    if (
+      type === "text" &&
+      "text" in part &&
+      typeof (part as { text?: unknown }).text === "string"
+    ) {
+      text.push((part as { text: string }).text);
+      continue;
+    }
+
+    const image = normalizeImageBlock(part);
+    if (image) images.push(image);
+  }
+
+  return { text, images };
+}
+
+/**
  * Extract tool results from a user message
  *
  * Returns output, error status, and the tool_use_id for matching
- * to the pending tool_use that produced this result.
+ * to the pending tool_use that produced this result. Non-text image blocks in
+ * the result content are preserved on {@link ToolResult.images} so a consuming
+ * UI can render them; the text-only {@link ToolResult.output} is always set.
  *
  * @param message - SDK message object (user type with tool results)
  * @returns Array of parsed tool results
@@ -180,21 +312,16 @@ export function extractToolResults(message: {
       if (typeof blockContent === "string" && blockContent.length > 0) {
         results.push({ output: blockContent, isError, toolUseId });
       } else if (Array.isArray(blockContent)) {
-        const textParts: string[] = [];
-        for (const part of blockContent) {
-          if (
-            part &&
-            typeof part === "object" &&
-            "type" in part &&
-            part.type === "text" &&
-            "text" in part &&
-            typeof part.text === "string"
-          ) {
-            textParts.push(part.text);
-          }
-        }
-        if (textParts.length > 0) {
-          results.push({ output: textParts.join("\n"), isError, toolUseId });
+        const { text, images } = collectContentBlocks(blockContent);
+        // Push when there is text OR images: an image-only tool result (e.g. a
+        // screenshot) has empty text but must still surface its image blocks.
+        if (text.length > 0 || images.length > 0) {
+          results.push({
+            output: text.join("\n"),
+            isError,
+            toolUseId,
+            ...(images.length > 0 ? { images } : {}),
+          });
         }
       }
     }
@@ -233,24 +360,15 @@ export function extractToolResultContent(result: unknown): ToolResult | undefine
 
     // Check for content blocks array
     if (Array.isArray(obj.content)) {
-      const textParts: string[] = [];
-      for (const block of obj.content) {
-        if (
-          block &&
-          typeof block === "object" &&
-          "type" in block &&
-          (block as Record<string, unknown>).type === "text" &&
-          "text" in block &&
-          typeof (block as Record<string, unknown>).text === "string"
-        ) {
-          textParts.push((block as Record<string, unknown>).text as string);
-        }
-      }
-      if (textParts.length > 0) {
+      const { text, images } = collectContentBlocks(obj.content);
+      // Push when there is text OR images: an image-only result must still
+      // surface its image blocks even though its text output is empty.
+      if (text.length > 0 || images.length > 0) {
         return {
-          output: textParts.join("\n"),
+          output: text.join("\n"),
           isError: obj.is_error === true,
           toolUseId: typeof obj.tool_use_id === "string" ? obj.tool_use_id : undefined,
+          ...(images.length > 0 ? { images } : {}),
         };
       }
     }

--- a/packages/web/src/client/src/components/agent/MarkdownRenderer.tsx
+++ b/packages/web/src/client/src/components/agent/MarkdownRenderer.tsx
@@ -126,6 +126,20 @@ export function MarkdownRenderer({ content, useSerif = false }: MarkdownRenderer
       );
     },
 
+    // Images (e.g. agent-produced images served at /files/…). Constrain so a
+    // large image can't blow out the chat column, and lazy-load.
+    img({ src, alt }: ComponentPropsWithoutRef<"img">) {
+      if (typeof src !== "string" || src.length === 0) return null;
+      return (
+        <img
+          src={src}
+          alt={alt ?? ""}
+          loading="lazy"
+          className="max-w-full h-auto rounded-lg border border-herd-border my-2"
+        />
+      );
+    },
+
     // Headers (capped at text-lg per design system)
     h1({ children }: ComponentPropsWithoutRef<"h1">) {
       return <h1 className="text-lg font-semibold text-herd-fg mt-4 mb-2">{children}</h1>;

--- a/packages/web/src/server/__tests__/routes.test.ts
+++ b/packages/web/src/server/__tests__/routes.test.ts
@@ -8,6 +8,7 @@
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { AgentNotFoundError } from "@herdctl/core";
 import Fastify, { type FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { registerAgentRoutes } from "../routes/agents.js";
@@ -772,11 +773,21 @@ describe("File Routes", () => {
 
   it("returns 404 for an unknown agent", async () => {
     mockFM.getAgentWorkingDirectory.mockImplementation(() => {
-      throw new Error("Agent not found: ghost");
+      throw new AgentNotFoundError("ghost");
     });
 
     const response = await server.inject({ method: "GET", url: "/files/ghost/note.txt" });
     expect(response.statusCode).toBe(404);
+  });
+
+  it("returns 500 for an unexpected resolution error (not a 404)", async () => {
+    mockFM.getAgentWorkingDirectory.mockImplementation(() => {
+      throw new Error("disk exploded");
+    });
+
+    const response = await server.inject({ method: "GET", url: "/files/coder/note.txt" });
+    expect(response.statusCode).toBe(500);
+    expect(response.json().error).toContain("disk exploded");
   });
 
   it("returns 404 when the agent has no working directory", async () => {

--- a/packages/web/src/server/__tests__/routes.test.ts
+++ b/packages/web/src/server/__tests__/routes.test.ts
@@ -5,9 +5,13 @@
  * without needing a real server or network connections.
  */
 
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Fastify, { type FastifyInstance } from "fastify";
-import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { registerAgentRoutes } from "../routes/agents.js";
+import { registerFileRoutes } from "../routes/files.js";
 import { registerFleetRoutes } from "../routes/fleet.js";
 import { registerJobRoutes } from "../routes/jobs.js";
 import { registerScheduleRoutes } from "../routes/schedules.js";
@@ -29,6 +33,7 @@ function createMockFleetManager() {
     forkJob: vi.fn(),
     getAgents: vi.fn().mockReturnValue([]),
     getStateDir: vi.fn().mockReturnValue("/tmp/test-state"),
+    getAgentWorkingDirectory: vi.fn(),
     on: vi.fn(),
     off: vi.fn(),
   };
@@ -648,5 +653,125 @@ describe("Schedule Routes", () => {
       expect(response.statusCode).toBe(500);
       expect(response.json().error).toContain("State save failed");
     });
+  });
+});
+
+// =============================================================================
+// File Routes (issue #386)
+// =============================================================================
+
+describe("File Routes", () => {
+  let server: FastifyInstance;
+  let mockFM: ReturnType<typeof createMockFleetManager>;
+  let workingDir: string;
+  // A 1x1 transparent PNG.
+  const PNG_BYTES = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    "base64",
+  );
+
+  beforeEach(async () => {
+    workingDir = mkdtempSync(join(tmpdir(), "herdctl-files-test-"));
+    // Lay down the Discord-style attachment layout: <workingDir>/<download_dir>/<uuid>/<file>
+    const attachDir = join(workingDir, ".discord-attachments", "abc-123");
+    mkdirSync(attachDir, { recursive: true });
+    writeFileSync(join(attachDir, "shot.png"), PNG_BYTES);
+    writeFileSync(join(workingDir, "note.txt"), "hello");
+    // A secret file outside the working directory + a symlink to it inside.
+    const secret = join(tmpdir(), `herdctl-secret-${process.pid}.txt`);
+    writeFileSync(secret, "top secret");
+    try {
+      symlinkSync(secret, join(workingDir, "escape-link"));
+    } catch {
+      // Symlink creation may be unsupported in some CI sandboxes; the test that
+      // relies on it is resilient to a 404 as well as a 403.
+    }
+
+    server = Fastify();
+    mockFM = createMockFleetManager();
+    mockFM.getAgentWorkingDirectory.mockReturnValue(workingDir);
+    registerFileRoutes(server, mockFM as any);
+    await server.ready();
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it("serves a file with an inferred content-type", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/files/coder/.discord-attachments/abc-123/shot.png",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-type"]).toBe("image/png");
+    expect(response.rawPayload.equals(PNG_BYTES)).toBe(true);
+    expect(mockFM.getAgentWorkingDirectory).toHaveBeenCalledWith("coder");
+  });
+
+  it("serves a text file from the working directory root", async () => {
+    const response = await server.inject({ method: "GET", url: "/files/coder/note.txt" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/plain");
+    expect(response.body).toBe("hello");
+  });
+
+  it("rejects a path that escapes the working directory with 403", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/files/coder/..%2f..%2fetc%2fpasswd",
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().error).toMatch(/escapes working directory/i);
+  });
+
+  it("rejects an absolute path with 403", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/files/coder/%2fetc%2fpasswd",
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  it("does not follow a symlink out of the working directory", async () => {
+    const response = await server.inject({ method: "GET", url: "/files/coder/escape-link" });
+
+    // Either the symlink was created and containment blocked it (403), or the
+    // sandbox couldn't create the symlink so the target is simply missing (404).
+    expect([403, 404]).toContain(response.statusCode);
+    expect(response.body).not.toContain("top secret");
+  });
+
+  it("returns 404 for a missing file", async () => {
+    const response = await server.inject({ method: "GET", url: "/files/coder/nope.png" });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("returns 404 when the path is a directory", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/files/coder/.discord-attachments",
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("returns 404 for an unknown agent", async () => {
+    mockFM.getAgentWorkingDirectory.mockImplementation(() => {
+      throw new Error("Agent not found: ghost");
+    });
+
+    const response = await server.inject({ method: "GET", url: "/files/ghost/note.txt" });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("returns 404 when the agent has no working directory", async () => {
+    mockFM.getAgentWorkingDirectory.mockReturnValue(undefined);
+
+    const response = await server.inject({ method: "GET", url: "/files/coder/note.txt" });
+    expect(response.statusCode).toBe(404);
   });
 });

--- a/packages/web/src/server/__tests__/routes.test.ts
+++ b/packages/web/src/server/__tests__/routes.test.ts
@@ -710,6 +710,17 @@ describe("File Routes", () => {
     expect(mockFM.getAgentWorkingDirectory).toHaveBeenCalledWith("coder");
   });
 
+  it("sets nosniff + a restrictive CSP so served files can't execute same-origin", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/files/coder/.discord-attachments/abc-123/shot.png",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["x-content-type-options"]).toBe("nosniff");
+    expect(response.headers["content-security-policy"]).toBe("default-src 'none'; sandbox");
+  });
+
   it("serves a text file from the working directory root", async () => {
     const response = await server.inject({ method: "GET", url: "/files/coder/note.txt" });
 

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -24,6 +24,7 @@ import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest }
 import { WebChatManager } from "./chat/index.js";
 import { registerAgentRoutes } from "./routes/agents.js";
 import { registerChatRoutes } from "./routes/chat.js";
+import { registerFileRoutes } from "./routes/files.js";
 import { registerFleetRoutes } from "./routes/fleet.js";
 import { registerJobRoutes } from "./routes/jobs.js";
 import { registerScheduleRoutes } from "./routes/schedules.js";
@@ -177,6 +178,7 @@ export async function createWebServer(
   registerJobRoutes(server, fleetManager, listJobs);
   registerScheduleRoutes(server, fleetManager);
   registerChatRoutes(server, fleetManager, chatManager, discoveryService);
+  registerFileRoutes(server, fleetManager);
 
   // Health check endpoint
   server.get("/api/health", async (_request, reply) => {
@@ -226,8 +228,13 @@ export async function createWebServer(
   server.setNotFoundHandler(async (request: FastifyRequest, reply: FastifyReply) => {
     const url = request.url;
 
-    // Don't serve SPA for API routes, WebSocket, or static assets
-    if (url.startsWith("/api/") || url === "/ws" || url.startsWith("/assets/")) {
+    // Don't serve SPA for API routes, WebSocket, served files, or static assets
+    if (
+      url.startsWith("/api/") ||
+      url === "/ws" ||
+      url.startsWith("/files/") ||
+      url.startsWith("/assets/")
+    ) {
       return reply.status(404).send({ error: "Not found" });
     }
 

--- a/packages/web/src/server/routes/files.ts
+++ b/packages/web/src/server/routes/files.ts
@@ -15,10 +15,9 @@
  * layout (`<workingDir>/<download_dir>/<uuid>/…`).
  */
 
-import { createReadStream } from "node:fs";
-import { realpath, stat } from "node:fs/promises";
+import { type FileHandle, open, realpath } from "node:fs/promises";
 import { extname, isAbsolute, relative, resolve, sep } from "node:path";
-import { createLogger, type FleetManager } from "@herdctl/core";
+import { createLogger, type FleetManager, isAgentNotFoundError } from "@herdctl/core";
 import type { FastifyInstance } from "fastify";
 
 const logger = createLogger("web:files");
@@ -89,10 +88,12 @@ export function registerFileRoutes(server: FastifyInstance, fleetManager: FleetM
       try {
         workingDir = fleetManager.getAgentWorkingDirectory(agentName);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (message.toLowerCase().includes("not found")) {
-          return reply.status(404).send({ error: message, statusCode: 404 });
+        // Use the exported type guard rather than string-matching the message,
+        // so only a genuine unknown-agent error maps to 404.
+        if (isAgentNotFoundError(error)) {
+          return reply.status(404).send({ error: error.message, statusCode: 404 });
         }
+        const message = error instanceof Error ? error.message : String(error);
         return reply
           .status(500)
           .send({ error: `Failed to resolve agent: ${message}`, statusCode: 500 });
@@ -152,14 +153,27 @@ export function registerFileRoutes(server: FastifyInstance, fleetManager: FleetM
         });
       }
 
-      // Only serve regular files (never directories).
-      let stats: Awaited<ReturnType<typeof stat>>;
+      // Open the verified canonical path ONCE, then fstat and stream from that
+      // same fd. Re-touching the path string with a separate stat + read would
+      // leave a TOCTOU window where a symlink under the working directory could
+      // be swapped between the containment check and the read; binding to one
+      // fd closes it and honors this route's containment guarantee.
+      let handle: FileHandle;
       try {
-        stats = await stat(realPath);
+        handle = await open(realPath, "r");
       } catch {
         return reply.status(404).send({ error: "File not found", statusCode: 404 });
       }
+
+      let stats: Awaited<ReturnType<FileHandle["stat"]>>;
+      try {
+        stats = await handle.stat();
+      } catch {
+        await handle.close();
+        return reply.status(404).send({ error: "File not found", statusCode: 404 });
+      }
       if (!stats.isFile()) {
+        await handle.close();
         return reply.status(404).send({ error: "Not a file", statusCode: 404 });
       }
 
@@ -175,7 +189,8 @@ export function registerFileRoutes(server: FastifyInstance, fleetManager: FleetM
       reply.header("X-Content-Type-Options", "nosniff");
       reply.header("Content-Security-Policy", "default-src 'none'; sandbox");
       reply.type(contentTypeForPath(realPath));
-      return reply.send(createReadStream(realPath));
+      // The stream owns the fd and closes it when the response finishes/aborts.
+      return reply.send(handle.createReadStream());
     },
   );
 }

--- a/packages/web/src/server/routes/files.ts
+++ b/packages/web/src/server/routes/files.ts
@@ -166,6 +166,14 @@ export function registerFileRoutes(server: FastifyInstance, fleetManager: FleetM
       reply.header("Content-Length", stats.size);
       // Files can change between runs; keep caching conservative.
       reply.header("Cache-Control", "private, max-age=60");
+      // These files live on the dashboard's origin and can be agent-produced
+      // (untrusted — an agent may be induced to write e.g. an SVG containing
+      // <script>). Neutralize script execution from a served file and MIME
+      // sniffing so navigating directly to a served URL can't run code in the
+      // dashboard origin (react-markdown's <img> already won't, but a direct
+      // link/navigation would).
+      reply.header("X-Content-Type-Options", "nosniff");
+      reply.header("Content-Security-Policy", "default-src 'none'; sandbox");
       reply.type(contentTypeForPath(realPath));
       return reply.send(createReadStream(realPath));
     },

--- a/packages/web/src/server/routes/files.ts
+++ b/packages/web/src/server/routes/files.ts
@@ -1,0 +1,173 @@
+/**
+ * Workspace file-serving route
+ *
+ * Serves files from an agent's resolved working directory over HTTP so that
+ * agent-produced images (or any file written into the working directory) can be
+ * displayed inline in the dashboard — an agent writes an image into its working
+ * directory and emits markdown `![](/files/<agent>/<path>)`, which the
+ * `MarkdownRenderer` renders via react-markdown's default `<img>`.
+ *
+ * Security posture: the route is GUARDED. The requested path is resolved
+ * against the agent's working directory and both sides are `realpath`-resolved
+ * before a containment check, so `..` traversal and symlink escapes cannot read
+ * files outside the working directory. Only regular files are served. This
+ * mirrors the storage posture of the `herdctl_send_file` / Discord attachment
+ * layout (`<workingDir>/<download_dir>/<uuid>/…`).
+ */
+
+import { createReadStream } from "node:fs";
+import { realpath, stat } from "node:fs/promises";
+import { extname, isAbsolute, relative, resolve, sep } from "node:path";
+import { createLogger, type FleetManager } from "@herdctl/core";
+import type { FastifyInstance } from "fastify";
+
+const logger = createLogger("web:files");
+
+/**
+ * Minimal extension → MIME type map. Focused on the image types this route
+ * exists to serve, plus a few common companions. Unknown extensions fall back
+ * to `application/octet-stream` (the browser will download rather than render).
+ */
+const MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".avif": "image/avif",
+  ".bmp": "image/bmp",
+  ".ico": "image/x-icon",
+  ".pdf": "application/pdf",
+  ".txt": "text/plain; charset=utf-8",
+};
+
+/**
+ * Resolve a Content-Type for a file path from its extension.
+ */
+export function contentTypeForPath(filePath: string): string {
+  return MIME_TYPES[extname(filePath).toLowerCase()] ?? "application/octet-stream";
+}
+
+/**
+ * Whether a decoded relative path is structurally safe to resolve — no absolute
+ * paths and no `..` segments. This is a cheap pre-check before touching disk;
+ * the authoritative guard is the post-`realpath` containment check.
+ */
+function isStructurallySafe(relPath: string): boolean {
+  if (isAbsolute(relPath)) return false;
+  // Split on both separators so a `..` segment is caught on any platform.
+  return !relPath.split(/[\\/]/).some((segment) => segment === "..");
+}
+
+/**
+ * Register the workspace file-serving route.
+ *
+ * @param server - Fastify instance
+ * @param fleetManager - FleetManager used to resolve an agent's working directory
+ */
+export function registerFileRoutes(server: FastifyInstance, fleetManager: FleetManager): void {
+  /**
+   * GET /files/:agentName/*
+   *
+   * Serves the file at the wildcard path, resolved relative to the named
+   * agent's working directory. Returns:
+   * - 200 with the file stream (and an inferred Content-Type),
+   * - 400 for an undecodable path,
+   * - 403 when the path escapes the working directory,
+   * - 404 when the agent, working directory, or file does not exist,
+   * - 500 for unexpected resolution errors.
+   */
+  server.get<{ Params: { agentName: string; "*": string } }>(
+    "/files/:agentName/*",
+    async (request, reply) => {
+      const { agentName } = request.params;
+      const wildcard = request.params["*"] ?? "";
+
+      // Resolve the agent's working directory. Unknown agents → 404.
+      let workingDir: string | undefined;
+      try {
+        workingDir = fleetManager.getAgentWorkingDirectory(agentName);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.toLowerCase().includes("not found")) {
+          return reply.status(404).send({ error: message, statusCode: 404 });
+        }
+        return reply
+          .status(500)
+          .send({ error: `Failed to resolve agent: ${message}`, statusCode: 500 });
+      }
+
+      if (!workingDir) {
+        return reply.status(404).send({
+          error: `Agent has no working directory: ${agentName}`,
+          statusCode: 404,
+        });
+      }
+
+      // Decode the wildcard path (Fastify leaves it percent-encoded).
+      let relPath: string;
+      try {
+        relPath = decodeURIComponent(wildcard);
+      } catch {
+        return reply.status(400).send({ error: "Invalid file path encoding", statusCode: 400 });
+      }
+
+      if (!relPath) {
+        return reply.status(404).send({ error: "No file specified", statusCode: 404 });
+      }
+
+      // Cheap structural reject before hitting the filesystem.
+      if (!isStructurallySafe(relPath)) {
+        return reply.status(403).send({
+          error: "Forbidden: path escapes working directory",
+          statusCode: 403,
+        });
+      }
+
+      const resolved = resolve(workingDir, relPath);
+
+      // Authoritative guard: realpath both sides (defeating symlink escapes),
+      // then require the target to live inside the working directory.
+      let realWorkingDir: string;
+      try {
+        realWorkingDir = await realpath(workingDir);
+      } catch {
+        return reply.status(404).send({ error: "Working directory not found", statusCode: 404 });
+      }
+
+      let realPath: string;
+      try {
+        realPath = await realpath(resolved);
+      } catch {
+        return reply.status(404).send({ error: "File not found", statusCode: 404 });
+      }
+
+      const rel = relative(realWorkingDir, realPath);
+      if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+        logger.warn("Blocked path traversal attempt", { agentName, relPath });
+        return reply.status(403).send({
+          error: "Forbidden: path escapes working directory",
+          statusCode: 403,
+        });
+      }
+
+      // Only serve regular files (never directories).
+      let stats: Awaited<ReturnType<typeof stat>>;
+      try {
+        stats = await stat(realPath);
+      } catch {
+        return reply.status(404).send({ error: "File not found", statusCode: 404 });
+      }
+      if (!stats.isFile()) {
+        return reply.status(404).send({ error: "Not a file", statusCode: 404 });
+      }
+
+      reply.header("Content-Length", stats.size);
+      // Files can change between runs; keep caching conservative.
+      reply.header("Cache-Control", "private, max-age=60");
+      reply.type(contentTypeForPath(realPath));
+      return reply.send(createReadStream(realPath));
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Two complementary changes that together enable inline display of agent-produced and MCP-tool-returned images in a consuming web UI (the keystone that also unblocks Paddock's native-image work and #59).

### #385 — preserve non-text (image) content blocks

Message extraction and the SDK message translator silently dropped every non-text content block when flattening a tool/assistant result to a plain `output: string`. Any image an agent emitted inline — or that an MCP tool *returned* (e.g. a Playwright `browser_take_screenshot`) — was discarded before any UI could see it.

- **`@herdctl/core` (`state/tool-parsing.ts`):** new `ExtractedImage` type + `normalizeImageBlock` / `isImageContentBlock` / `imageToDataUrl` helpers. `extractToolResults` and `extractToolResultContent` now preserve image blocks on `ToolResult.images`, and surface **image-only** results (empty text) instead of dropping them. Handles both the nested `content[]` `tool_result` shape and the top-level `tool_use_result` shape, and both `media_type` (snake) and `mediaType` (camel) sources.
- **`@herdctl/chat` (`message-extraction.ts`):** `extractImageBlocks` / `hasImageContent` surface agent-emitted inline images; the text-only `extractMessageContent` fallback is unchanged.
- **`@herdctl/chat` (`sdk-message-translator.ts`):** `TranslatedToolCall.images` carries tool-returned images to consumers, and a new optional `onImages` handler exposes inline assistant images. Both are additive and backward compatible.

### #386 — serve workspace files over HTTP for inline image display

There was no HTTP route serving workspace files (only the SPA build). Added a **guarded** `GET /files/:agentName/*` route that serves files from an agent's resolved working directory, so an agent can write an image into its cwd and emit markdown `![](/files/<agent>/<path>)` that the existing `MarkdownRenderer` renders inline.

- **`@herdctl/core`:** `FleetManager.getAgentWorkingDirectory(name)` resolves an agent's working directory (string or `{ root }`) without reaching into config internals.
- **`@herdctl/web`:** `registerFileRoutes` — `realpath` containment guard defeats `..` traversal and symlink escapes (**403**), directories and missing files **404**, Content-Type inferred from extension. `/files/` is excluded from the SPA fallback. `MarkdownRenderer` now renders `<img>` constrained to the chat column (`max-w-full`, rounded, lazy-loaded).

## Testing

- **Unit tests** for #385 on both the SDK and non-SDK paths (core `tool-parsing`, chat `message-extraction` + `sdk-message-translator`): image blocks survive extraction, image-only results are not dropped, text-only results carry no `images`.
- **Route tests** for #386 including the path-escape and **symlink-escape** rejection cases, directory/missing → 404, unknown agent → 404.
- `pnpm build`, `pnpm typecheck`, and per-package `pnpm test` (chat: 298, web: 174, core tool-parsing: all green). The one remaining core failure (`initStateDirectory … parent directory is not writable`) is a pre-existing environment artifact of running the suite as root and is unrelated to this change.
- **Verified live in a browser:** ran the web dashboard, confirmed `GET /files/demo/…/shot.png` serves the PNG (200, `image/png`), the guard cases return 403/404, and a same-origin relative `/files/…` URL (exactly what `MarkdownRenderer` emits) loads and renders inline.

Closes #385
Closes #386


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying images returned by agents and tools, including inline markdown images.
  * Added secure file serving for agent working-directory files, including images and attachments.
  * Added image handling for base64 and URL-based content.
* **Bug Fixes**
  * Prevented unsafe path traversal and symlink access outside an agent’s working directory.
  * Improved image rendering with safe sizing, lazy loading, and consistent styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->