### PR TITLE
fix(core): defer turn_end reap on resume-with-prompt so a replayed backlog turn can't interrupt the human (#406)

### DIFF
--- a/.changeset/spicy-donkeys-406.md
+++ b/.changeset/spicy-donkeys-406.md
@@ -1,0 +1,20 @@
+---
+"@herdctl/core": minor
+---
+
+Fix a resume self-interrupt that loses the human's turn (#406). On a real
+(non-fork) resume that carries a human prompt, if the prior process died mid-turn
+leaving pending background-task state, the CLI replays that leftover as its own
+turn ahead of the human turn; the `SessionReaper` reaping on the replayed backlog
+turn's `turn_end` closed the session out from under the in-flight human turn,
+producing `[Request interrupted by user]` / `interruptedByShutdown` and dropping
+the human's message.
+
+`SessionReaper.manage` now accepts a `turnEndReapGraceMs` (via
+`ManageSessionOptions`) that defers a `turn_end` reap so an immediately-following
+turn's `activity` can cancel it — mirroring the existing background-drain grace.
+Default `0` preserves current behavior. `openChatSession` arms this grace
+(`DEFAULT_REINVOCATION_GRACE_MS`, 15s) unconditionally on any real resume that
+carries a prompt, so a replayed backlog turn can no longer reap the resumed prompt
+turn; a genuinely final turn still reaps once its grace elapses. Fresh (non-resume)
+sessions and `--fork-session` resumes are unaffected.

--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -12,6 +12,8 @@ import { isAbsolute, join, resolve } from "node:path";
 import type { HookEvent, ResolvedAgent } from "../config/index.js";
 import { type HookContext, HookExecutor } from "../hooks/index.js";
 import {
+  countPendingAsyncQueueEntries,
+  getCliSessionFile,
   JobExecutor,
   RuntimeFactory,
   type RuntimeSession,
@@ -19,6 +21,7 @@ import {
   type SlashCommand,
 } from "../runner/index.js";
 import type { ManagedSession, SessionLifecycleSignal, SessionReaper } from "../session/index.js";
+import { DEFAULT_REINVOCATION_GRACE_MS } from "../session/index.js";
 import { createJob, getJob, getSessionInfo, readJobOutputAll, updateJob } from "../state/index.js";
 import type { JobMetadata } from "../state/schemas/job-metadata.js";
 import type { FleetManagerContext } from "./context.js";
@@ -427,6 +430,50 @@ export class JobControl {
       );
     }
 
+    // #406: a real resume that carries a human prompt can self-interrupt and lose
+    // the human's message. If the prior process died mid-turn leaving pending
+    // background-task state, the CLI replays that leftover as its OWN turn (turn A)
+    // ahead of the caller's queued prompt turn (turn B). Turn A ends with no
+    // background work, so the reaper reaps immediately on its `turn_end` and closes
+    // the session out from under turn B — interrupting it (`[Request interrupted by
+    // user]` / `interruptedByShutdown`) and losing the message. This is NOT the
+    // #403/#404 double-resume class: the session is not reaper-live at resume, so
+    // that guard is correctly skipped; the trigger is the reaper reaping the
+    // *backlog* turn.
+    //
+    // Fix: hand the managed session a `turnEndReapGraceMs` so a `turn_end` reap is
+    // deferred long enough for turn B's `activity` to cancel it (a genuinely final
+    // turn's grace still elapses and reaps). Arm it UNCONDITIONALLY on any real
+    // (non-fork) resume that carries a prompt — `openChatSession` never forks, so
+    // every resume here qualifies. We deliberately do NOT gate on disk detection:
+    // the replay is background-task-state-driven and the queue residue below is
+    // only a correlated side-effect (correlation, not causation), and this failure
+    // has slipped narrow guards repeatedly — so belt-and-suspenders. Cost is ~one
+    // reinvocation-grace window (~15s) of extra RSS per resumed session before it
+    // reaps at true idle. Fresh sessions (no `sessionId`) are unaffected. See #406.
+    let turnEndReapGraceMs = 0;
+    if (sessionId && options?.prompt) {
+      turnEndReapGraceMs = DEFAULT_REINVOCATION_GRACE_MS;
+      // Best-effort telemetry only (NOT a gate): log whether the resumed session
+      // carries the correlated stale async-input residue, so production logs can
+      // confirm the #406 signature. A detection failure never changes behavior.
+      let residue: number | undefined;
+      try {
+        const workspacePath = resolveAgentWorkspacePath(effectiveAgent);
+        residue = await countPendingAsyncQueueEntries(getCliSessionFile(workspacePath, sessionId));
+      } catch (error) {
+        logger.debug(
+          `Pending-async-queue telemetry skipped for ${sessionId}: ${(error as Error).message}`,
+        );
+      }
+      logger.info(
+        `Resuming session ${sessionId} (${agentName}) with a prompt; deferring turn-end ` +
+          `reaps by ${turnEndReapGraceMs}ms so a replayed backlog turn cannot reap the ` +
+          `resumed prompt turn (#406)` +
+          (residue !== undefined ? ` [pending-async-queue residue: ${residue}]` : ""),
+      );
+    }
+
     const runtime = new SDKRuntime();
     logger.info(`Opening streaming chat session for ${agentName} (sdk runtime)`);
 
