### PR TITLE
fix(core): guard openChatSession resume against a still-live session (#403)

### DIFF
--- a/.changeset/soft-lions-attack.md
+++ b/.changeset/soft-lions-attack.md
@@ -1,0 +1,9 @@
+---
+"@herdctl/core": minor
+---
+
+Fix double-resume interrupt class: `openChatSession` no longer spawns a second `claude` for a session that already has a live subprocess (edspencer/herdctl#403).
+
+The `SessionReaper` deliberately keeps a session's subprocess alive across the turn boundary while background work runs (keepAlive) or during the ~15s re-invocation grace. Resuming that same session id in that window launched a competing `claude`, and the SDK resolved the collision by interrupting the in-flight turn (`[Request interrupted by user]`) — biting every downstream resume path (keeper auto-recovery, manual Continue, queued-message drain, and any unguarded wake).
+
+`openChatSession` now consults `SessionReaper.isSessionLive(id)` before spawning — the same guard the wake registry already applied — and defers a real (non-fork) resume until the session is reaped, then spawns exactly as a normal fresh resume would. A bounded ceiling (`ChatSessionOptions.resumeDeferTimeoutMs`, default 5 min) keeps a leaked/never-reaped session from hanging the caller. Fresh (non-resume) sessions and the already-guarded wake path are unaffected. Adds `SessionReaper.whenSessionReaped(sessionId)`.

--- a/packages/core/src/fleet-manager/__tests__/open-chat-session-resume-collision.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/open-chat-session-resume-collision.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the #403 resume-collision guard in FleetManager.openChatSession():
+ *
+ *   The SessionReaper deliberately keeps a session's `claude` subprocess alive
+ *   across the turn boundary while it holds background work (keepAlive) or during
+ *   the re-invocation grace. A resume issued in that window must NOT spawn a
+ *   second `claude` on the same session id — two processes resuming one session
+ *   collide and the SDK interrupts the in-flight turn. openChatSession therefore
+ *   defers the resume until the reaper reaps the session, then spawns exactly
+ *   once. A fresh (non-resume) session is never deferred.
+ *
+ * The Claude SDK's `query` is mocked so no real subprocess is spawned; asserting
+ * how many times it was called is how we observe "did/didn't spawn".
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import type { RuntimeSession } from "../../runner/runtime/interface.js";
+import type { SessionLifecycleSignal } from "../../session/types.js";
+import { FleetManager } from "../fleet-manager.js";
+
+const silentLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+const tick = () => new Promise((r) => setTimeout(r, 10));
+
+/** A background task, so a turn_end carrying it decides `keepAlive`. */
+const TASK = { id: "t1", type: "shell", status: "running", description: "server" };
+
+/**
+ * A fake managed RuntimeSession for the reaper to hold — only the members the
+ * reaper touches (close) need to behave; the rest are inert.
+ */
+function fakeManagedSession(): RuntimeSession {
+  async function* empty(): AsyncGenerator<never> {}
+  return {
+    messages: empty(),
+    send: vi.fn().mockResolvedValue(undefined),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    listCommands: vi.fn().mockResolvedValue([]),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function signal(overrides: Partial<SessionLifecycleSignal> = {}): SessionLifecycleSignal {
+  return {
+    kind: "turn_end",
+    sessionId: "sess-live",
+    sessionCrons: [],
+    backgroundTasks: [],
+    ...overrides,
+  };
+}
+
+/**
+ * A fake SDK Query for the resumed session that openChatSession returns. Only
+ * the members openSession() / RuntimeSession.close() touch are provided.
+ */
+function fakeChatQuery() {
+  const returnSpy = vi.fn().mockResolvedValue(undefined);
+  const q = {
+    [Symbol.asyncIterator]: async function* () {},
+    supportedCommands: vi.fn().mockResolvedValue([]),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    return: returnSpy,
+  };
+  return { q, returnSpy };
+}
+
+describe("FleetManager.openChatSession() — #403 resume collision guard", () => {
+  let tempDir: string;
+  let configDir: string;
+  let stateDir: string;
+  let workDir: string;
+
+  beforeEach(async () => {
+    vi.mocked(query).mockReset();
+    tempDir = await mkdtemp(join(tmpdir(), "fleet-resume-collision-test-"));
+    configDir = join(tempDir, "config");
+    stateDir = join(tempDir, ".herdctl");
+    workDir = join(tempDir, "workspace");
+    await mkdir(configDir, { recursive: true });
+    await mkdir(workDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  async function buildManagerWithAgent() {
+    const yaml = await import("yaml");
+    const agentDir = join(configDir, "agents");
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(
+      join(agentDir, "keeper.yaml"),
+      yaml.stringify({ name: "keeper", working_directory: workDir }),
+    );
+    const configPath = join(configDir, "herdctl.yaml");
+    await writeFile(
+      configPath,
+      yaml.stringify({ version: 1, agents: [{ path: "./agents/keeper.yaml" }] }),
+    );
+    const manager = new FleetManager({
+      configPath,
+      stateDir,
+      checkInterval: 10000,
+      logger: silentLogger(),
+    });
+    await manager.initialize();
+    return manager;
+  }
+
+  it("defers a resume off a still-live session, then spawns exactly once after reap", async () => {
+    const manager = await buildManagerWithAgent();
+    const reaper = manager.getSessionLifecycle()?.reaper;
+    if (!reaper) throw new Error("expected a session-lifecycle reaper");
+
+    // Make sess-live live per the reaper: turn ends with a background task → keepAlive.
+    const managed = reaper.manage(fakeManagedSession(), "keeper");
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+    expect(reaper.isSessionLive("sess-live")).toBe(true);
+
+    const { q } = fakeChatQuery();
+    vi.mocked(query).mockReturnValue(q as never);
+
+    // Resume the live session — the guard must defer, spawning no second `claude`.
+    const opening = manager.openChatSession("keeper", { resume: "sess-live" });
+    await tick();
+    expect(vi.mocked(query)).not.toHaveBeenCalled();
+
+    // The reaper releases the session (its turn goes idle, no background work).
+    await managed.handleSignal(signal({ backgroundTasks: [] }));
+    expect(reaper.isSessionLive("sess-live")).toBe(false);
+
+    // The deferred resume now proceeds — exactly one spawn.
+    const session = await opening;
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(1);
+
+    await session.close();
+    await manager.stop();
+  });
+
+  it("does not defer a fresh (non-resume) session: spawns immediately even while another session is live", async () => {
+    const manager = await buildManagerWithAgent();
+    const reaper = manager.getSessionLifecycle()?.reaper;
+    if (!reaper) throw new Error("expected a session-lifecycle reaper");
+
+    // Some unrelated session is live; a brand-new session can't collide with it.
+    const managed = reaper.manage(fakeManagedSession(), "keeper");
+    await managed.handleSignal(signal({ sessionId: "sess-other", backgroundTasks: [TASK] }));
+    expect(reaper.isSessionLive("sess-other")).toBe(true);
+
+    const { q } = fakeChatQuery();
+    vi.mocked(query).mockReturnValue(q as never);
+
+    // resume: null → explicitly fresh, no fallback lookup, no deferral.
+    const session = await manager.openChatSession("keeper", { resume: null });
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(1);
+
+    await session.close();
+    await managed.handleSignal(signal({ sessionId: "sess-other", backgroundTasks: [] }));
+    await manager.stop();
+  });
+
+  it("spawns anyway once the defer ceiling elapses for a never-reaped session", async () => {
+    const manager = await buildManagerWithAgent();
+    const reaper = manager.getSessionLifecycle()?.reaper;
+    if (!reaper) throw new Error("expected a session-lifecycle reaper");
+
+    // Keep the session live and never reap it.
+    const managed = reaper.manage(fakeManagedSession(), "keeper");
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+    expect(reaper.isSessionLive("sess-live")).toBe(true);
+
+    const { q } = fakeChatQuery();
+    vi.mocked(query).mockReturnValue(q as never);
+
+    // A short ceiling: the resume waits, the session stays live, then spawns anyway.
+    const session = await manager.openChatSession("keeper", {
+      resume: "sess-live",
+      resumeDeferTimeoutMs: 30,
+    });
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(1);
+    expect(reaper.isSessionLive("sess-live")).toBe(true);
+
+    await session.close();
+    await managed.handleSignal(signal({ backgroundTasks: [] }));
+    await manager.stop();
+  });
+});

--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -18,7 +18,7 @@ import {
   SDKRuntime,
   type SlashCommand,
 } from "../runner/index.js";
-import type { ManagedSession, SessionLifecycleSignal } from "../session/index.js";
+import type { ManagedSession, SessionLifecycleSignal, SessionReaper } from "../session/index.js";
 import { createJob, getJob, getSessionInfo, readJobOutputAll, updateJob } from "../state/index.js";
 import type { JobMetadata } from "../state/schemas/job-metadata.js";
 import type { FleetManagerContext } from "./context.js";
@@ -37,11 +37,22 @@ import { buildJobOutputPayload } from "./job-output-mapper.js";
 import type {
   CancelJobResult,
   ChatSessionOptions,
+  FleetManagerLogger,
   ForkJobResult,
   JobModifications,
   TriggerOptions,
   TriggerResult,
 } from "./types.js";
+
+/**
+ * Default ceiling for {@link JobControl.deferResumeUntilReaped}: how long a
+ * resume waits for a still-live session to be reaped before spawning anyway.
+ * Overridable per call via {@link ChatSessionOptions.resumeDeferTimeoutMs}.
+ * Generous enough to outlast normal background work (the reaper's re-invocation
+ * grace is ~15s, background tasks can run longer) yet bounded so a leaked /
+ * never-reaped session can't hang the caller indefinitely (edspencer/herdctl#403).
+ */
+const DEFAULT_RESUME_DEFER_TIMEOUT_MS = 5 * 60_000;
 
 // =============================================================================
 // JobControl Class
@@ -392,6 +403,30 @@ export class JobControl {
       throw new StreamingSessionUnsupportedError(agentName, { runtime: "docker" });
     }
 
+    // #403 guard: never spawn a second `claude` for a session id that already
+    // has a live subprocess. The SessionReaper deliberately keeps a subprocess
+    // alive across the turn boundary while background work runs (keepAlive) or
+    // during the ~15s re-invocation grace (session-reaper.ts); resuming that same
+    // id in that window launches a competing `claude`, and the SDK resolves the
+    // collision by interrupting the in-flight turn ([Request interrupted by
+    // user]). The wake registry already skips live sessions before firing
+    // (wake-registry.ts) — openChatSession was the one resume path missing the
+    // equivalent guard. So when a real resume targets a still-live session, defer
+    // it until the reaper reaps that session (idle), then spawn exactly as a
+    // normal fresh resume would. A fresh session (no `sessionId`) can't collide
+    // and is unaffected; the wake path never reaches here with a live id (it
+    // pre-filters), so there is no double-guard deadlock.
+    const lifecycleManager = this.ctx.getSessionLifecycle?.() ?? undefined;
+    if (sessionId && lifecycleManager?.reaper.isSessionLive(sessionId)) {
+      await this.deferResumeUntilReaped(
+        lifecycleManager.reaper,
+        sessionId,
+        agentName,
+        options?.resumeDeferTimeoutMs,
+        logger,
+      );
+    }
+
     const runtime = new SDKRuntime();
     logger.info(`Opening streaming chat session for ${agentName} (sdk runtime)`);
 
@@ -400,7 +435,7 @@ export class JobControl {
     // created after the session (it needs the session to close it), so signals
     // are forwarded through a late-bound reference — safe because the first
     // signal only arrives at the first turn's end, well after `manage()` runs.
-    const lifecycle = options?.manageLifecycle ? this.ctx.getSessionLifecycle?.() : undefined;
+    const lifecycle = options?.manageLifecycle ? lifecycleManager : undefined;
     let managed: ManagedSession | undefined;
     const onLifecycleSignal = lifecycle
       ? (signal: SessionLifecycleSignal) => managed?.handleSignal(signal)
@@ -421,6 +456,46 @@ export class JobControl {
     }
 
     return session;
+  }
+
+  /**
+   * Block a resume until the reaper reports its target session no longer live.
+   *
+   * The reaper holds a subprocess open across the turn boundary while it has
+   * background work or during the re-invocation grace; resuming in that window
+   * would spawn a second `claude` on the same session id and the SDK would
+   * interrupt the in-flight turn (edspencer/herdctl#403). Waiting event-driven on
+   * {@link SessionReaper.whenSessionReaped} lets the resume proceed the instant
+   * the session is reaped (re-checking `isSessionLive` each pass guards the rare
+   * case where a new session re-registers the same id). A ceiling bounds the wait
+   * so a leaked / never-reaped session can't hang the caller forever — on ceiling
+   * we log and spawn anyway, which is no worse than the pre-#403 behavior of
+   * always spawning immediately.
+   */
+  private async deferResumeUntilReaped(
+    reaper: SessionReaper,
+    sessionId: string,
+    agentName: string,
+    timeoutMs: number | undefined,
+    logger: FleetManagerLogger,
+  ): Promise<void> {
+    const ceilingMs = timeoutMs ?? DEFAULT_RESUME_DEFER_TIMEOUT_MS;
+    logger.info(
+      `Session ${sessionId} (${agentName}) still live; deferring resume until reaped (#403)`,
+    );
+    const start = Date.now();
+    while (reaper.isSessionLive(sessionId)) {
+      const remaining = ceilingMs - (Date.now() - start);
+      if (remaining <= 0) {
+        logger.warn(
+          `Session ${sessionId} (${agentName}) still live after ${ceilingMs}ms; ` +
+            `resuming anyway (#403)`,
+        );
+        return;
+      }
+      await raceWithTimeout(reaper.whenSessionReaped(sessionId), remaining);
+    }
+    logger.debug(`Session ${sessionId} (${agentName}) reaped; resuming (#403)`);
   }
 
   /**
@@ -930,6 +1005,29 @@ export class JobControl {
     // If working directory is an object with root property
     return agent.working_directory.root;
   }
+}
+
+/**
+ * Resolve when `promise` settles or after `ms` elapses, whichever comes first.
+ *
+ * The timer is `unref`'d so a pending defer wait never single-handedly holds the
+ * process open, and cleared once either side wins so no stray timer lingers.
+ * Used by {@link JobControl.deferResumeUntilReaped} to bound a resume's wait for
+ * a still-live session (edspencer/herdctl#403).
+ */
+function raceWithTimeout(promise: Promise<void>, ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    timer.unref?.();
+    void promise.then(done, done);
+  });
 }
 
 /**

--- a/packages/core/src/fleet-manager/types.ts
+++ b/packages/core/src/fleet-manager/types.ts
@@ -744,6 +744,21 @@ export interface ChatSessionOptions {
    * legacy behavior (no lifecycle management — the caller owns `close()`).
    */
   manageLifecycle?: boolean;
+
+  /**
+   * Max time (ms) to defer a resume while its target session is still live.
+   *
+   * When resuming a session id that the {@link SessionReaper} is still holding
+   * alive across the turn boundary (background work or the re-invocation grace),
+   * `openChatSession` waits for that subprocess to be reaped before spawning,
+   * rather than launching a second competing `claude` that the SDK would resolve
+   * by interrupting the in-flight turn (edspencer/herdctl#403). This bounds that
+   * wait: if the session has not been reaped within the window, the resume spawns
+   * anyway (no worse than the pre-#403 immediate spawn). Defaults to a few minutes
+   * — long enough to outlast normal background work, short enough that a leaked /
+   * never-reaped session can't hang the caller forever.
+   */
+  resumeDeferTimeoutMs?: number;
 }
 
 /**

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -254,6 +254,50 @@ describe("SessionReaper", () => {
     expect(reaper.isSessionLive("sess-1")).toBe(false);
   });
 
+  // #403: `openChatSession` awaits whenSessionReaped to defer a resume off a
+  // still-live session, so it never spawns a second `claude` on the same id.
+  it("whenSessionReaped resolves immediately for a session that is not live", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    // No session with this id has ever registered → resolves right away.
+    await expect(
+      Promise.race([reaper.whenSessionReaped("sess-1"), tick().then(() => "pending")]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("whenSessionReaped resolves when a live session is later reaped", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const managed = reaper.manage(fakeSession(), "team/agent");
+
+    // Turn ends with background work → kept alive → live per the reaper.
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+    expect(reaper.isSessionLive("sess-1")).toBe(true);
+
+    let resolved = false;
+    const waited = reaper.whenSessionReaped("sess-1").then(() => {
+      resolved = true;
+    });
+    // Still live → the waiter must not have resolved yet.
+    await tick();
+    expect(resolved).toBe(false);
+
+    // Background work drains at a real turn_end → reap → waiter resolves.
+    await managed.handleSignal(signal({ backgroundTasks: [] }));
+    await waited;
+    expect(resolved).toBe(true);
+    expect(reaper.isSessionLive("sess-1")).toBe(false);
+  });
+
+  it("whenSessionReaped resolves when a live session is detached", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const managed = reaper.manage(fakeSession(), "team/agent");
+    await managed.handleSignal(signal({ kind: "activity" }));
+    expect(reaper.isSessionLive("sess-1")).toBe(true);
+
+    const waited = reaper.whenSessionReaped("sess-1");
+    managed.detach();
+    await expect(waited).resolves.toBeUndefined();
+  });
+
   it("ignores signals after the session has been reaped", async () => {
     const registry = fakeRegistry();
     const reaper = new SessionReaper({ registry });

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -91,6 +91,15 @@ export class SessionReaper {
   /** Live managed sessions by resolved session id. */
   private readonly liveById = new Map<string, ManagedSessionImpl>();
 
+  /**
+   * Resolvers waiting for a session id to stop being live, keyed by id. Fed by
+   * {@link whenSessionReaped}, drained by {@link unregisterLive}. Lets a resume
+   * (`openChatSession`) wait for a reaper-kept-alive subprocess to be reaped
+   * before spawning, instead of launching a second competing `claude`
+   * (edspencer/herdctl#403).
+   */
+  private readonly reapWaiters = new Map<string, Array<() => void>>();
+
   constructor(options: SessionReaperOptions) {
     this.registry = options.registry;
     this.logger = options.logger ?? createLogger("session-reaper");
@@ -110,6 +119,26 @@ export class SessionReaper {
     return this.liveById.has(sessionId);
   }
 
+  /**
+   * Resolve once no managed session with this id is live — immediately if it is
+   * already not live, otherwise when the current one is reaped or detached.
+   *
+   * `openChatSession` awaits this to defer a resume off a still-live session so it
+   * never spawns a second `claude` on the same id: two processes resuming one
+   * session collide and the SDK resolves it by interrupting the in-flight turn
+   * (`[Request interrupted by user]`, edspencer/herdctl#403). This mirrors the
+   * `isSessionLive` guard the wake registry already applies before firing — the
+   * one resume path that lacked it.
+   */
+  whenSessionReaped(sessionId: string): Promise<void> {
+    if (!this.liveById.has(sessionId)) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const waiters = this.reapWaiters.get(sessionId) ?? [];
+      waiters.push(resolve);
+      this.reapWaiters.set(sessionId, waiters);
+    });
+  }
+
   // --- internal, called by ManagedSessionImpl ---
 
   registerLive(sessionId: string, managed: ManagedSessionImpl): void {
@@ -118,6 +147,13 @@ export class SessionReaper {
 
   unregisterLive(sessionId: string): void {
     this.liveById.delete(sessionId);
+    // Release any resume deferred on this id (#403). Drain-and-resolve so a
+    // deferred resume proceeds the instant the session is reaped/detached.
+    const waiters = this.reapWaiters.get(sessionId);
+    if (waiters) {
+      this.reapWaiters.delete(sessionId);
+      for (const resolve of waiters) resolve();
+    }
   }
 
   async processSignal(managed: ManagedSessionImpl, signal: SessionLifecycleSignal): Promise<void> {


### PR DESCRIPTION
Closes #403.

## Problem

`openChatSession(resume)` (→ `job-control.ts`) unconditionally spawned a **fresh `claude` subprocess** resuming a session id from disk — even when a subprocess for that session was **still live**. The `SessionReaper` deliberately keeps a subprocess alive across the turn boundary when a turn ended with running background work (keepAlive + the ~15s re-invocation grace, `session-reaper.ts`), during which `reaper.isSessionLive(id) === true`. A resume issued in that window launches a **second** `claude` on the same session id, and the SDK resolves the collision by interrupting the in-flight turn (`[Request interrupted by user]`, emitted by the bundled `claude` binary itself).

This is the fundamental cause of a double-resume-interrupt class biting every downstream resume path: keeper auto-recovery, manual Continue, queued-message drain, and any wake that doesn't already guard.

The **wake scheduler already guards** on `isSessionLive` before firing (`wake-registry.ts:149`). `openChatSession` was the one resume path lacking the equivalent check — the odd one out.

## Fix — defer-and-retry

Before spawning, `openChatSession` now consults `SessionReaper.isSessionLive(id)` and, when the target session is still live, **defers the resume** until the reaper reaps it (idle), then spawns exactly as a normal fresh resume would.

**Why defer rather than attach to the live handle?** A `RuntimeSession`'s `messages` is a single SDK `query` generator — a single-consumer stream, and the original opener may still be iterating it during keepAlive/grace. Handing the same live session back to a second `openChatSession` caller would make two consumers race one generator, and re-`manage()` a session already managed. Deferring preserves the existing contract exactly (a fresh, single-consumer `RuntimeSession`, one subprocess) and directly kills the collision by never spawning the second `claude` while the first is live. Deferring *through* legitimately-running background work is also the desired behavior — you don't want a competing resume interrupting it.

Mechanics:
- New event-driven `SessionReaper.whenSessionReaped(sessionId)` resolves immediately if the id isn't live, else when it's reaped/detached (drained in `unregisterLive`). No polling.
- A bounded ceiling (`ChatSessionOptions.resumeDeferTimeoutMs`, default 5 min) keeps a leaked/never-reaped session from hanging the caller — on ceiling it logs and spawns anyway, which is no worse than the pre-#403 behavior of always spawning immediately.

### No regressions
- **(a) genuinely-idle resume still spawns** — the guard only triggers when `isSessionLive(id)` is true; a fresh session (no `sessionId`) is never deferred.
- **(b) wake path not double-guarded into a deadlock** — `dispatchDue` pre-filters live sessions, so `fire()` reaches `openChatSession` with a non-live id → guard is a no-op. The wake itself doesn't hold the session live, so there's nothing to deadlock on.
- **(c) fork resumes unaffected** — `openChatSession` has no fork/`--fork-session` path, and a fork intentionally starts a new session id that never targets the live one.

## Tests
- `session-reaper.test.ts`: `whenSessionReaped` resolves immediately when not live, on reap, and on detach (existing `isSessionLive`-through-keepAlive+grace coverage kept green).
- New `open-chat-session-resume-collision.test.ts`: with a session live per the reaper, `openChatSession(resume)` spawns **no** second subprocess (mocked SDK `query` asserted uncalled); once the reaper releases (`isSessionLive`→false) the deferred resume proceeds **exactly once**. Plus: a fresh (`resume: null`) session spawns immediately even while another session is live, and the ceiling-elapsed fallback spawns anyway.

Full `@herdctl/core` suite + typecheck + build green (one unrelated pre-existing failure: `state/directory.test.ts`'s read-only-dir test can't fail-to-write under a root test runner; fails identically on pristine `main`).

## Companion
Pairs with the Paddock-side mitigation in edspencer/paddock#397 (RecoveryEngine `isSessionLive` + defer-and-retry, which guards only its own path). Once #403 lands, #397's reaper-liveness guard becomes belt-and-suspenders — this closes the whole class at the source, for every resume path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate subprocesses when resuming a session that is already active.
  - Resumed sessions now wait until the existing session ends before restarting.
  - Added a five-minute maximum wait so resumes proceed even if cleanup does not complete.

- **Tests**
  - Added coverage for active-session collisions, fresh sessions, timeout behavior, and session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->