### PR TITLE
feat(core): persist per-run per-model token accounting + SDK cost on job record

### DIFF
--- a/.changeset/persist-token-accounting.md
+++ b/.changeset/persist-token-accounting.md
@@ -1,0 +1,13 @@
+---
+"@herdctl/core": minor
+---
+
+Persist per-run, per-model token accounting and SDK cost on the job record
+
+herdctl already receives the SDK's authoritative `total_cost_usd` + `usage` on the terminal result message and aggregates CLI-runtime tokens, but discarded all of it before the final `updateJob`. The job record now carries a `usage` field capturing this accounting at run-end:
+
+- **Per model** (`usage.per_model`, keyed by model id) — each model's four token classes (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`). A single run can span multiple models (e.g. an Opus main agent delegating to Haiku subagents), so counts are broken down per model rather than summed.
+- **`usage.num_turns`** — total agentic turns reported by the runtime.
+- **`usage.total_cost_usd`** — the SDK's own authoritative run cost, when reported. Absent for CLI / Max-plan runs that have no real per-token spend.
+
+New `extractRunUsage` reader maps the SDK result's camelCase `modelUsage` to the persisted snake-case shape; the CLI runtime now aggregates per-model usage (incl. cache classes) into its synthesized result so both runtimes persist a uniform breakdown. Pricing stays out of herdctl — only raw token counts and the SDK's own cost figure are stored; the consuming app applies a price table. Additive and backward-compatible: existing job records without the field still parse, and headless fleets see no behaviour change.

--- a/packages/core/src/runner/__tests__/job-executor.test.ts
+++ b/packages/core/src/runner/__tests__/job-executor.test.ts
@@ -176,6 +176,93 @@ describe("JobExecutor", () => {
       expect(job?.duration_seconds).toBeGreaterThanOrEqual(0);
     });
 
