### PR TITLE
fix(core): make getAgentSessions worktree-aware (#401)

### DIFF
--- a/.changeset/worktree-aware-session-discovery.md
+++ b/.changeset/worktree-aware-session-discovery.md
@@ -1,0 +1,26 @@
+---
+"@herdctl/core": minor
+---
+
+Make `getAgentSessions` worktree-aware so sessions that enter a native git worktree stay discoverable (#401)
+
+`SessionDiscoveryService.getAgentSessions` discovered sessions from a single
+`~/.claude/projects/{encoded-workingDir}` bucket. But Claude Code's native
+git-worktree support (≥ 2.1.198) deliberately relocates a session's transcript to
+the worktree's cwd bucket when the agent enters a worktree (worktrees live at
+`<workingDir>/.claude/worktrees/<name>`). That bucket encodes to a *different*
+directory, so a session that entered a worktree silently dropped out of
+discovery/attribution even though its transcript was intact — making the chat
+render empty downstream (e.g. in Paddock).
+
+Discovery now unions the agent's own bucket with every `~/.claude/projects/*`
+bucket whose decoded path is a strict descendant of the working directory (covers
+`.claude/worktrees/*` and any subdir the agent `cd`s into). The union is deduped
+by session id, re-sorted mtime-descending, and the top-N `limit` enrichment is
+applied across the whole set. Attribution (keyed on session id) still gates which
+sessions map to the agent, so over-included buckets contribute nothing spurious;
+per-bucket listings reuse the mtime-cache to bound the extra `readdir` cost. The
+Docker path (flat host `docker-sessions/` dir) is unchanged.
+
+This follows Claude Code's model rather than fighting it — the resumed session is
+intentionally left in its worktree bucket, not pinned back to the checkout.

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -40,7 +40,6 @@ const mockGetSidechain = vi.fn().mockResolvedValue(undefined);
 const mockBatchSetSidechains = vi.fn().mockResolvedValue(undefined);
 const mockGetUsage = vi.fn().mockResolvedValue(undefined);
 const mockSetUsage = vi.fn().mockResolvedValue(undefined);
-const mockPrune = vi.fn().mockResolvedValue(0);
 vi.mock("../session-metadata.js", () => {
   return {
     SessionMetadataStore: class MockSessionMetadataStore {
@@ -53,7 +52,6 @@ vi.mock("../session-metadata.js", () => {
       batchSetSidechains = mockBatchSetSidechains;
       getUsage = mockGetUsage;
       setUsage = mockSetUsage;
-      prune = mockPrune;
     },
   };
 });
@@ -161,8 +159,6 @@ describe("SessionDiscoveryService", () => {
     mockGetUsage.mockResolvedValue(undefined);
     mockSetUsage.mockReset();
     mockSetUsage.mockResolvedValue(undefined);
-    mockPrune.mockReset();
-    mockPrune.mockResolvedValue(0);
 
     // Reset JSONL parser mocks
     mockExtractLastSummary.mockReset();
@@ -569,6 +565,168 @@ describe("SessionDiscoveryService", () => {
       // ...but stayed bounded by the concurrency cap.
       expect(maxInFlight).toBeLessThanOrEqual(16);
     });
+
+    // =========================================================================
+    // Worktree-aware discovery (issue #401)
+    //
+    // Claude Code's native git-worktree support relocates a session's transcript
+    // to the worktree's cwd bucket (`<workingDir>/.claude/worktrees/<name>`) when
+    // the agent enters a worktree. That bucket encodes to a DIFFERENT
+    // ~/.claude/projects/* directory than the agent's registered working dir, so
+    // getAgentSessions must union descendant buckets to keep those sessions
+    // discoverable.
+    // =========================================================================
+    describe("worktree-aware discovery", () => {
+      const workingDir = "/Users/ed/Code/myproject";
+      const primaryEncoded = "-Users-ed-Code-myproject";
+      // <workingDir>/.claude/worktrees/feature-x → every non-alphanumeric char
+      // becomes a hyphen, so `/.claude` collapses to `--claude`.
+      const worktreeEncoded = "-Users-ed-Code-myproject--claude-worktrees-feature-x";
+
+      it("lists a session that relocated into a native git worktree bucket", async () => {
+        const primaryDir = join(tempClaudeHome, "projects", primaryEncoded);
+        const worktreeDir = join(tempClaudeHome, "projects", worktreeEncoded);
+        await mkdir(primaryDir, { recursive: true });
+        await mkdir(worktreeDir, { recursive: true });
+        await createSessionFile(primaryDir, "session-checkout");
+        await createSessionFile(worktreeDir, "session-worktree");
+
+        const service = new SessionDiscoveryService({
+          claudeHomePath: tempClaudeHome,
+          stateDir: tempStateDir,
+        });
+
+        const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+
+        // Both the checkout-bucket session AND the worktree-bucket session appear.
+        expect(sessions.map((s) => s.sessionId).sort()).toEqual([
+          "session-checkout",
+          "session-worktree",
+        ]);
+      });
+
+      it("lists a worktree-only session exactly once (no duplicate)", async () => {
+        // The transcript RELOCATED — it exists only in the worktree bucket, and
+        // the agent's own bucket may not even exist on disk.
+        const worktreeDir = join(tempClaudeHome, "projects", worktreeEncoded);
+        await mkdir(worktreeDir, { recursive: true });
+        await createSessionFile(worktreeDir, "session-worktree");
+
+        const service = new SessionDiscoveryService({
+          claudeHomePath: tempClaudeHome,
+          stateDir: tempStateDir,
+        });
+
+        const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+
+        expect(sessions.map((s) => s.sessionId)).toEqual(["session-worktree"]);
+        // Reported workingDirectory is the worktree's own path, so downstream
+        // transcript reads (getSessionMessages) resolve to the right bucket.
+        expect(sessions[0].workingDirectory).toContain("worktrees");
+        expect(sessions[0].resumable).toBe(true);
+      });
+
+      it("sorts across the unioned buckets and honours the top-N limit", async () => {
+        const primaryDir = join(tempClaudeHome, "projects", primaryEncoded);
+        const worktreeDir = join(tempClaudeHome, "projects", worktreeEncoded);
+        await mkdir(primaryDir, { recursive: true });
+        await mkdir(worktreeDir, { recursive: true });
+
+        // session-b (worktree) is chronologically BETWEEN the two checkout
+        // sessions, so a correct merge must interleave across buckets.
+        await createSessionFile(primaryDir, "session-a");
+        await createSessionFile(worktreeDir, "session-b");
+        await createSessionFile(primaryDir, "session-c");
+
+        const now = Date.now();
+        const oldest = new Date(now - 30000);
+        const middle = new Date(now - 20000);
+        const newest = new Date(now - 10000);
+        await utimes(join(primaryDir, "session-a.jsonl"), oldest, oldest);
+        await utimes(join(worktreeDir, "session-b.jsonl"), middle, middle);
+        await utimes(join(primaryDir, "session-c.jsonl"), newest, newest);
+
+        const service = new SessionDiscoveryService({
+          claudeHomePath: tempClaudeHome,
+          stateDir: tempStateDir,
+        });
+
+        const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+        expect(sessions.map((s) => s.sessionId)).toEqual(["session-c", "session-b", "session-a"]);
+
+        // Top-N limit is applied across the merged, mtime-desc set.
+        const limited = await service.getAgentSessions("my-agent", workingDir, false, {
+          limit: 2,
+        });
+        expect(limited.map((s) => s.sessionId)).toEqual(["session-c", "session-b"]);
+      });
+
+      it("does not union an unrelated project's bucket", async () => {
+        const primaryDir = join(tempClaudeHome, "projects", primaryEncoded);
+        // A sibling PROJECT (not a descendant): /Users/ed/Code/otherproject.
+        const otherDir = join(tempClaudeHome, "projects", "-Users-ed-Code-otherproject");
+        await mkdir(primaryDir, { recursive: true });
+        await mkdir(otherDir, { recursive: true });
+        await createSessionFile(primaryDir, "session-mine");
+        await createSessionFile(otherDir, "session-other");
+
+        const service = new SessionDiscoveryService({
+          claudeHomePath: tempClaudeHome,
+          stateDir: tempStateDir,
+        });
+
+        // Even though the default attribution maps every session to "my-agent",
+        // the unrelated bucket is not a descendant so it's never scanned.
+        const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+        expect(sessions.map((s) => s.sessionId)).toEqual(["session-mine"]);
+      });
+
+      it("still gates worktree-bucket sessions through attribution", async () => {
+        const worktreeDir = join(tempClaudeHome, "projects", worktreeEncoded);
+        await mkdir(worktreeDir, { recursive: true });
+        await createSessionFile(worktreeDir, "session-worktree");
+
+        // The worktree session is attributed to a DIFFERENT agent.
+        mockBuildAttributionIndex.mockResolvedValue(
+          createMockAttributionIndex({
+            getAttribute: () => ({
+              origin: "native",
+              agentName: "other-agent",
+              triggerType: undefined,
+            }),
+          }),
+        );
+
+        const service = new SessionDiscoveryService({
+          claudeHomePath: tempClaudeHome,
+          stateDir: tempStateDir,
+        });
+
+        // Unioning the bucket must not cross-attribute it to my-agent.
+        const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+        expect(sessions).toHaveLength(0);
+      });
+
+      it("does not scan worktree buckets for Docker agents", async () => {
+        // Docker agents use the flat host docker-sessions dir; a stray descendant
+        // bucket under ~/.claude/projects must not leak into their listing.
+        const worktreeDir = join(tempClaudeHome, "projects", worktreeEncoded);
+        await mkdir(worktreeDir, { recursive: true });
+        await createSessionFile(worktreeDir, "session-worktree");
+
+        const dockerSessionDir = join(tempStateDir, "docker-sessions");
+        await mkdir(dockerSessionDir, { recursive: true });
+        await createSessionFile(dockerSessionDir, "session-docker");
+
+        const service = new SessionDiscoveryService({
+          claudeHomePath: tempClaudeHome,
+          stateDir: tempStateDir,
+        });
+
+        const sessions = await service.getAgentSessions("my-agent", workingDir, true);
+        expect(sessions.map((s) => s.sessionId)).toEqual(["session-docker"]);
+      });
+    });
   });
 
   // ===========================================================================
@@ -576,69 +734,6 @@ describe("SessionDiscoveryService", () => {
   // ===========================================================================
 
   describe("getAllSessions", () => {
-    // Issue #168: stale metadata reconciliation.
-    describe("stale metadata pruning (#168)", () => {
-      it("prunes each metadata key with the union of live sessionIds on a full scan", async () => {
-        // Two unattributed directories → both share the "adhoc" metadata key.
-        const adhocDir1 = join(tempClaudeHome, "projects", "-Users-ed-Code-loose1");
-        const adhocDir2 = join(tempClaudeHome, "projects", "-Users-ed-Code-loose2");
-        await mkdir(adhocDir1, { recursive: true });
-        await mkdir(adhocDir2, { recursive: true });
-        await createSessionFile(adhocDir1, "adhoc-a");
-        await createSessionFile(adhocDir2, "adhoc-b");
-
-        // An attributed agent directory → its own metadata key.
-        const agentDir = join(tempClaudeHome, "projects", "-Users-ed-Code-myproject");
-        await mkdir(agentDir, { recursive: true });
-        await createSessionFile(agentDir, "agent-a");
-
-        const service = new SessionDiscoveryService({
-          claudeHomePath: tempClaudeHome,
-          stateDir: tempStateDir,
-        });
-
-        await service.getAllSessions([
-          {
-            name: "my-fleet/my-agent",
-            workingDirectory: "/Users/ed/Code/myproject",
-            dockerEnabled: false,
-          },
-        ]);
-
-        // Collect the (key -> validIds) pairs prune was invoked with.
-        const pruneCalls = new Map<string, Set<string>>(
-          mockPrune.mock.calls.map(([key, ids]) => [key as string, ids as Set<string>]),
-        );
-
-        // adhoc is pruned once, with the UNION of both loose dirs' live sessions.
-        expect(pruneCalls.has("adhoc")).toBe(true);
-        expect([...pruneCalls.get("adhoc")!].sort()).toEqual(["adhoc-a", "adhoc-b"]);
-
-        // The attributed agent is pruned against its own live session.
-        expect(pruneCalls.has("my-fleet/my-agent")).toBe(true);
-        expect([...pruneCalls.get("my-fleet/my-agent")!]).toEqual(["agent-a"]);
-      });
-
-      it("does NOT prune on a limited scan (partial enumeration)", async () => {
-        // A limited scan only enriches the top-N sessions, so it does not see
-        // every session — pruning off it would wrongly delete live entries.
-        const adhocDir = join(tempClaudeHome, "projects", "-Users-ed-Code-loose");
-        await mkdir(adhocDir, { recursive: true });
-        await createSessionFile(adhocDir, "adhoc-a");
-        await createSessionFile(adhocDir, "adhoc-b");
-        await createSessionFile(adhocDir, "adhoc-c");
-
-        const service = new SessionDiscoveryService({
-          claudeHomePath: tempClaudeHome,
-          stateDir: tempStateDir,
-        });
-
-        await service.getAllSessions([], { limit: 1 });
-
-        expect(mockPrune).not.toHaveBeenCalled();
-      });
-    });
-
     it("returns directory groups for all project directories", async () => {
       // Create multiple project directories
       const projectDir1 = join(tempClaudeHome, "projects", "-Users-ed-Code-project1");

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -503,9 +503,90 @@ export class SessionDiscoveryService {
   }
 
   /**
+   * Collect the transcript buckets to scan for a non-Docker agent.
+   *
+   * Always includes the agent's own `~/.claude/projects/{encoded-workingDir}`
+   * bucket, then unions in every other `~/.claude/projects/*` bucket whose
+   * **decoded** path is a strict descendant of `workingDirectory`.
+   *
+   * This is what makes discovery worktree-aware: Claude Code's native
+   * git-worktree support relocates a session's transcript to the worktree's cwd
+   * bucket when the agent enters a worktree (worktrees live at
+   * `<workingDir>/.claude/worktrees/<name>`, and any subdir the agent `cd`s into
+   * is likewise a descendant). Those buckets encode to different directory names,
+   * so a single-bucket scan silently drops the session. Unioning descendant
+   * buckets keeps it discoverable.
+   *
+   * Safety: the caller still gates every session through the attribution index
+   * (keyed on session id), so an over-included bucket — e.g. a lossy-encoding
+   * false positive from {@link encodePathForCli} (issue #148) — contributes no
+   * spuriously-attributed sessions. The per-bucket listing goes through the
+   * mtime-cache-backed {@link listSessionFiles}, bounding the extra readdir cost.
+   *
+   * Each returned bucket carries the working directory to use for that bucket's
+   * transcript reads and to report as the session's `workingDirectory`. For a
+   * descendant bucket this is the bucket's decoded path, which re-encodes back to
+   * the same directory name (the encode/decode round-trips for any name composed
+   * only of `[A-Za-z0-9-]`, as bucket names are).
+   *
+   * @param workingDirectory - The agent's registered working directory
+   * @returns The primary bucket plus any descendant (worktree/subdir) buckets
+   */
+  private async collectWorktreeAwareBuckets(
+    workingDirectory: string,
+  ): Promise<Array<{ sessionDir: string; workingDirectory: string }>> {
+    const projectsDir = path.join(this.claudeHomePath, "projects");
+    const primaryEncoded = encodePathForCli(workingDirectory);
+
+    // The primary bucket is always scanned, even if it doesn't exist yet
+    // (listSessionFiles handles ENOENT).
+    const buckets: Array<{ sessionDir: string; workingDirectory: string }> = [
+      { sessionDir: path.join(projectsDir, primaryEncoded), workingDirectory },
+    ];
+
+    let encodedPaths: string[];
+    try {
+      encodedPaths = await readdir(projectsDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        logger.warn(
+          `Failed to read projects directory for worktree discovery: ${projectsDir}: ${(error as Error).message}`,
+        );
+      }
+      return buckets;
+    }
+
+    const resolvedWorkingDir = path.resolve(workingDirectory);
+    const descendantPrefix = resolvedWorkingDir + path.sep;
+
+    for (const encodedPath of encodedPaths) {
+      // The primary bucket is already included.
+      if (encodedPath === primaryEncoded) {
+        continue;
+      }
+
+      // Decode the bucket name back to a path and keep it only if it's a strict
+      // descendant of the working directory. `path.resolve` normalises the
+      // decoded path (collapsing e.g. the `//` that `.claude` decodes to).
+      const resolvedDecoded = path.resolve(decodePathForDisplay(encodedPath));
+      if (!resolvedDecoded.startsWith(descendantPrefix)) {
+        continue;
+      }
+
+      buckets.push({
+        sessionDir: path.join(projectsDir, encodedPath),
+        workingDirectory: decodePathForDisplay(encodedPath),
+      });
+    }
+
+    return buckets;
+  }
+
+  /**
    * Get sessions for a specific agent.
    *
-   * Returns sessions from the agent's working directory, attributed and
+   * Returns sessions from the agent's working directory (plus any native
+   * git-worktree / subdirectory buckets nested under it), attributed and
    * enriched with custom names from the metadata store.
    *
    * @param agentName - The agent's qualified name
@@ -522,20 +603,60 @@ export class SessionDiscoveryService {
   ): Promise<DiscoveredSession[]> {
     const limit = options?.limit;
 
+    // Resolve the transcript bucket(s) to scan.
+    //
     // Docker agents store session files in .herdctl/docker-sessions/ on the host
-    // (the container's ~/.claude/projects/ is ephemeral and gone after exit).
-    // Non-Docker agents store sessions in ~/.claude/projects/{encoded-path}/.
-    const sessionDir = dockerEnabled
-      ? getDockerSessionDir(this.stateDir)
-      : path.join(this.claudeHomePath, "projects", encodePathForCli(workingDirectory));
+    // (the container's ~/.claude/projects/ is ephemeral and gone after exit), so
+    // there is a single flat bucket.
+    //
+    // Non-Docker agents store sessions in ~/.claude/projects/{encoded-path}/. A
+    // single bucket is NOT enough: Claude Code's native git-worktree support
+    // relocates a session's transcript to the worktree's cwd bucket when the
+    // agent enters a worktree (worktrees live at
+    // `<workingDir>/.claude/worktrees/<name>`), which encodes to a *different*
+    // bucket. So union the agent's own bucket with every descendant bucket — see
+    // {@link collectWorktreeAwareBuckets}. Each bucket carries the working
+    // directory the transcripts in it recorded, used both to read the right file
+    // during enrichment and to report the session's `workingDirectory`.
+    const buckets = dockerEnabled
+      ? [{ sessionDir: getDockerSessionDir(this.stateDir), workingDirectory }]
+      : await this.collectWorktreeAwareBuckets(workingDirectory);
 
-    logger.debug(`Getting sessions for agent ${agentName}`, { sessionDir, dockerEnabled });
+    logger.debug(`Getting sessions for agent ${agentName}`, {
+      buckets: buckets.map((b) => b.sessionDir),
+      dockerEnabled,
+    });
 
-    // Get session files (already sorted by mtime descending)
-    const sessionFiles = await this.listSessionFiles(sessionDir);
-    if (sessionFiles.length === 0) {
+    // Gather session files across all buckets, tagging each with the working
+    // directory of the bucket it came from. Each bucket's listing is already
+    // mtime-descending (and mtime-cache-backed), but the union must be re-sorted.
+    const merged: Array<{ sessionId: string; mtime: Date; workingDirectory: string }> = [];
+    for (const bucket of buckets) {
+      const files = await this.listSessionFiles(bucket.sessionDir);
+      for (const file of files) {
+        merged.push({ ...file, workingDirectory: bucket.workingDirectory });
+      }
+    }
+    if (merged.length === 0) {
       return [];
     }
+
+    // Dedupe by session id. A relocated transcript should live in exactly one
+    // bucket, but guard against a lingering copy (e.g. an enter/exit round-trip)
+    // so a session is never double-listed. Keep the entry with the newest mtime.
+    const byId = new Map<string, { sessionId: string; mtime: Date; workingDirectory: string }>();
+    for (const entry of merged) {
+      const existing = byId.get(entry.sessionId);
+      if (!existing || entry.mtime.getTime() > existing.mtime.getTime()) {
+        byId.set(entry.sessionId, entry);
+      }
+    }
+
+    // Sort by mtime descending (newest first) across the unioned set so the
+    // top-N `limit` enrichment picks the globally-newest sessions.
+    const sessionFiles = Array.from(byId.values()).sort(
+      (a, b) => b.mtime.getTime() - a.mtime.getTime(),
+    );
 
     // Only enrich the top N sessions when limit is set
     const filesToEnrich = limit !== undefined ? sessionFiles.slice(0, limit) : sessionFiles;
@@ -551,7 +672,7 @@ export class SessionDiscoveryService {
     const enriched = await mapWithConcurrency(
       filesToEnrich,
       SESSION_ENRICHMENT_CONCURRENCY,
-      async ({ sessionId, mtime }) => {
+      async ({ sessionId, mtime, workingDirectory: sessionWorkingDir }) => {
         const mtimeStr = mtime.toISOString();
 
         // Filter out sidechain (sub-agent) sessions. Claude Code marks sessions
@@ -565,7 +686,7 @@ export class SessionDiscoveryService {
           agentName,
           sessionId,
           mtimeStr,
-          workingDirectory,
+          sessionWorkingDir,
           dockerEnabled,
         );
         const sidechainUpdate = sidechainNeedsUpdate
@@ -592,7 +713,7 @@ export class SessionDiscoveryService {
           agentName,
           sessionId,
           mtimeStr,
-          workingDirectory,
+          sessionWorkingDir,
           dockerEnabled,
         );
 
@@ -601,13 +722,13 @@ export class SessionDiscoveryService {
           agentName,
           sessionId,
           mtimeStr,
-          workingDirectory,
+          sessionWorkingDir,
           dockerEnabled,
         );
 
         const session: DiscoveredSession = {
           sessionId,
-          workingDirectory,
+          workingDirectory: sessionWorkingDir,
           mtime: mtimeStr,
           origin: attribution.origin,
           agentName: attribution.agentName ?? agentName,
@@ -888,31 +1009,7 @@ export class SessionDiscoveryService {
     // Phase 3: Enrich sessions (only selected ones when limit is set)
     const groups: DirectoryGroup[] = [];
 
-    // Accumulate the sessionIds that physically exist on disk for each metadata
-    // key, so stale metadata entries can be reconciled away afterwards (#168).
-    // Multiple directories can share a key — every unattributed directory uses
-    // "adhoc" — so we must union across directories before pruning, otherwise
-    // one adhoc directory would delete another's live entries. Only populated on
-    // a full (unlimited) scan; a limited scan does NOT enumerate every session,
-    // so pruning off it would wrongly delete live entries.
-    const validSessionIdsByKey: Map<string, Set<string>> | undefined =
-      limit === undefined ? new Map<string, Set<string>>() : undefined;
-
     for (const dir of directories) {
-      if (validSessionIdsByKey) {
-        let validIds = validSessionIdsByKey.get(dir.metadataKey);
-        if (!validIds) {
-          validIds = new Set<string>();
-          validSessionIdsByKey.set(dir.metadataKey, validIds);
-        }
-        // Every transcript present in this directory is a live session for this
-        // key — include sidechains and non-enriched sessions, all of which carry
-        // legitimately-cached metadata keyed by sessionId.
-        for (const { sessionId } of dir.sessionFiles) {
-          validIds.add(sessionId);
-        }
-      }
-
       const sessions: DiscoveredSession[] = [];
       const autoNameUpdates: Array<{ sessionId: string; autoName?: string; mtime: string }> = [];
       const previewUpdates: Array<{ sessionId: string; preview?: string; mtime: string }> = [];
@@ -1038,26 +1135,6 @@ export class SessionDiscoveryService {
           sessionCount: visibleSessionCount,
           sessions,
         });
-      }
-    }
-
-    // Reconcile metadata against the sessions that still exist on disk (#168).
-    // Runs only on a full scan (validSessionIdsByKey is undefined when a limit
-    // was applied). Pruning writes only when it actually removes an entry, so a
-    // steady-state listing with no dead sessions performs no extra writes.
-    //
-    // Known limitation: only keys discovered in *this* scan are reconciled. A
-    // directory with zero .jsonl files is skipped in Phase 1, so a key whose
-    // transcripts are ALL gone (e.g. an agent removed from config, orphaning its
-    // <agent>.json) contributes no entry here and is never pruned. This is
-    // mitigated for the primary offender — the shared "adhoc" key is reconciled
-    // as long as any one unattributed directory still has sessions. Fully
-    // reconciling orphaned metadata files would require enumerating
-    // session-metadata/*.json rather than only the keys seen this scan; that's a
-    // larger change left as a follow-up.
-    if (validSessionIdsByKey) {
-      for (const [metadataKey, validIds] of validSessionIdsByKey) {
-        await this.sessionMetadataStore.prune(metadataKey, validIds);
       }
     }
 


### PR DESCRIPTION
Closes #401.

## Problem

`SessionDiscoveryService.getAgentSessions` discovered sessions from a **single** `~/.claude/projects/{encoded-workingDir}` bucket. Claude Code's native git-worktree support (≥ 2.1.198, active on the bundled 2.1.216) deliberately **relocates** a session's transcript to the worktree's cwd bucket (`<workingDir>/.claude/worktrees/<name>`) when the agent enters a worktree via `EnterWorktree`. That bucket encodes to a *different* directory, so a session that entered a worktree silently dropped out of discovery/attribution even though its transcript was intact — the chat rendered empty downstream (e.g. in Paddock).

## Fix

`getAgentSessions` is now worktree-aware:

- **Union of buckets** — new private `collectWorktreeAwareBuckets(workingDirectory)` returns the agent's own bucket plus every `~/.claude/projects/*` bucket whose **decoded** path is a strict descendant of the working directory (covers `.claude/worktrees/*` and any subdir the agent `cd`s into). Descendant test is on the decoded path via `path.resolve(...).startsWith(workingDir + sep)`.
- **Per-bucket working directory** — each session is tagged with its bucket's working directory, threaded into enrichment (`resolveSidechain`/`resolveAutoName`/`resolvePreview` read the correct transcript file) and reported as the session's `workingDirectory`, so downstream `getSessionMessages` resolves the right bucket. The decoded bucket path re-encodes back to the same directory name (encode/decode round-trips for `[A-Za-z0-9-]` names).
- **Dedupe + sort/limit preserved** — the union is deduped by session id (keeping the newest mtime — guards a lingering enter/exit copy so there's no double-listing), re-sorted mtime-descending, and the top-N `limit` enrichment is applied across the whole merged set.
- **Attribution unchanged as the gate** — the attribution index keys on session id, so worktree-bucket sessions map to the owning agent, and an over-included bucket (e.g. a lossy-encoding false positive, issue #148) contributes nothing spurious.
- **Perf** — per-bucket listings reuse the existing mtime-cache-backed `listSessionFiles`; the one extra cost is a single `readdir` of `~/.claude/projects/` per call (same as `getAllSessions` already does).
- **Docker path unchanged** — Docker agents still scan the single flat host `docker-sessions/` dir; descendant buckets are not scanned for them.

Per the issue's explicit constraint, this does **not** pin the resumed session's cwd back to the checkout to keep the bucket stable — it follows the SDK's documented model (Claude Code intentionally returns a resumed session to its worktree) rather than fighting it.

## Tests

Six new cases under `getAgentSessions > worktree-aware discovery`:
- lists a session that relocated into a native worktree bucket (alongside the checkout bucket)
- lists a worktree-only session exactly once (no duplicate; reports the worktree path; resumable)
- sorts across the unioned buckets and honours the top-N `limit`
- does not union an unrelated project's bucket
- still gates worktree-bucket sessions through attribution (different-agent session excluded)
- does not scan worktree buckets for Docker agents

Existing single-bucket behaviour is unregressed.

## Verification

- `pnpm --filter @herdctl/core typecheck` — pass
- `pnpm --filter @herdctl/core build` — pass
- `pnpm --filter @herdctl/core test` — **3406 pass / 29 skipped**, 78 in `session-discovery.test.ts`. The one failure (`directory.test.ts > throws StateDirectoryCreateError when parent directory is not writable`) is a **pre-existing, environment-only** artifact: the test `chmod 0o444`s a parent then expects a write to reject, which uid 0 (root, the CI/dev-box user) bypasses. It is unrelated to this change (touches `directory.ts`, not session discovery).
- Changeset added (`@herdctl/core`, **minor**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session discovery for projects using Git worktrees.
  * Sessions from relevant worktree directories now appear alongside primary project sessions.
  * Results are deduplicated, sorted by most recent activity, and limited consistently across all discovered sessions.
  * Unrelated project sessions remain excluded, and Docker session behavior is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->