@@ -452,7 +499,11 @@ export class JobControl {
     });
 
     if (lifecycle) {
-      managed = lifecycle.manage(session, agentName);
+      managed = lifecycle.manage(
+        session,
+        agentName,
+        turnEndReapGraceMs > 0 ? { turnEndReapGraceMs } : undefined,
+      );
     }
 
     return session;
@@ -1047,6 +1098,22 @@ function raceWithTimeout(promise: Promise<void>, ms: number): Promise<void> {
  * @throws {InvalidWorkingDirectoryOverrideError} If the override is provided but
  *   not a non-empty string
  */
+/**
+ * Resolve the absolute workspace path a resumed session's transcript is keyed by.
+ *
+ * Mirrors the cwd the SDK adapter passes to `claude` (`agent.working_directory`,
+ * which may be a string or `{ root }`), falling back to the process cwd when the
+ * agent has none — the same basis Claude Code uses to encode
+ * `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`. Used only for #406's
+ * best-effort residue telemetry, so a wrong guess degrades to "no residue logged".
+ */
+function resolveAgentWorkspacePath(agent: ResolvedAgent): string {
+  const wd = agent.working_directory;
+  if (typeof wd === "string" && wd.trim() !== "") return wd;
+  if (wd && typeof wd === "object" && typeof wd.root === "string") return wd.root;
+  return process.cwd();
+}
+
 function applyWorkingDirectoryOverride(
   agent: ResolvedAgent,
   override: string | undefined,

--- a/packages/core/src/runner/index.ts
+++ b/packages/core/src/runner/index.ts
@@ -46,11 +46,13 @@ export type {
   SlashCommand,
 } from "./runtime/index.js";
 export {
+  countPendingAsyncQueueEntries,
   encodePathForCli,
   getCliSessionDir,
   getCliSessionFile,
   getDockerSessionDir,
   getDockerSessionFile,
+  hasPendingAsyncQueue,
   MessageQueue,
   RuntimeFactory,
   type RuntimeType,

--- a/packages/core/src/runner/runtime/__tests__/pending-async-queue.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/pending-async-queue.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { countPendingAsyncQueueEntries, hasPendingAsyncQueue } from "../pending-async-queue.js";
+
+/**
+ * The detection keys off the CLI's `queue-operation` audit entries — the same
+ * shape the real `dcd8e17e-…` transcript carries: `killed`/`stopped`
+ * `<task-notification>` enqueues that were never dequeued before the process
+ * died. A running enqueue−dequeue tally that ends above zero is the "stale
+ * backlog pending replay" signal the resume seam uses.
+ */
+describe("pending-async-queue detection", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "herdctl-paq-"));
+    file = join(dir, "session.jsonl");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const enq = (content: string) =>
+    JSON.stringify({ type: "queue-operation", operation: "enqueue", content });
+  const deq = () => JSON.stringify({ type: "queue-operation", operation: "dequeue" });
+  const user = (text: string) =>
+    JSON.stringify({ type: "user", message: { role: "user", content: text } });
+
+  it("returns 0 for a missing transcript (fresh session)", async () => {
+    expect(await countPendingAsyncQueueEntries(join(dir, "nope.jsonl"))).toBe(0);
+    expect(await hasPendingAsyncQueue(join(dir, "nope.jsonl"))).toBe(false);
+  });
+
+  it("returns 0 for a balanced queue (clean turn boundary)", async () => {
+    await writeFile(file, [enq("hi"), deq(), user("hi")].join("\n") + "\n");
+    expect(await countPendingAsyncQueueEntries(file)).toBe(0);
+    expect(await hasPendingAsyncQueue(file)).toBe(false);
+  });
+
+  it("counts trailing un-dequeued enqueues (the dcd8e17e signature)", async () => {
+    // One clean turn, then five killed task-notifications enqueued at a turn
+    // boundary and never dequeued before the process died.
+    const lines = [enq("first prompt"), deq(), user("first prompt")];
+    for (let i = 0; i < 5; i++) {
+      lines.push(enq(`<task-notification><status>killed</status> ${i}</task-notification>`));
+    }
+    await writeFile(file, lines.join("\n") + "\n");
+    expect(await countPendingAsyncQueueEntries(file)).toBe(5);
+    expect(await hasPendingAsyncQueue(file)).toBe(true);
+  });
+
+  it("never goes negative when dequeues exceed enqueues", async () => {
+    await writeFile(file, [deq(), deq(), enq("a"), deq()].join("\n") + "\n");
+    expect(await countPendingAsyncQueueEntries(file)).toBe(0);
+  });
+
+  it("tolerates a torn final JSON line", async () => {
+    await writeFile(file, `${enq("a")}\n${enq("b")}\n{"type":"queue-operation","opera`);
+    expect(await countPendingAsyncQueueEntries(file)).toBe(2);
+  });
+
+  it("ignores non-queue-operation lines", async () => {
+    await writeFile(file, [user("hello"), enq("x"), user("world")].join("\n") + "\n");
+    expect(await countPendingAsyncQueueEntries(file)).toBe(1);
+  });
+});