+    it("persists per-model token accounting from the result message", async () => {
+      const messages: SDKMessage[] = [
+        { type: "system", content: "Start" },
+        { type: "assistant", content: "Working" },
+        {
+          type: "result",
+          subtype: "success",
+          result: "Task completed!",
+          num_turns: 4,
+          total_cost_usd: 0.2571,
+          usage: { input_tokens: 10, output_tokens: 20 },
+          // SDK per-model breakdown: an Opus main agent + a Haiku subagent.
+          modelUsage: {
+            "claude-opus-4-8": {
+              inputTokens: 800,
+              outputTokens: 400,
+              cacheCreationInputTokens: 100,
+              cacheReadInputTokens: 6000,
+              webSearchRequests: 0,
+              costUSD: 0.25,
+              contextWindow: 200000,
+            },
+            "claude-haiku-4-5": {
+              inputTokens: 120,
+              outputTokens: 40,
+              cacheCreationInputTokens: 0,
+              cacheReadInputTokens: 0,
+              webSearchRequests: 0,
+              costUSD: 0.0071,
+              contextWindow: 200000,
+            },
+          },
+        } as unknown as SDKMessage,
+      ];
+
+      const executor = new JobExecutor(createMockRuntimeWithMessages(messages), {
+        logger: createMockLogger(),
+      });
+
+      const result = await executor.execute({
+        agent: createTestAgent(),
+        prompt: "Test prompt",
+        stateDir,
+      });
+
+      expect(result.success).toBe(true);
+
+      // Assert against the persisted job record on disk (real run path).
+      const job = await getJob(join(stateDir, "jobs"), result.jobId);
+      expect(job?.usage).toBeDefined();
+      expect(job?.usage?.num_turns).toBe(4);
+      expect(job?.usage?.total_cost_usd).toBeCloseTo(0.2571);
+      expect(Object.keys(job?.usage?.per_model ?? {})).toEqual([
+        "claude-opus-4-8",
+        "claude-haiku-4-5",
+      ]);
+      expect(job?.usage?.per_model["claude-opus-4-8"]).toEqual({
+        input_tokens: 800,
+        output_tokens: 400,
+        cache_creation_input_tokens: 100,
+        cache_read_input_tokens: 6000,
+      });
+      expect(job?.usage?.per_model["claude-haiku-4-5"].input_tokens).toBe(120);
+      // No $/token price table is persisted in herdctl state.
+      expect(job?.usage?.per_model["claude-opus-4-8"]).not.toHaveProperty("costUSD");
+    });
+
+    it("leaves usage null when the run produces no result message", async () => {
+      const messages: SDKMessage[] = [
+        { type: "system", content: "Start" },
+        { type: "assistant", content: "Done, no result summary" },
+      ];
+
+      const executor = new JobExecutor(createMockRuntimeWithMessages(messages), {
+        logger: createMockLogger(),
+      });
+
+      const result = await executor.execute({
+        agent: createTestAgent(),
+        prompt: "Test prompt",
+        stateDir,
+      });
+
+      const job = await getJob(join(stateDir, "jobs"), result.jobId);
+      expect(job?.usage).toBeNull();
+    });
+
     it("updates job with failed status on error", async () => {
       const messages: SDKMessage[] = [
         { type: "system", content: "Start" },

--- a/packages/core/src/runner/__tests__/message-processor.test.ts
+++ b/packages/core/src/runner/__tests__/message-processor.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { extractSummary, isTerminalMessage, processSDKMessage } from "../message-processor.js";
+import {
+  extractRunUsage,
+  extractSummary,
+  isTerminalMessage,
+  processSDKMessage,
+} from "../message-processor.js";
 import type { SDKMessage } from "../types.js";
 
 // =============================================================================
@@ -926,5 +931,173 @@ describe("malformed response handling (US-7)", () => {
       }
       expect(result.isFinal).toBe(true);
     });
+  });
+});
+
+// =============================================================================
+// extractRunUsage tests
+// =============================================================================
+
+describe("extractRunUsage", () => {
+  it("returns undefined for non-result messages", () => {
+    expect(extractRunUsage({ type: "assistant" } as SDKMessage)).toBeUndefined();
+    expect(extractRunUsage({ type: "system" } as SDKMessage)).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined/non-object messages", () => {
+    expect(extractRunUsage(null as unknown as SDKMessage)).toBeUndefined();
+    expect(extractRunUsage(undefined as unknown as SDKMessage)).toBeUndefined();
+    expect(extractRunUsage("result" as unknown as SDKMessage)).toBeUndefined();
+  });
+
+  it("extracts per-model accounting from an SDK result message", () => {
+    const message = {
+      type: "result",
+      subtype: "success",
+      num_turns: 5,
+      total_cost_usd: 0.1234,
+      usage: { input_tokens: 10, output_tokens: 20 },
+      modelUsage: {
+        "claude-opus-4-8": {
+          inputTokens: 100,
+          outputTokens: 200,
+          cacheCreationInputTokens: 30,
+          cacheReadInputTokens: 4000,
+          webSearchRequests: 0,
+          costUSD: 0.1,
+          contextWindow: 200000,
+        },
+        "claude-haiku-4-5": {
+          inputTokens: 50,
+          outputTokens: 10,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          webSearchRequests: 0,
+          costUSD: 0.0034,
+          contextWindow: 200000,
+        },
+      },
+    } as unknown as SDKMessage;
+
+    const usage = extractRunUsage(message);
+    expect(usage).toBeDefined();
+    expect(usage?.num_turns).toBe(5);
+    expect(usage?.total_cost_usd).toBeCloseTo(0.1234);
+    // Per-model breakdown maps SDK camelCase → snake_case, dropping cost/price fields.
+    expect(usage?.per_model["claude-opus-4-8"]).toEqual({
+      input_tokens: 100,
+      output_tokens: 200,
+      cache_creation_input_tokens: 30,
+      cache_read_input_tokens: 4000,
+    });
+    expect(usage?.per_model["claude-haiku-4-5"].input_tokens).toBe(50);
+    // No $/token table is persisted — only the four token classes per model.
+    expect(usage?.per_model["claude-opus-4-8"]).not.toHaveProperty("costUSD");
+  });
+
+  it("falls back to top-level usage keyed by model when modelUsage is absent", () => {
+    const message = {
+      type: "result",
+      num_turns: 2,
+      model: "claude-sonnet-5",
+      usage: {
+        input_tokens: 40,
+        output_tokens: 15,
+        cache_creation_input_tokens: 5,
+        cache_read_input_tokens: 100,
+      },
+    } as unknown as SDKMessage;
+
+    const usage = extractRunUsage(message);
+    expect(usage?.per_model["claude-sonnet-5"]).toEqual({
+      input_tokens: 40,
+      output_tokens: 15,
+      cache_creation_input_tokens: 5,
+      cache_read_input_tokens: 100,
+    });
+    expect(usage?.num_turns).toBe(2);
+    expect(usage?.total_cost_usd).toBeUndefined();
+  });
+
+  it("keys the fallback bucket 'unknown' when no model id is present", () => {
+    const message = {
+      type: "result",
+      usage: { input_tokens: 7, output_tokens: 3 },
+    } as unknown as SDKMessage;
+
+    const usage = extractRunUsage(message);
+    expect(usage?.per_model.unknown).toEqual({
+      input_tokens: 7,
+      output_tokens: 3,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    });
+  });
+
+  it("records num_turns/total_cost_usd even with no token usage", () => {
+    const message = {
+      type: "result",
+      num_turns: 1,
+      total_cost_usd: 0.5,
+    } as unknown as SDKMessage;
+
+    const usage = extractRunUsage(message);
+    expect(usage).toBeDefined();
+    expect(usage?.per_model).toEqual({});
+    expect(usage?.num_turns).toBe(1);
+    expect(usage?.total_cost_usd).toBe(0.5);
+  });
+
+  it("returns undefined when a result carries no usable accounting", () => {
+    expect(extractRunUsage({ type: "result", result: "done" } as SDKMessage)).toBeUndefined();
+    expect(extractRunUsage({ type: "result", modelUsage: {} } as SDKMessage)).toBeUndefined();
+  });
+
+  it("coerces malformed token counts to zero rather than NaN", () => {
+    const message = {
+      type: "result",
+      modelUsage: {
+        "claude-opus-4-8": {
+          inputTokens: "lots",
+          outputTokens: -5,
+          cacheCreationInputTokens: null,
+          cacheReadInputTokens: undefined,
+        },
+      },
+    } as unknown as SDKMessage;
+
+    const usage = extractRunUsage(message);
+    expect(usage?.per_model["claude-opus-4-8"]).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    });
+  });
+
+  it("consumes a CLI-synthesized result (per-model modelUsage) uniformly", () => {
+    // Shape produced by cli-runtime.ts synthetic result.
+    const message = {
+      type: "result",
+      result: "",
+      is_error: false,
+      duration_ms: 1200,
+      num_turns: 3,
+      usage: { input_tokens: 150, output_tokens: 60 },
+      modelUsage: {
+        "claude-opus-4-8": {
+          inputTokens: 150,
+          outputTokens: 60,
+          cacheCreationInputTokens: 10,
+          cacheReadInputTokens: 900,
+        },
+      },
+    } as unknown as SDKMessage;
+
+    const usage = extractRunUsage(message);
+    expect(usage?.per_model["claude-opus-4-8"].cache_read_input_tokens).toBe(900);
+    expect(usage?.num_turns).toBe(3);
+    // CLI/Max runs have no authoritative cost.
+    expect(usage?.total_cost_usd).toBeUndefined();
   });
 });

