### PR TITLE
fix(core): prune stale adhoc session metadata entries (#168)

### DIFF
--- a/.changeset/prune-stale-adhoc-session-metadata.md
+++ b/.changeset/prune-stale-adhoc-session-metadata.md
@@ -1,0 +1,15 @@
+---
+"@herdctl/core": patch
+---
+
+Prune stale session metadata entries during full session scans (#168)
+
+`SessionMetadataStore` accumulated autoName/preview/sidechain/usage cache entries
+for every discovered session but never removed them, so files like `adhoc.json`
+grew unboundedly — entries persisted long after the underlying JSONL transcript
+was deleted. Added `SessionMetadataStore.prune(agentName, validSessionIds)` and
+wired it into `getAllSessions()`, which reconciles each metadata key against the
+sessions still present on disk. Pruning runs only on a full (unlimited)
+enumeration and unions valid sessionIds across every directory sharing a key
+(all unattributed dirs share `"adhoc"`), so a limited/top-N scan never deletes
+live entries, and it writes only when something was actually removed.

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -40,6 +40,7 @@ const mockGetSidechain = vi.fn().mockResolvedValue(undefined);
 const mockBatchSetSidechains = vi.fn().mockResolvedValue(undefined);
 const mockGetUsage = vi.fn().mockResolvedValue(undefined);
 const mockSetUsage = vi.fn().mockResolvedValue(undefined);
+const mockPrune = vi.fn().mockResolvedValue(0);
 vi.mock("../session-metadata.js", () => {
   return {
     SessionMetadataStore: class MockSessionMetadataStore {
@@ -52,6 +53,7 @@ vi.mock("../session-metadata.js", () => {
       batchSetSidechains = mockBatchSetSidechains;
       getUsage = mockGetUsage;
       setUsage = mockSetUsage;
+      prune = mockPrune;
     },
   };
 });
@@ -159,6 +161,8 @@ describe("SessionDiscoveryService", () => {
     mockGetUsage.mockResolvedValue(undefined);
     mockSetUsage.mockReset();
     mockSetUsage.mockResolvedValue(undefined);
+    mockPrune.mockReset();
+    mockPrune.mockResolvedValue(0);
 
     // Reset JSONL parser mocks
     mockExtractLastSummary.mockReset();
@@ -572,6 +576,69 @@ describe("SessionDiscoveryService", () => {
   // ===========================================================================
 
   describe("getAllSessions", () => {
+    // Issue #168: stale metadata reconciliation.
+    describe("stale metadata pruning (#168)", () => {
+      it("prunes each metadata key with the union of live sessionIds on a full scan", async () => {
+        // Two unattributed directories → both share the "adhoc" metadata key.
+        const adhocDir1 = join(tempClaudeHome, "projects", "-Users-ed-Code-loose1");
+        const adhocDir2 = join(tempClaudeHome, "projects", "-Users-ed-Code-loose2");
+        await mkdir(adhocDir1, { recursive: true });
+        await mkdir(adhocDir2, { recursive: true });
+        await createSessionFile(adhocDir1, "adhoc-a");
+        await createSessionFile(adhocDir2, "adhoc-b");
+
+        // An attributed agent directory → its own metadata key.
+        const agentDir = join(tempClaudeHome, "projects", "-Users-ed-Code-myproject");
+        await mkdir(agentDir, { recursive: true });
+        await createSessionFile(agentDir, "agent-a");
+
+        const service = new SessionDiscoveryService({
+          claudeHomePath: tempClaudeHome,
+          stateDir: tempStateDir,
+        });
+
+        await service.getAllSessions([
+          {
+            name: "my-fleet/my-agent",
+            workingDirectory: "/Users/ed/Code/myproject",
+            dockerEnabled: false,
+          },
+        ]);
+
+        // Collect the (key -> validIds) pairs prune was invoked with.
+        const pruneCalls = new Map<string, Set<string>>(
+          mockPrune.mock.calls.map(([key, ids]) => [key as string, ids as Set<string>]),
+        );
+
+        // adhoc is pruned once, with the UNION of both loose dirs' live sessions.
+        expect(pruneCalls.has("adhoc")).toBe(true);
+        expect([...pruneCalls.get("adhoc")!].sort()).toEqual(["adhoc-a", "adhoc-b"]);
+
+        // The attributed agent is pruned against its own live session.
+        expect(pruneCalls.has("my-fleet/my-agent")).toBe(true);
+        expect([...pruneCalls.get("my-fleet/my-agent")!]).toEqual(["agent-a"]);
+      });
+
+      it("does NOT prune on a limited scan (partial enumeration)", async () => {
+        // A limited scan only enriches the top-N sessions, so it does not see
+        // every session — pruning off it would wrongly delete live entries.
+        const adhocDir = join(tempClaudeHome, "projects", "-Users-ed-Code-loose");
+        await mkdir(adhocDir, { recursive: true });
+        await createSessionFile(adhocDir, "adhoc-a");
+        await createSessionFile(adhocDir, "adhoc-b");
+        await createSessionFile(adhocDir, "adhoc-c");
+
+        const service = new SessionDiscoveryService({
+          claudeHomePath: tempClaudeHome,
+          stateDir: tempStateDir,
+        });
+
+        await service.getAllSessions([], { limit: 1 });
+
+        expect(mockPrune).not.toHaveBeenCalled();
+      });
+    });
+
     it("returns directory groups for all project directories", async () => {
       // Create multiple project directories
       const projectDir1 = join(tempClaudeHome, "projects", "-Users-ed-Code-project1");

--- a/packages/core/src/state/__tests__/session-metadata.test.ts
+++ b/packages/core/src/state/__tests__/session-metadata.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -718,6 +718,91 @@ describe("SessionMetadataStore", () => {
 
       expect((await store.getPreview("test-agent", "session-1"))!.preview).toBe("Hi");
       expect((await store.getUsage("test-agent", "session-1"))!.usage!.inputTokens).toBe(1);
+    });
+  });
+
+  describe("prune", () => {
+    // Helper to seed a metadata file directly on disk with the given sessionIds.
+    async function seedMetadata(agentName: string, sessionIds: string[]): Promise<void> {
+      const metadataDir = join(tempDir, "session-metadata");
+      await mkdir(metadataDir, { recursive: true });
+      const sessions: Record<string, unknown> = {};
+      for (const id of sessionIds) {
+        sessions[id] = {
+          autoName: `name-${id}`,
+          autoNameMtime: "2024-01-15T10:00:00.000Z",
+          preview: `preview-${id}`,
+          previewMtime: "2024-01-15T10:00:00.000Z",
+        };
+      }
+      await writeFile(
+        join(metadataDir, `${agentName}.json`),
+        JSON.stringify({ version: 1, agentName, sessions }),
+        "utf-8",
+      );
+    }
+
+    it("removes entries whose sessionId is absent from the valid set", async () => {
+      await seedMetadata("adhoc", ["live-1", "dead-1", "dead-2"]);
+
+      const pruned = await store.prune("adhoc", new Set(["live-1"]));
+
+      expect(pruned).toBe(2);
+      const metadata = await store.getAgentMetadata("adhoc");
+      expect(Object.keys(metadata!.sessions).sort()).toEqual(["live-1"]);
+    });
+
+    it("keeps entries that are present in the valid set", async () => {
+      await seedMetadata("adhoc", ["live-1", "live-2", "dead-1"]);
+
+      const pruned = await store.prune("adhoc", new Set(["live-1", "live-2"]));
+
+      expect(pruned).toBe(1);
+      const metadata = await store.getAgentMetadata("adhoc");
+      expect(Object.keys(metadata!.sessions).sort()).toEqual(["live-1", "live-2"]);
+      // Surviving entries keep their cached fields intact
+      expect(metadata!.sessions["live-1"].autoName).toBe("name-live-1");
+      expect(metadata!.sessions["live-2"].preview).toBe("preview-live-2");
+    });
+
+    it("returns 0 and writes nothing when no metadata file exists", async () => {
+      const pruned = await store.prune("adhoc", new Set(["anything"]));
+      expect(pruned).toBe(0);
+
+      // No file should have been created
+      const metadataDir = join(tempDir, "session-metadata");
+      await expect(readdir(metadataDir)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("does not rewrite the file when nothing changed (all entries valid)", async () => {
+      await seedMetadata("adhoc", ["s-1", "s-2"]);
+      const filePath = join(tempDir, "session-metadata", "adhoc.json");
+
+      // Capture the on-disk state, then prune with a set that covers everything
+      // (as a full scan would). A superset of the valid ids must also be a no-op.
+      const before = await readFile(filePath, "utf-8");
+      const beforeMtime = (await stat(filePath)).mtimeMs;
+
+      const pruned = await store.prune("adhoc", new Set(["s-1", "s-2", "s-3"]));
+
+      expect(pruned).toBe(0);
+      const after = await readFile(filePath, "utf-8");
+      expect(after).toBe(before);
+      // File was not rewritten (mtime unchanged) — no disk write on a no-op prune.
+      expect((await stat(filePath)).mtimeMs).toBe(beforeMtime);
+    });
+
+    it("prunes across a shared 'adhoc' key using the union of all directories", async () => {
+      // Two unattributed directories both write to adhoc.json. The valid set for
+      // a full scan is the UNION of their live sessions; anything else is dead.
+      await seedMetadata("adhoc", ["dirA-1", "dirA-2", "dirB-1", "orphan"]);
+
+      const unionOfLiveIds = new Set(["dirA-1", "dirA-2", "dirB-1"]);
+      const pruned = await store.prune("adhoc", unionOfLiveIds);
+
+      expect(pruned).toBe(1);
+      const metadata = await store.getAgentMetadata("adhoc");
+      expect(Object.keys(metadata!.sessions).sort()).toEqual(["dirA-1", "dirA-2", "dirB-1"]);
     });
   });
 });

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -895,7 +895,8 @@ export class SessionDiscoveryService {
     // one adhoc directory would delete another's live entries. Only populated on
     // a full (unlimited) scan; a limited scan does NOT enumerate every session,
     // so pruning off it would wrongly delete live entries.
-    const validSessionIdsByKey = limit === undefined ? new Map<string, Set<string>>() : undefined;
+    const validSessionIdsByKey: Map<string, Set<string>> | undefined =
+      limit === undefined ? new Map<string, Set<string>>() : undefined;
 
     for (const dir of directories) {
       if (validSessionIdsByKey) {

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -1045,6 +1045,16 @@ export class SessionDiscoveryService {
     // Runs only on a full scan (validSessionIdsByKey is undefined when a limit
     // was applied). Pruning writes only when it actually removes an entry, so a
     // steady-state listing with no dead sessions performs no extra writes.
+    //
+    // Known limitation: only keys discovered in *this* scan are reconciled. A
+    // directory with zero .jsonl files is skipped in Phase 1, so a key whose
+    // transcripts are ALL gone (e.g. an agent removed from config, orphaning its
+    // <agent>.json) contributes no entry here and is never pruned. This is
+    // mitigated for the primary offender — the shared "adhoc" key is reconciled
+    // as long as any one unattributed directory still has sessions. Fully
+    // reconciling orphaned metadata files would require enumerating
+    // session-metadata/*.json rather than only the keys seen this scan; that's a
+    // larger change left as a follow-up.
     if (validSessionIdsByKey) {
       for (const [metadataKey, validIds] of validSessionIdsByKey) {
         await this.sessionMetadataStore.prune(metadataKey, validIds);

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -888,7 +888,30 @@ export class SessionDiscoveryService {
     // Phase 3: Enrich sessions (only selected ones when limit is set)
     const groups: DirectoryGroup[] = [];
 
+    // Accumulate the sessionIds that physically exist on disk for each metadata
+    // key, so stale metadata entries can be reconciled away afterwards (#168).
+    // Multiple directories can share a key — every unattributed directory uses
+    // "adhoc" — so we must union across directories before pruning, otherwise
+    // one adhoc directory would delete another's live entries. Only populated on
+    // a full (unlimited) scan; a limited scan does NOT enumerate every session,
+    // so pruning off it would wrongly delete live entries.
+    const validSessionIdsByKey = limit === undefined ? new Map<string, Set<string>>() : undefined;
+
     for (const dir of directories) {
+      if (validSessionIdsByKey) {
+        let validIds = validSessionIdsByKey.get(dir.metadataKey);
+        if (!validIds) {
+          validIds = new Set<string>();
+          validSessionIdsByKey.set(dir.metadataKey, validIds);
+        }
+        // Every transcript present in this directory is a live session for this
+        // key — include sidechains and non-enriched sessions, all of which carry
+        // legitimately-cached metadata keyed by sessionId.
+        for (const { sessionId } of dir.sessionFiles) {
+          validIds.add(sessionId);
+        }
+      }
+
       const sessions: DiscoveredSession[] = [];
       const autoNameUpdates: Array<{ sessionId: string; autoName?: string; mtime: string }> = [];
       const previewUpdates: Array<{ sessionId: string; preview?: string; mtime: string }> = [];
@@ -1014,6 +1037,16 @@ export class SessionDiscoveryService {
           sessionCount: visibleSessionCount,
           sessions,
         });
+      }
+    }
+
+    // Reconcile metadata against the sessions that still exist on disk (#168).
+    // Runs only on a full scan (validSessionIdsByKey is undefined when a limit
+    // was applied). Pruning writes only when it actually removes an entry, so a
+    // steady-state listing with no dead sessions performs no extra writes.
+    if (validSessionIdsByKey) {
+      for (const [metadataKey, validIds] of validSessionIdsByKey) {
+        await this.sessionMetadataStore.prune(metadataKey, validIds);
       }
     }
 

--- a/packages/core/src/state/session-metadata.ts
+++ b/packages/core/src/state/session-metadata.ts
@@ -568,6 +568,55 @@ export class SessionMetadataStore {
   }
 
   /**
+   * Prune stale session entries, keeping only those whose sessionId is in the
+   * provided valid set.
+   *
+   * Session metadata (autoName / preview / sidechain / usage caches) is written
+   * for every discovered session but never removed, so files like `adhoc.json`
+   * grow unboundedly as Claude Code creates and deletes transcripts over time
+   * (issue #168). This reconciles the cache against the set of sessions that
+   * still exist on disk, deleting entries whose transcript is gone.
+   *
+   * IMPORTANT: only call this with a set derived from a **full/unlimited**
+   * enumeration of the agent's sessions. Passing a partial set (e.g. from a
+   * top-N limited scan) would wrongly delete metadata for live sessions that
+   * simply weren't enriched on this pass. When several directories share a
+   * metadata key (all unattributed dirs use `"adhoc"`), the caller must pass the
+   * UNION of valid sessionIds across every directory sharing that key.
+   *
+   * Writes only when something was actually removed, mirroring the batch-write
+   * semantics of the rest of the store.
+   *
+   * @param agentName - The agent's qualified name (use "adhoc" for unattributed sessions)
+   * @param validSessionIds - Set of sessionIds that still exist on disk for this key
+   * @returns The number of entries removed
+   */
+  async prune(agentName: string, validSessionIds: Set<string>): Promise<number> {
+    const metadata = await this.loadMetadata(agentName);
+    if (!metadata) {
+      return 0;
+    }
+
+    let pruned = 0;
+    for (const sessionId of Object.keys(metadata.sessions)) {
+      if (!validSessionIds.has(sessionId)) {
+        delete metadata.sessions[sessionId];
+        pruned++;
+      }
+    }
+
+    if (pruned > 0) {
+      await this.saveMetadata(agentName, metadata);
+      logger.debug(`Pruned ${pruned} stale session metadata entries`, {
+        agentName,
+        remaining: Object.keys(metadata.sessions).length,
+      });
+    }
+
+    return pruned;
+  }
+
+  /**
    * Get cached usage and its mtime for a session
    *
    * @param agentName - The agent's qualified name (use "adhoc" for unattributed sessions)


### PR DESCRIPTION
## What

Adds `SessionMetadataStore.prune(agentName, validSessionIds)` and wires it into `SessionDiscoveryService.getAllSessions()` so stale session-metadata entries are reconciled away against the sessions that still exist on disk.

## Why

`SessionMetadataStore` cached `autoName` / `preview` / `isSidechain` / `usage` entries per session under a metadata key (`"adhoc"` for unattributed sessions) but had **no** cleanup, TTL, or reconciliation. Every unique Claude Code session ever discovered in an unattributed directory got an entry in `adhoc.json`, and entries persisted forever — even after the underlying JSONL transcript was deleted. In production this had grown to 110 dead entries, and the file grows monotonically with CLI usage (slower read/parse/write on every `/api/chat/all` and `/api/chat/recent`).

Closes #168.

## How

- **`prune(agentName, validSessionIds)`** removes entries whose `sessionId` is absent from the provided set and returns the count removed. It writes only when something was actually removed, mirroring the store's existing batch-write semantics (no write on a steady-state, nothing-to-prune listing).
- **Wired into `getAllSessions()`**, guarded to run **only on a full (unlimited) enumeration**. This is the key correctness point: Phase-2 top-N filtering means a *limited* scan does not enumerate every session, so pruning off a limited set would wrongly delete live entries. When `options.limit` is set, no pruning happens at all.
- **Unions valid sessionIds across every directory that shares a metadata key.** Multiple unattributed directories all write to `adhoc.json`, so pruning per-directory-group (as the issue's sketch suggested) would make one adhoc directory delete another's live entries. The valid set for each key is accumulated across all directories before a single prune per key. The valid set includes *all* transcripts physically present (sidechains and non-enriched sessions too), since their cached metadata is legitimately keyed by sessionId.

## Test coverage

- `session-metadata.test.ts` — `prune()` unit tests: removes absent entries; keeps present ones (fields intact); no-op / no file write when nothing changed (asserts file mtime unchanged); returns 0 and creates no file when none exists; union-across-shared-`adhoc`-key.
- `session-discovery.test.ts` — integration: a full scan prunes each key with the correct union of live sessionIds (adhoc = union of both loose dirs; attributed agent = its own set); **a limited scan (`{ limit: 1 }`) does NOT prune** at all.

All `@herdctl/core` tests pass locally (`build`, `typecheck`, and the two touched suites green; full suite green except one pre-existing root-only env failure in `directory.test.ts` — a read-only-dir permission assertion that root bypasses; unrelated to this change and passes in CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed stale session metadata during complete session scans.
  * Preserved metadata during limited or partial scans to prevent accidental removal.
  * Correctly reconciled metadata shared across multiple session directories.

* **Tests**
  * Added coverage for stale-entry removal, retention of active sessions, missing metadata, no-op pruning, and shared directory scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->