--- a/packages/core/src/runner/runtime/index.ts
+++ b/packages/core/src/runner/runtime/index.ts
@@ -31,4 +31,5 @@ export type {
   SlashCommand,
 } from "./interface.js";
 export { MessageQueue } from "./message-queue.js";
+export { countPendingAsyncQueueEntries, hasPendingAsyncQueue } from "./pending-async-queue.js";
 export { SDKRuntime } from "./sdk-runtime.js";

--- a/packages/core/src/runner/runtime/pending-async-queue.ts
+++ b/packages/core/src/runner/runtime/pending-async-queue.ts
@@ -1,0 +1,87 @@
+/**
+ * Detect a stale, un-drained async-input backlog left in a `claude` CLI session.
+ *
+ * ## The failure this correlates with
+ *
+ * When a keeper backgrounds Task agents and the turn boundary kills them
+ * (herdctl#374), the `claude` CLI enqueues `killed` `<task-notification>` messages
+ * into the session's on-disk async-input queue (`type:"queue-operation"`,
+ * `operation:"enqueue"`). If the process tears down before those enqueues are
+ * dequeued, they persist in the transcript. Later — even days later, when the
+ * session is no longer reaper-live — a human sends a message and `claude --resume`
+ * reattaches. The CLI replays the stale backlog as its own turn AHEAD of the
+ * caller's prompt turn; reaping on the backlog turn's `turn_end` tears the human
+ * turn down mid-flight and the SDK emits `[Request interrupted by user]` — the
+ * human message is lost (herdctl#406).
+ *
+ * Ground-truth signature (real transcript `dcd8e17e-…`): five `enqueue`
+ * `<task-notification>` ops with `<status>killed</status>` that were never
+ * dequeued before the process died. This helper detects exactly that residue.
+ *
+ * ## Telemetry only — NOT the fix, NOT a gate
+ *
+ * The resume seam (`openChatSession`, herdctl#406) arms its turn-end reap grace
+ * **unconditionally** on any real resume that carries a prompt — it does NOT gate
+ * on this detector. The replay is background-task-state-driven; this queue residue
+ * is only a correlated side-effect, so detection is correlation-not-causation and
+ * a future replay could leave no residue. This helper is retained purely to **log**
+ * whether residue was present on a given resume so production logs can correlate
+ * the failure signature; it must never gate reap behavior.
+ *
+ * ## Detection
+ *
+ * The CLI records every queue mutation to the transcript as a `queue-operation`
+ * with `operation:"enqueue"` / `"dequeue"`. A clean turn boundary leaves the queue
+ * empty (every enqueue matched by a dequeue). A running tally over the transcript
+ * (+1 per enqueue, −1 per dequeue, clamped at 0) that ends **above zero** means
+ * inputs were enqueued but never dequeued — a pending backlog that the CLI will
+ * replay on the next resume. The exact count is not important; any positive
+ * residue is the signal.
+ */
+
+import { readFile } from "node:fs/promises";
+
+/**
+ * Compute the net number of un-dequeued async-input `queue-operation` entries in a
+ * CLI session transcript.
+ *
+ * @param sessionFilePath Absolute path to the `<sessionId>.jsonl` transcript.
+ * @returns The pending-queue depth (0 if the file is missing, unreadable, or the
+ *   queue is balanced). Never throws — a detection failure degrades to "no
+ *   backlog" so the resume path is unchanged.
+ */
+export async function countPendingAsyncQueueEntries(sessionFilePath: string): Promise<number> {
+  let raw: string;
+  try {
+    raw = await readFile(sessionFilePath, "utf8");
+  } catch {
+    // Missing / unreadable transcript (e.g. a fresh session that never wrote one):
+    // treat as no backlog. The serialize path is a no-op then.
+    return 0;
+  }
+
+  let depth = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    // Cheap prefilter: only queue-operation lines matter.
+    if (!line.includes('"queue-operation"')) continue;
+    let entry: { type?: string; operation?: string };
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue; // tolerate a torn final line
+    }
+    if (entry.type !== "queue-operation") continue;
+    if (entry.operation === "enqueue") depth += 1;
+    else if (entry.operation === "dequeue") depth = Math.max(0, depth - 1);
+  }
+  return depth;
+}
+
+/**
+ * True when a resumed session carries a stale, un-drained async-input backlog that
+ * the CLI will replay on resume (see {@link countPendingAsyncQueueEntries}).
+ */
+export async function hasPendingAsyncQueue(sessionFilePath: string): Promise<boolean> {
+  return (await countPendingAsyncQueueEntries(sessionFilePath)) > 0;
+}

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -387,4 +387,78 @@ describe("SessionReaper", () => {
     expect(managed.isLive()).toBe(false);
     expect(session.close).toHaveBeenCalledTimes(1);
   });