--- a/packages/core/src/runner/job-executor.ts
+++ b/packages/core/src/runner/job-executor.ts
@@ -20,6 +20,7 @@ import {
   isSessionExpiredError,
   isTokenExpiredError,
   type JobMetadata,
+  type RunUsage,
   type TriggerType,
   updateJob,
   updateSessionInfo,
@@ -36,7 +37,12 @@ import {
   SDKStreamingError,
   wrapError,
 } from "./errors.js";
-import { extractSummary, isTerminalMessage, processSDKMessage } from "./message-processor.js";
+import {
+  extractRunUsage,
+  extractSummary,
+  isTerminalMessage,
+  processSDKMessage,
+} from "./message-processor.js";
 import type { RuntimeInterface } from "./runtime/index.js";
 import type {
   ProcessedMessage,
@@ -150,6 +156,7 @@ export class JobExecutor {
     let sessionId: string | undefined;
     let summary: string | undefined;
     let lastAssistantContent: string | undefined; // Track last assistant message for fallback summary
+    let runUsage: RunUsage | undefined; // Per-run per-model token accounting from the terminal result message
     let lastError: RunnerError | undefined;
     let errorDetails: RunnerErrorDetails | undefined;
     let messagesReceived = 0;
@@ -515,6 +522,15 @@ export class JobExecutor {
             }
           }
 
+          // Capture per-run per-model token accounting from the terminal result
+          // message (SDK native or CLI-synthesized). Later result messages win.
+          if (sdkMessage && sdkMessage.type === "result") {
+            const usage = extractRunUsage(sdkMessage);
+            if (usage) {
+              runUsage = usage;
+            }
+          }
+
           // Call user's onMessage callback if provided
           if (onMessage) {
             try {
@@ -748,6 +764,9 @@ export class JobExecutor {
         summary,
         exit_reason: exitReason,
         output_file: getJobOutputPath(jobsDir, job.id),
+        // Persist per-model token accounting when the run produced a terminal
+        // result. Left untouched (stays null/absent) when there was none.
+        ...(runUsage ? { usage: runUsage } : {}),
       });
     } catch (error) {
       this.logger.warn(`Failed to update job final status: ${(error as Error).message}`);

--- a/packages/core/src/runner/message-processor.ts
+++ b/packages/core/src/runner/message-processor.ts
@@ -6,7 +6,7 @@
  * of malformed or unexpected SDK responses.
  */
 
-import type { JobOutputInput } from "../state/index.js";
+import type { JobOutputInput, ModelTokenUsage, RunUsage } from "../state/index.js";
 import type { ProcessedMessage, SDKMessage } from "./types.js";
 
 // =============================================================================
@@ -629,4 +629,117 @@ export function extractSummary(message: SDKMessage): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Coerce an unknown value to a finite, non-negative number (0 if not usable).
+ *
+ * Token counts from the runtime should always be non-negative integers, but we
+ * defend against malformed payloads so accounting never throws or records NaN.
+ */
+function toTokenCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+/**
+ * Extract per-run token accounting from a terminal `result` message.
+ *
+ * The SDK result message carries authoritative per-model usage in its
+ * camelCase `modelUsage` map (`{ [modelId]: { inputTokens, outputTokens,
+ * cacheReadInputTokens, cacheCreationInputTokens, ... } }`), plus a top-level
+ * `total_cost_usd` and `num_turns`. The CLI runtime synthesizes a result
+ * message in the same shape (see `cli-runtime.ts`).
+ *
+ * Returns a {@link RunUsage} object suitable for persisting on the job record,
+ * or `undefined` when the message carries no usable accounting (e.g. a
+ * non-result message, or a result with empty usage). Token counts are stored
+ * as raw counts only — pricing is deliberately left to the consuming app.
+ *
+ * @param message - The SDK (or synthetic) message to inspect
+ * @returns Per-run token accounting, or undefined if none is present
+ */
+export function extractRunUsage(message: SDKMessage): RunUsage | undefined {
+  // Only result messages carry run-level accounting.
+  if (message === null || message === undefined || typeof message !== "object") {
+    return undefined;
+  }
+  if (message.type !== "result") {
+    return undefined;
+  }
+
+  const resultMsg = message as {
+    total_cost_usd?: unknown;
+    num_turns?: unknown;
+    modelUsage?: Record<string, unknown> | undefined;
+    usage?: Record<string, unknown> | undefined;
+    model?: unknown;
+  };
+
+  const perModel: Record<string, ModelTokenUsage> = {};
+
+  // Preferred source: the SDK's per-model breakdown (camelCase counts).
+  const modelUsage = resultMsg.modelUsage;
+  if (modelUsage && typeof modelUsage === "object") {
+    for (const [modelId, raw] of Object.entries(modelUsage)) {
+      if (!modelId || !raw || typeof raw !== "object") {
+        continue;
+      }
+      const u = raw as Record<string, unknown>;
+      perModel[modelId] = {
+        input_tokens: toTokenCount(u.inputTokens),
+        output_tokens: toTokenCount(u.outputTokens),
+        cache_creation_input_tokens: toTokenCount(u.cacheCreationInputTokens),
+        cache_read_input_tokens: toTokenCount(u.cacheReadInputTokens),
+      };
+    }
+  }
+
+  // Fallback: no per-model map, but a top-level snake_case `usage` block is
+  // present. Key it by the run's model id when known, else "unknown", so the
+  // counts are not silently dropped.
+  if (
+    Object.keys(perModel).length === 0 &&
+    resultMsg.usage &&
+    typeof resultMsg.usage === "object"
+  ) {
+    const u = resultMsg.usage as Record<string, unknown>;
+    const hasAny =
+      "input_tokens" in u ||
+      "output_tokens" in u ||
+      "cache_creation_input_tokens" in u ||
+      "cache_read_input_tokens" in u;
+    if (hasAny) {
+      const modelId =
+        typeof resultMsg.model === "string" && resultMsg.model ? resultMsg.model : "unknown";
+      perModel[modelId] = {
+        input_tokens: toTokenCount(u.input_tokens),
+        output_tokens: toTokenCount(u.output_tokens),
+        cache_creation_input_tokens: toTokenCount(u.cache_creation_input_tokens),
+        cache_read_input_tokens: toTokenCount(u.cache_read_input_tokens),
+      };
+    }
+  }
+
+  const numTurns =
+    typeof resultMsg.num_turns === "number" && Number.isFinite(resultMsg.num_turns)
+      ? resultMsg.num_turns
+      : undefined;
+  const totalCostUsd =
+    typeof resultMsg.total_cost_usd === "number" && Number.isFinite(resultMsg.total_cost_usd)
+      ? resultMsg.total_cost_usd
+      : undefined;
+
+  // Nothing worth persisting.
+  if (Object.keys(perModel).length === 0 && numTurns === undefined && totalCostUsd === undefined) {
+    return undefined;
+  }
+
+  const usage: RunUsage = { per_model: perModel };
+  if (numTurns !== undefined) {
+    usage.num_turns = numTurns;
+  }
+  if (totalCostUsd !== undefined) {
+    usage.total_cost_usd = totalCostUsd;
+  }
+  return usage;
 }

--- a/packages/core/src/runner/runtime/__tests__/cli-runtime.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/cli-runtime.test.ts
@@ -120,6 +120,127 @@ describe("CLIRuntime synthetic result aggregation", () => {
     expect(result?.usage?.input_tokens).toBe(110);
     expect(result?.usage?.output_tokens).toBe(30);
   });
+
+  it("aggregates per-model token usage (incl. cache classes) across models", async () => {
+    watchMessages.push(
+      {
+        type: "assistant",
+        message: {
+          id: "msg-1",
+          model: "claude-opus-4-8",
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 100,
+            output_tokens: 25,
+            cache_creation_input_tokens: 40,
+            cache_read_input_tokens: 900,
+          },
+          content: [{ type: "text", text: "opus turn one" }],
+        },
+      } as SDKMessage,
+      {
+        type: "assistant",
+        message: {
+          id: "msg-2",
+          model: "claude-opus-4-8",
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 50,
+            output_tokens: 15,
+            cache_creation_input_tokens: 10,
+            cache_read_input_tokens: 100,
+          },
+          content: [{ type: "text", text: "opus turn two" }],
+        },
+      } as SDKMessage,
+      {
+        type: "assistant",
+        message: {
+          id: "msg-3",
+          model: "claude-haiku-4-5",
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 20,
+            output_tokens: 8,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+          content: [{ type: "text", text: "haiku subagent" }],
+        },
+      } as SDKMessage,
+    );
+
+    const runtime = new CLIRuntime({
+      processSpawner: (() => makeSubprocess() as never) as never,
+    });
+
+    const messages: SDKMessage[] = [];
+    for await (const message of runtime.execute({
+      prompt: "Hello",
+      agent: { name: "test-agent", configPath: "/tmp/agent.yaml" } as never,
+    })) {
+      messages.push(message);
+    }
+
+    const result = messages.find((m) => m.type === "result") as
+      | (SDKMessage & {
+          type: "result";
+          modelUsage?: Record<
+            string,
+            {
+              inputTokens: number;
+              outputTokens: number;
+              cacheCreationInputTokens: number;
+              cacheReadInputTokens: number;
+            }
+          >;
+        })
+      | undefined;
+
+    expect(result?.modelUsage).toBeDefined();
+    // Opus turns are summed across both messages; Haiku is its own bucket.
+    expect(result?.modelUsage?.["claude-opus-4-8"]).toEqual({
+      inputTokens: 150,
+      outputTokens: 40,
+      cacheCreationInputTokens: 50,
+      cacheReadInputTokens: 1000,
+    });
+    expect(result?.modelUsage?.["claude-haiku-4-5"]).toEqual({
+      inputTokens: 20,
+      outputTokens: 8,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    });
+  });
+
+  it("buckets usage under 'unknown' when an assistant message has no model", async () => {
+    watchMessages.push({
+      type: "assistant",
+      message: {
+        id: "msg-1",
+        stop_reason: "end_turn",
+        usage: { input_tokens: 12, output_tokens: 4 },
+        content: [{ type: "text", text: "no model field" }],
+      },
+    } as SDKMessage);
+
+    const runtime = new CLIRuntime({
+      processSpawner: (() => makeSubprocess() as never) as never,
+    });
+
+    const messages: SDKMessage[] = [];
+    for await (const message of runtime.execute({
+      prompt: "Hello",
+      agent: { name: "test-agent", configPath: "/tmp/agent.yaml" } as never,
+    })) {
+      messages.push(message);
+    }
+
+    const result = messages.find((m) => m.type === "result") as
+      | (SDKMessage & { type: "result"; modelUsage?: Record<string, { inputTokens: number }> })
+      | undefined;
+    expect(result?.modelUsage?.unknown?.inputTokens).toBe(12);
+  });
 });
 
 describe("CLIRuntime working directory / session resolution", () => {

--- a/packages/core/src/runner/runtime/cli-runtime.ts
+++ b/packages/core/src/runner/runtime/cli-runtime.ts
@@ -290,12 +290,26 @@ export class CLIRuntime implements RuntimeInterface {
     let watcher: CLISessionWatcher | undefined;
     let hasError = false;
 
-    // Track usage stats across all assistant turns for synthetic result message
+    // Track usage stats across all assistant turns for synthetic result message.
+    // The Claude CLI does not emit an SDK-style `result` message, so we aggregate
+    // usage per model (a run can span an Opus main agent + Haiku subagents) to
+    // reconstruct the same per-model breakdown the SDK reports (see issue #378).
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let numTurns = 0;
     let lastAssistantText = "";
     const seenAssistantMessageIds = new Set<string>();
+    // Per-model aggregation in the SDK's camelCase `modelUsage` shape so the
+    // downstream `extractRunUsage` reader handles CLI and SDK results uniformly.
+    const modelUsage: Record<
+      string,
+      {
+        inputTokens: number;
+        outputTokens: number;
+        cacheCreationInputTokens: number;
+        cacheReadInputTokens: number;
+      }
+    > = {};
 
     // Helper to accumulate usage from each assistant message
     const trackAssistantUsage = (message: SDKMessage) => {
@@ -328,14 +342,37 @@ export class CLIRuntime implements RuntimeInterface {
       numTurns++;
       const msg = message as {
         message?: {
+          model?: string;
           content?: Array<{ type: string; text?: string }>;
-          usage?: { input_tokens?: number; output_tokens?: number };
+          usage?: {
+            input_tokens?: number;
+            output_tokens?: number;
+            cache_creation_input_tokens?: number;
+            cache_read_input_tokens?: number;
+          };
         };
       };
       const usage = msg.message?.usage;
       if (usage) {
-        totalInputTokens += usage.input_tokens ?? 0;
-        totalOutputTokens += usage.output_tokens ?? 0;
+        const inputTokens = usage.input_tokens ?? 0;
+        const outputTokens = usage.output_tokens ?? 0;
+        const cacheCreationInputTokens = usage.cache_creation_input_tokens ?? 0;
+        const cacheReadInputTokens = usage.cache_read_input_tokens ?? 0;
+
+        totalInputTokens += inputTokens;
+        totalOutputTokens += outputTokens;
+
+        const modelId = msg.message?.model ?? "unknown";
+        const bucket = (modelUsage[modelId] ??= {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+        });
+        bucket.inputTokens += inputTokens;
+        bucket.outputTokens += outputTokens;
+        bucket.cacheCreationInputTokens += cacheCreationInputTokens;
+        bucket.cacheReadInputTokens += cacheReadInputTokens;
       }
       // Capture last text content for result fallback
       const content = msg.message?.content;
@@ -583,6 +620,9 @@ export class CLIRuntime implements RuntimeInterface {
             input_tokens: totalInputTokens,
             output_tokens: totalOutputTokens,
           },
+          // Per-model token accounting (SDK camelCase shape) so run-end
+          // persistence records the same per-model breakdown for CLI runs.
+          modelUsage,
         };
       }
     } catch (error) {

--- a/packages/core/src/state/__tests__/job-metadata-schema.test.ts
+++ b/packages/core/src/state/__tests__/job-metadata-schema.test.ts
@@ -6,6 +6,8 @@ import {
   type JobMetadata,
   JobMetadataSchema,
   JobStatusSchema,
+  ModelTokenUsageSchema,
+  RunUsageSchema,
   TriggerTypeSchema,
 } from "../schemas/job-metadata.js";
 
@@ -421,5 +423,137 @@ describe("createJobMetadata", () => {
     });
 
     expect(job.id).toMatch(/^job-\d{4}-\d{2}-\d{2}-[a-z0-9]{6}$/);
+  });
+
+  it("initializes usage to null", () => {
+    const job = createJobMetadata({
+      agent: "my-agent",
+      trigger_type: "manual",
+    });
+
+    expect(job.usage).toBeNull();
+  });
+});
+
+describe("ModelTokenUsageSchema", () => {
+  it("accepts the four token classes", () => {
+    const usage = ModelTokenUsageSchema.parse({
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 10,
+    });
+
+    expect(usage.input_tokens).toBe(100);
+    expect(usage.output_tokens).toBe(50);
+    expect(usage.cache_creation_input_tokens).toBe(20);
+    expect(usage.cache_read_input_tokens).toBe(10);
+  });
+
+  it("rejects negative token counts", () => {
+    expect(() =>
+      ModelTokenUsageSchema.parse({
+        input_tokens: -1,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      }),
+    ).toThrow();
+  });
+
+  it("requires all four token classes", () => {
+    expect(() => ModelTokenUsageSchema.parse({ input_tokens: 1 })).toThrow();
+  });
+});
+
+describe("RunUsageSchema", () => {
+  it("accepts per-model accounting spanning multiple models", () => {
+    const usage = RunUsageSchema.parse({
+      per_model: {
+        "claude-opus-4-8": {
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_creation_input_tokens: 200,
+          cache_read_input_tokens: 8000,
+        },
+        "claude-haiku-4-5": {
+          input_tokens: 300,
+          output_tokens: 120,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+      num_turns: 7,
+      total_cost_usd: 0.4213,
+    });
+
+    expect(Object.keys(usage.per_model)).toHaveLength(2);
+    expect(usage.per_model["claude-opus-4-8"].cache_read_input_tokens).toBe(8000);
+    expect(usage.num_turns).toBe(7);
+    expect(usage.total_cost_usd).toBeCloseTo(0.4213);
+  });
+
+  it("allows num_turns and total_cost_usd to be omitted (CLI/Max runs)", () => {
+    const usage = RunUsageSchema.parse({
+      per_model: {
+        "claude-opus-4-8": {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    });
+
+    expect(usage.num_turns).toBeUndefined();
+    expect(usage.total_cost_usd).toBeUndefined();
+  });
+
+  it("allows an empty per_model map", () => {
+    const usage = RunUsageSchema.parse({ per_model: {}, num_turns: 1 });
+    expect(usage.per_model).toEqual({});
+  });
+});
+
+describe("JobMetadataSchema usage field (backward compatibility)", () => {
+  const baseJob: JobMetadata = {
+    id: "job-2024-01-15-abc123",
+    agent: "my-agent",
+    trigger_type: "manual",
+    status: "completed",
+    started_at: "2024-01-15T10:00:00.000Z",
+  };
+
+  it("parses legacy job records that predate the usage field", () => {
+    // No `usage` key at all — must still parse (additive + backward-compatible).
+    const parsed = JobMetadataSchema.parse(baseJob);
+    expect(parsed.usage).toBeUndefined();
+  });
+
+  it("accepts a null usage field", () => {
+    const parsed = JobMetadataSchema.parse({ ...baseJob, usage: null });
+    expect(parsed.usage).toBeNull();
+  });
+
+  it("round-trips a populated usage field", () => {
+    const parsed = JobMetadataSchema.parse({
+      ...baseJob,
+      usage: {
+        per_model: {
+          "claude-opus-4-8": {
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_creation_input_tokens: 200,
+            cache_read_input_tokens: 8000,
+          },
+        },
+        num_turns: 3,
+        total_cost_usd: 0.12,
+      },
+    });
+
+    expect(parsed.usage?.per_model["claude-opus-4-8"].output_tokens).toBe(500);
+    expect(parsed.usage?.num_turns).toBe(3);
+    expect(parsed.usage?.total_cost_usd).toBe(0.12);
   });
 });

--- a/packages/core/src/state/schemas/index.ts
+++ b/packages/core/src/state/schemas/index.ts
@@ -31,6 +31,10 @@ export {
   JobMetadataSchema,
   type JobStatus,
   JobStatusSchema,
+  type ModelTokenUsage,
+  ModelTokenUsageSchema,
+  type RunUsage,
+  RunUsageSchema,
   type TriggerType,
   TriggerTypeSchema,
 } from "./job-metadata.js";

--- a/packages/core/src/state/schemas/job-metadata.ts
+++ b/packages/core/src/state/schemas/job-metadata.ts
@@ -37,6 +37,52 @@ export const TriggerTypeSchema = z.enum([
 export const ExitReasonSchema = z.enum(["success", "error", "timeout", "cancelled", "max_turns"]);
 
 // =============================================================================
+// Token Accounting Schemas
+// =============================================================================
+
+/**
+ * The four token classes tracked for a single model.
+ *
+ * Mirrors the Anthropic usage breakdown: fresh input, generated output, and the
+ * two prompt-cache classes. Kept as raw counts only — herdctl deliberately does
+ * NOT persist a $/token price table (it drifts, and Max/CLI plans have no real
+ * per-token spend); the consuming app applies pricing.
+ */
+export const ModelTokenUsageSchema = z.object({
+  /** Fresh (non-cached) input tokens */
+  input_tokens: z.number().nonnegative(),
+  /** Generated output tokens */
+  output_tokens: z.number().nonnegative(),
+  /** Tokens written to the prompt cache */
+  cache_creation_input_tokens: z.number().nonnegative(),
+  /** Tokens read from the prompt cache */
+  cache_read_input_tokens: z.number().nonnegative(),
+});
+
+/**
+ * Per-run token accounting, captured at run-end from the runtime's terminal
+ * result message.
+ *
+ * Token counts are broken down **per model** because a single run can span more
+ * than one model (e.g. an Opus main agent delegating to Haiku subagents).
+ */
+export const RunUsageSchema = z.object({
+  /**
+   * Per-model token accounting, keyed by model id (e.g. `claude-opus-4-8`).
+   * Each entry carries that model's four token classes.
+   */
+  per_model: z.record(z.string(), ModelTokenUsageSchema),
+  /** Total agentic turns reported by the runtime for this run */
+  num_turns: z.number().nonnegative().nullable().optional(),
+  /**
+   * SDK-authoritative run cost in USD, when the runtime reports one. Absent for
+   * CLI / Max-plan runs that have no real per-token spend. This is the SDK's own
+   * reported figure, not a herdctl-computed price.
+   */
+  total_cost_usd: z.number().nonnegative().nullable().optional(),
+});
+
+// =============================================================================
 // Job Metadata Schema
 // =============================================================================
 
@@ -93,6 +139,13 @@ export const JobMetadataSchema = z.object({
 
   /** Path to the output file containing full session output */
   output_file: z.string().nullable().optional(),
+
+  /**
+   * Per-run token accounting (per model) + turn count + SDK cost, captured at
+   * run-end. Absent (null/undefined) for jobs recorded before this field existed
+   * and for runs that produced no terminal usage — backward-compatible.
+   */
+  usage: RunUsageSchema.nullable().optional(),
 });
 
 // =============================================================================
@@ -102,6 +155,8 @@ export const JobMetadataSchema = z.object({
 export type JobStatus = z.infer<typeof JobStatusSchema>;
 export type TriggerType = z.infer<typeof TriggerTypeSchema>;
 export type ExitReason = z.infer<typeof ExitReasonSchema>;
+export type ModelTokenUsage = z.infer<typeof ModelTokenUsageSchema>;
+export type RunUsage = z.infer<typeof RunUsageSchema>;
 export type JobMetadata = z.infer<typeof JobMetadataSchema>;
 
 // =============================================================================
@@ -169,5 +224,6 @@ export function createJobMetadata(
     prompt: options.prompt ?? null,
     summary: null,
     output_file: null,
+    usage: null,
   };
 }


### PR DESCRIPTION
Closes #378. Unblocks paddock#271.

## What

herdctl already receives the SDK's authoritative `total_cost_usd` + `usage` on the terminal result message (and the CLI runtime aggregates its own token counts), but **discarded all of it** before the final `updateJob`. This persists that accounting on the job record.

The job record (`JobMetadataSchema`) gains an additive, backward-compatible `usage` field capturing, at run-end:

- **`usage.per_model`** — per-model token accounting keyed by model id. Each entry carries that model's **four token classes** (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`). A single run can span multiple models (e.g. an Opus main agent delegating to Haiku subagents), so counts are broken down per model rather than summed.
- **`usage.num_turns`** — total agentic turns reported by the runtime.
- **`usage.total_cost_usd`** — the SDK's own authoritative run cost, when reported. Absent for CLI / Max-plan runs that have no real per-token spend.

**Pricing stays out of herdctl** — only raw token counts and the SDK's own cost figure are stored (no `$/token` table, which drifts). The consuming app (Paddock) applies pricing.

## How

- **`state/schemas/job-metadata.ts`** — new `ModelTokenUsageSchema` + `RunUsageSchema`; `usage: RunUsageSchema.nullable().optional()` on `JobMetadataSchema`; factory initializes it to `null`.
- **`runner/message-processor.ts`** — new `extractRunUsage(message)` maps the SDK result's camelCase `modelUsage` (with a top-level snake_case `usage` fallback keyed by model id, else `"unknown"`) into the persisted shape, coercing malformed counts to `0`.
- **`runner/runtime/cli-runtime.ts`** — the synthesized CLI result now aggregates **per-model** usage (incl. cache classes) into a `modelUsage` map, so both runtimes persist a uniform breakdown.
- **`runner/job-executor.ts`** — captures accounting from the terminal result message and writes it in the final `updateJob` (left untouched — stays `null` — when a run produces no result).

## Backward compatibility

Additive only. Existing job records without the field still parse; headless fleets see no behaviour change. Verified by a schema test that parses a legacy record with no `usage` key.

## Testing

- **Schema** — `RunUsageSchema` / `ModelTokenUsageSchema` validation (multi-model, optional cost/turns, empty map), legacy-record backward-compat, populated round-trip.
- **`extractRunUsage`** — SDK `modelUsage`, top-level `usage` fallback, `unknown` keying, malformed→0 coercion, CLI-synthetic shape, empty/none → undefined.
- **CLI runtime** — per-model aggregation across Opus + Haiku turns (incl. cache classes), `unknown` bucket for model-less turns.
- **End-to-end (real run path)** — `job-executor` test asserts the **persisted job record on disk** carries `usage.per_model` / `num_turns` / `total_cost_usd`, and stays `null` with no result message.

`pnpm build` + `pnpm typecheck` pass. Full core suite green except one pre-existing failure (`directory.test.ts` "parent not writable" — fails on clean main too; a root-permission-bypass in this sandbox, passes on CI's non-root runner).