+
+  // A resume that may replay a stale async-input backlog runs the replayed backlog
+  // as its OWN turn ahead of the caller's queued prompt turn. Reaping on the
+  // backlog turn's turn_end would close the session out from under the queued turn
+  // and interrupt it ([Request interrupted by user], losing the message). A
+  // `turnEndReapGraceMs` defers the turn_end reap so the queued turn's `activity`
+  // can cancel it; a genuinely final turn's grace still elapses and reaps. This
+  // mirrors the real-binary before/after proven for #406.
+  describe("turnEndReapGraceMs (resume-backlog reap grace, #406)", () => {
+    it("reaps a turn_end synchronously when the grace is 0 (default, unchanged)", async () => {
+      const onReap = vi.fn();
+      const reaper = new SessionReaper({ registry: fakeRegistry(), onReap });
+      const session = fakeSession();
+      const managed = reaper.manage(session, "team/agent"); // no grace
+
+      await managed.handleSignal(signal());
+      expect(onReap).toHaveBeenCalledTimes(1);
+      expect(managed.isLive()).toBe(false);
+    });
+
+    it("defers the turn_end reap so a following turn's activity cancels it (protects the queued prompt turn)", async () => {
+      vi.useFakeTimers();
+      const onReap = vi.fn();
+      const reaper = new SessionReaper({ registry: fakeRegistry(), onReap });
+      const session = fakeSession();
+      const managed = reaper.manage(session, "team/agent", { turnEndReapGraceMs: 15_000 });
+
+      // Turn A (the replayed backlog turn) ends with no background work — the reap
+      // is DEFERRED, not synchronous, so the queued prompt turn can still start.
+      await managed.handleSignal(signal());
+      expect(onReap).not.toHaveBeenCalled();
+      expect(managed.isLive()).toBe(true);
+
+      // Turn B (the queued human prompt) starts producing output → `activity`
+      // cancels the pending reap so it is NOT reaped out from under that turn.
+      await managed.handleSignal(signal({ kind: "activity" }));
+      await vi.runAllTimersAsync();
+      expect(onReap).not.toHaveBeenCalled();
+      expect(managed.isLive()).toBe(true);
+      expect(session.close).not.toHaveBeenCalled();
+    });
+
+    it("still reaps a genuinely final turn once its grace elapses with no follow-up", async () => {
+      vi.useFakeTimers();
+      const onReap = vi.fn();
+      const reaper = new SessionReaper({ registry: fakeRegistry(), onReap });
+      const session = fakeSession();
+      const managed = reaper.manage(session, "team/agent", { turnEndReapGraceMs: 15_000 });
+
+      // The last turn ends and nothing follows → the grace elapses → reap.
+      await managed.handleSignal(signal());
+      expect(onReap).not.toHaveBeenCalled();
+      await vi.runAllTimersAsync();
+      expect(onReap).toHaveBeenCalledWith({ agent: "team/agent", sessionId: "sess-1" });
+      expect(managed.isLive()).toBe(false);
+      expect(session.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("reaps the human turn once IT ends (activity cancels the backlog grace, the next turn_end re-arms)", async () => {
+      vi.useFakeTimers();
+      const onReap = vi.fn();
+      const reaper = new SessionReaper({ registry: fakeRegistry(), onReap });
+      const session = fakeSession();
+      const managed = reaper.manage(session, "team/agent", { turnEndReapGraceMs: 15_000 });
+
+      await managed.handleSignal(signal()); // turn A (backlog) end → grace armed
+      await managed.handleSignal(signal({ kind: "activity" })); // turn B starts → cancel
+      await managed.handleSignal(signal()); // turn B (human) end → grace re-armed
+      expect(onReap).not.toHaveBeenCalled();
+      await vi.runAllTimersAsync(); // no further turn → grace elapses → reap
+      expect(onReap).toHaveBeenCalledTimes(1);
+      expect(managed.isLive()).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/session/session-lifecycle-manager.ts
+++ b/packages/core/src/session/session-lifecycle-manager.ts
@@ -14,7 +14,7 @@ import type { InjectedMcpServerDef } from "../runner/types.js";
 import { calculateNextCronTrigger } from "../scheduler/cron.js";
 import { createLogger } from "../utils/logger.js";
 import { FleetStateWakePersistence } from "./fleet-state-wake-persistence.js";
-import { type ManagedSession, SessionReaper } from "./session-reaper.js";
+import { type ManagedSession, type ManageSessionOptions, SessionReaper } from "./session-reaper.js";
 import type { BackgroundTaskSummary, SessionWakeEntry } from "./types.js";
 import { WakeRegistry } from "./wake-registry.js";
 import type { NextRunResolver } from "./wake-store.js";
@@ -153,8 +153,8 @@ export class SessionLifecycleManager {
   }
 
   /** Begin managing a freshly-opened streaming session's lifecycle. */
-  manage(session: RuntimeSession, agent: string): ManagedSession {
-    return this.reaper.manage(session, agent);
+  manage(session: RuntimeSession, agent: string, options?: ManageSessionOptions): ManagedSession {
+    return this.reaper.manage(session, agent, options);
   }
 
   /** Fire every wake now due. Wire as the scheduler's `onTick`. */

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -56,6 +56,26 @@ export interface SessionReaperOptions {
   reinvocationGraceMs?: number;
 }
 
+/** Per-session options for {@link SessionReaper.manage}. */
+export interface ManageSessionOptions {
+  /**
+   * Grace (ms) to defer a `turn_end` reap so an immediately-following turn's
+   * `activity` can cancel it — `0`/undefined reaps a `turn_end` synchronously
+   * (the default, unchanged behavior).
+   *
+   * Set on a resume that carries a human prompt: if the prior process died
+   * mid-turn leaving pending background-task state, the CLI replays that leftover
+   * as its OWN turn (turn A) BEFORE the caller's queued prompt turn (turn B).
+   * Turn A ends with no background work, so an immediate reap on its `turn_end`
+   * closes the session out from under turn B — interrupting it (`[Request
+   * interrupted by user]` / `interruptedByShutdown`) and losing the human's
+   * message. Deferring the reap lets turn B's `activity` cancel it so B runs to
+   * completion; a genuinely final turn's grace still elapses and reaps. Mirrors
+   * the background-task-drain grace (#368). See edspencer/herdctl#406.
+   */
+  turnEndReapGraceMs?: number;
+}
+
 /** A handle to a session the reaper is managing. */
 export interface ManagedSession {
   /**
@@ -109,8 +129,8 @@ export class SessionReaper {
   }
 
   /** Begin managing a session's lifecycle. */
-  manage(session: RuntimeSession, agent: string): ManagedSession {
-    const managed = new ManagedSessionImpl(session, agent, this);
+  manage(session: RuntimeSession, agent: string, options?: ManageSessionOptions): ManagedSession {
+    const managed = new ManagedSessionImpl(session, agent, this, options?.turnEndReapGraceMs ?? 0);
     return managed;
   }
 
@@ -224,6 +244,25 @@ export class SessionReaper {
       return;
     }
 
+    // A resume flagged with a turn-end reap grace may replay a stale pending
+    // background-task backlog as its own turn (turn A) ahead of the caller's
+    // queued prompt turn (turn B); reaping on turn A's `turn_end` closes the
+    // session out from under turn B and interrupts it (`[Request interrupted by
+    // user]`, losing the human message). Defer via a grace that turn B's
+    // `activity` cancels — so B runs to completion — while a genuinely final turn's
+    // grace still elapses and reaps. Mirrors the background-task-drain grace
+    // (#368). See edspencer/herdctl#406.
+    if (managed.turnEndReapGraceMs > 0) {
+      this.logger.debug(
+        `Deferring turn_end reap of session ${signal.sessionId} (${managed.agent}) by ` +
+          `${managed.turnEndReapGraceMs}ms; an incoming turn's activity cancels it`,
+      );
+      managed.armPendingReap(managed.turnEndReapGraceMs, () =>
+        this.reap(managed, signal.sessionId),
+      );
+      return;
+    }
+
     this.reap(managed, signal.sessionId);
   }
 
@@ -253,6 +292,11 @@ export class SessionReaper {
  */
 class ManagedSessionImpl implements ManagedSession {
   readonly agent: string;
+  /**
+   * Grace (ms) to defer a `turn_end` reap so a following turn's `activity` can
+   * cancel it; `0` reaps synchronously. See {@link ManageSessionOptions}.
+   */
+  readonly turnEndReapGraceMs: number;
   private readonly session: RuntimeSession;
   private readonly reaper: SessionReaper;
   private resolvedSessionId: string | undefined;
@@ -263,10 +307,16 @@ class ManagedSessionImpl implements ManagedSession {
   /** A deferred reap armed when the background-task set drained to empty (#368). */
   private pendingReapTimer: ReturnType<typeof setTimeout> | undefined;
 
-  constructor(session: RuntimeSession, agent: string, reaper: SessionReaper) {
+  constructor(
+    session: RuntimeSession,
+    agent: string,
+    reaper: SessionReaper,
+    turnEndReapGraceMs = 0,
+  ) {
     this.session = session;
     this.agent = agent;
     this.reaper = reaper;
+    this.turnEndReapGraceMs = turnEndReapGraceMs;
   }
 
   handleSignal(signal: SessionLifecycleSignal): Promise<void> {


### PR DESCRIPTION
Closes #406.

## The bug

In session drive-mode, a **real (non-fork) resume that carries a human prompt** can
self-interrupt and **lose the human's message**. If the prior process died mid-turn
leaving pending background-task state, the CLI replays that leftover as its **own
turn (turn A)** ahead of the caller's queued prompt **turn B**. Turn A ends with no
background work, so `SessionReaper` reaps **immediately** on its `turn_end`
(`processSignal → reap → scheduleClose → session.close()`), and `close()` aborts the
in-flight human turn — the transcript gets `[Request interrupted by user]` /
`interruptedByShutdown: true` and the human's message is dropped.

This is **not** the #403/#404 double-resume class: the session is **not** reaper-live
at resume, so #404's `isSessionLive` guard is correctly skipped. The trigger is the
reaper reaping the *backlog* turn.

## The fix — reaper grace on `turn_end` (mirrors the #368 background-drain grace)

- **`session/session-reaper.ts`** — add `ManageSessionOptions.turnEndReapGraceMs`. On
  a `turn_end` with no background work, if set, `armPendingReap(grace, …)` instead of
  reaping synchronously; an incoming turn's `activity` cancels the pending reap.
  Default `0` = today's behavior, unchanged.
- **`session/session-lifecycle-manager.ts`** — thread the option through `manage()`.
- **`fleet-manager/job-control.ts` `openChatSession`** — arm the grace
  (`DEFAULT_REINVOCATION_GRACE_MS`, 15s) on a real resume that carries a prompt, so a
  replayed backlog turn can no longer reap the resumed prompt turn. A genuinely final
  turn still reaps once its grace elapses (with an arriving turn's `activity`
  cancelling it). Fresh (non-resume) sessions and `--fork-session` resumes are
  unaffected.

### Design decision: the grace is armed **unconditionally** on resume-with-prompt

Per #406's open-decision section, the grace is armed on **any** real (non-fork)
resume that carries a `sessionId` + prompt, **not gated on disk detection**. The
replay is background-task-state-driven; the on-disk async-input queue residue is only
a *correlated side-effect* (correlation, not causation), so a future replay could
leave no residue. Since this failure has slipped narrow guards repeatedly, the
belt-and-suspenders is worth the cost: ~one reinvocation-grace window (~15s) of extra
resident memory per resumed session before it reaps at true idle.

A `hasPendingAsyncQueue()` / `countPendingAsyncQueueEntries()` detector (net
enqueue−dequeue depth of the CLI async-input queue) is included **as telemetry only**
— logged on resume so production logs can correlate the failure signature. It never
gates reap behavior.

## Merge gate — real-binary before/after on the BUILT artifact

Evidence is **not** "green unit tests." A harness drives the **real deployed bundled
`claude` binary (2.1.216)** through the **compiled `dist/` `SessionReaper` +
`SDKRuntime`** (not ts-source, not a fake claude), against a real OAuth session,
outside the sanitized test env. Turn A (the pending backlog `<task-notification>`) is
injected on-wire with the exact turn structure + reaper signals a real replay
produces (real CLI replay of the backlog-ahead-of-human ordering is timing-flaky —
see the honest note below); turn B is a real human command whose output is verifiable.
The authoritative signature is read from the **on-disk transcript** (the CLI writes
the `[Request interrupted by user]` user turn there even when the SDK consumer stream
ends before yielding it).

**BEFORE (grace = 0, current behavior)** — the reaper reaps on turn A's `turn_end`
and `close()` aborts the human turn. Transcript tail:

```
system
user "Run this exact command and report only its out…"   ← human turn B
assistant [tool_use]
user "\"HUMAN_ANSWER_7f3\""
last-prompt
mode
user <interruptedByShutdown> "[Request interrupted by user]"   ← the signature
=== GRACE=0 | TRANSCRIPT interrupt=1 sawHumanTurn=true | STREAM humanAnswered=false ===
```

Deterministic across repeated runs: `TRANSCRIPT interrupt=1` every time — the exact
`interruptedByShutdown` / `[Request interrupted by user]` signature, human turn torn
down.

**AFTER (grace = 15000, the fix)** — turn A's `turn_end` arms the grace; turn B's
`activity` cancels it; the human turn runs to completion (`RESULT #2 success`); the
session is reaped at true idle ~15s later (grace elapsed, no follow-up turn), no hang.
Transcript tail:

```
system
user "Run this exact command and report only its out…"   ← human turn B
assistant [tool_use]
user "\"HUMAN_ANSWER_7f3\""
assistant "HUMAN_ANSWER_7f3"                              ← human answered
last-prompt
mode
=== GRACE=15000 | TRANSCRIPT interrupt=0 humanExecuted=true sawHumanTurn=true | STREAM humanAnswered=true ===
```

Deterministic across repeated runs: `TRANSCRIPT interrupt=0`, human answered exactly
once, reaped at true idle.

### Fully-real anchor (honest)

Alongside the deterministic injection I also ran fully-real end-to-end replays: a real
background task killed mid-turn leaves un-drained backlog on disk (the shipped
detector reports residue depth 1–2), then the session is resumed with the human as the
initial prompt through the same compiled reaper + runtime — nothing injected. These
confirm faithfulness on three points: **real on-disk residue**, the real `RESULT #1`
no-op resume-ack, and a real reaper **reap-on-`turn_end`**. With the grace on, the
human turn completes and the session reaps at true idle ~15s later (no regression).

### Natural reproduction at production-like residue depth (~5) — attempted, did NOT trigger

To close the gap honestly I pushed the fully-natural path to production-like residue
depth and tried to make the CLI **spontaneously** replay the backlog as a turn ahead
of the human (no injection), on the real 2.1.216 binary through the compiled reaper +
runtime:

- Two backlog mechanisms: (a) many slow `run_in_background` **bash** tasks whose
  completion notifications enqueue un-dequeued (measured residue depth **1, 2, 6**);
  (b) **5 orphaned background Task agents** killed at the boundary — the exact
  production `<status>killed</status>` mechanism (#374) — measured residue depth
  **2, 3, 4**.
- Two resume orderings: human as the initial resume prompt, and no-prompt resume then
  human via `send()` a few seconds later.

**Result: the natural interrupt did NOT reproduce in any trial** (`TRANSCRIPT
interrupt=0` every time, human turn completed). Root cause, observed directly from the
lifecycle-signal trace: at 2.1.216 the CLI delivers the pending backlog **without a
separate turn boundary** — either as a no-op resume-ack (which emits **no** Stop hook /
`turn_end`) or by **coalescing** the backlog notifications *into the same single turn
as the human*. There is exactly **one** `turn_end`, so the reaper reaps **once, after
the human already completed** — it never gets the chance to reap *between* a backlog
turn and the human turn, which is the precise interrupt trigger.

**Honest read:** the specific state where the backlog gets its **own** `turn_end`
ahead of the human (which production transcript `dcd8e17e` exhibited at depth ~5) is
genuinely non-deterministic / version-or-state-dependent and **could not be provoked
on demand** here, even at matching residue depth. This is itself a finding about how
rare/timing-dependent the real trigger is, and is consistent with #406's "real CLI
replay is timing-flaky" note and why prior narrow fixes slipped. The **deterministic
injection harness** — which supplies exactly that turn structure + reaper signals and
reproduces the real `[Request interrupted by user]` transcript signature reliably —
therefore stands as the regression oracle. The fix's mechanism is unconditional and
independent of whether the backlog arrives as its own turn: any real resume-with-prompt
gets the grace, so a backlog turn that *does* get its own `turn_end` can no longer reap
the resumed prompt turn.

## Tests & changeset

- New unit tests: 4 for `turnEndReapGraceMs` grace behavior (synchronous reap when
  `0`; deferred + activity-cancelled; final-turn grace-elapsed reap; re-arm after the
  human turn) and 6 for the async-queue detector.
- Full `@herdctl/core` suite green **except** the one pre-existing, unrelated
  `state/directory.test.ts` case that asserts a non-writable-parent failure — it
  passes as non-root but root bypasses the `chmod 0o444` check. Untouched by this PR.
- Changeset added (`@herdctl/core`, minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
