### PR TITLE
fix(core): retire durable session wakes on CronDelete (#409)

### DIFF
--- a/.changeset/fix-409-crondelete-wake-retire.md
+++ b/.changeset/fix-409-crondelete-wake-retire.md
@@ -1,0 +1,21 @@
+---
+"@herdctl/core": patch
+---
+
+Retire durable session wakes when the agent runs `CronDelete` (#409).
+
+A recurring session wake (`CronCreate` / `/loop` / `ScheduleWakeup`) captured
+into herdctl's durable wake set could not be cancelled from within the session:
+`CronDelete` deleted the harness's in-memory cron (so `CronList` reported no
+jobs) but herdctl kept firing the persisted wake on schedule until the 7-day
+prune. `reconcile` deliberately keeps recurring wakes that are absent from a
+turn's `session_crons` report — on a herdctl-resumed turn the session-only cron
+is never re-armed, so its absence is indistinguishable from a delete — which
+left `WakeRegistry.remove` (the intended "gap 4b" retirement path) with no
+callers.
+
+The session lifecycle now watches for `CronDelete` via a `PostToolUse` hook and
+emits a `cron_deleted` signal carrying the deleted id, which the session-reaper
+routes to `WakeRegistry.remove`. This works on both live and resumed turns
+because it captures the delete explicitly rather than inferring it from the cron
+snapshot.

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -21,10 +21,27 @@ async function* stream(messages: SDKMessage[]): AsyncGenerator<SDKMessage> {
   for (const m of messages) yield m;
 }
 
+function postToolUseInput(overrides: Partial<HookInput> = {}): HookInput {
+  return {
+    hook_event_name: "PostToolUse",
+    session_id: "sess-1",
+    transcript_path: "/tmp/t.jsonl",
+    cwd: "/tmp",
+    tool_name: "CronDelete",
+    tool_input: { id: "c1" },
+    tool_response: { id: "c1" },
+    tool_use_id: "tu-1",
+    ...overrides,
+  } as HookInput;
+}
+
 describe("buildLifecycleHooks", () => {
-  it("registers a Stop matcher only (never SubagentStop)", () => {
+  it("registers a Stop matcher and a PostToolUse matcher (never SubagentStop)", () => {
     const hooks = buildLifecycleHooks(vi.fn());
     expect(hooks?.Stop?.[0].hooks).toHaveLength(1);
+    // The PostToolUse hook watches for CronDelete so a herdctl-owned recurring
+    // wake can be retired (#409).
+    expect(hooks?.PostToolUse?.[0].hooks).toHaveLength(1);
     // SubagentStop must NOT be wired: it fires mid-parent-turn when a synchronous
     // subagent finishes, and treating it as a turn_end reaps the live parent
     // session out from under the keeper. See isMainAgentStop.
@@ -94,6 +111,56 @@ describe("buildLifecycleHooks", () => {
     ).resolves.toEqual({ continue: true });
     // Let the swallowed rejection settle so it can't surface as unhandled.
     await new Promise((r) => setTimeout(r, 5));
+  });
+
+  it("emits a cron_deleted signal carrying the id of a CronDelete tool call", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.PostToolUse![0].hooks[0];
+    const result = await cb(postToolUseInput(), undefined, {
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual({ continue: true });
+    expect(sink).toHaveBeenCalledTimes(1);
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal).toMatchObject({
+      kind: "cron_deleted",
+      sessionId: "sess-1",
+      deletedCronIds: ["c1"],
+    });
+  });
+
+  it("ignores PostToolUse for tools other than CronDelete", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.PostToolUse![0].hooks[0];
+    await cb(postToolUseInput({ tool_name: "Bash", tool_input: { command: "ls" } }), undefined, {
+      signal: new AbortController().signal,
+    });
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it("ignores a CronDelete with a missing or non-string id", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.PostToolUse![0].hooks[0];
+    for (const badInput of [{}, { id: 42 }, { id: "" }, null]) {
+      await cb(postToolUseInput({ tool_input: badInput }), undefined, {
+        signal: new AbortController().signal,
+      });
+    }
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it("the Stop callback ignores PostToolUse and the PostToolUse callback ignores Stop", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const stopCb = hooks!.Stop![0].hooks[0];
+    const postCb = hooks!.PostToolUse![0].hooks[0];
+    await stopCb(postToolUseInput(), undefined, { signal: new AbortController().signal });
+    await postCb(stopInput(), undefined, { signal: new AbortController().signal });
+    expect(sink).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -4,8 +4,8 @@ import type { RuntimeSession } from "../../runner/runtime/interface.js";
 import type { SDKMessage } from "../../runner/types.js";
 import { buildLifecycleHooks, tapLifecycleStream } from "../session-hooks.js";
 import { SessionReaper } from "../session-reaper.js";
-import type { SessionLifecycleSignal } from "../types.js";
-import type { WakeRegistry } from "../wake-registry.js";
+import type { SessionLifecycleSignal, SessionWakeEntry } from "../types.js";
+import { type WakePersistence, WakeRegistry } from "../wake-registry.js";
 
 const tick = () => new Promise((r) => setTimeout(r, 5));
 
@@ -32,8 +32,12 @@ function fakeSession(): RuntimeSession & { close: ReturnType<typeof vi.fn> } {
 }
 
 function fakeRegistry() {
-  return { reconcile: vi.fn().mockResolvedValue(undefined) } as unknown as WakeRegistry & {
+  return {
+    reconcile: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+  } as unknown as WakeRegistry & {
     reconcile: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -280,6 +284,46 @@ describe("SessionReaper", () => {
     expect(session.close).not.toHaveBeenCalled();
   });
 
+  it("retires a wake via the registry on a cron_deleted signal, without reaping", async () => {
+    const registry = fakeRegistry();
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry, onReap });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ kind: "cron_deleted", deletedCronIds: ["c1", "c2"] }));
+
+    expect(registry.remove).toHaveBeenCalledWith("c1");
+    expect(registry.remove).toHaveBeenCalledWith("c2");
+    // A CronDelete is mid-turn work, not a turn boundary — it must not reconcile
+    // or reap the still-live session.
+    expect(registry.reconcile).not.toHaveBeenCalled();
+    expect(onReap).not.toHaveBeenCalled();
+    expect(managed.isLive()).toBe(true);
+    await tick();
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("keeps processing signals when a cron_deleted removal fails", async () => {
+    const registry = {
+      reconcile: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockRejectedValue(new Error("state io error")),
+    } as unknown as WakeRegistry & { remove: ReturnType<typeof vi.fn> };
+    const reaper = new SessionReaper({ registry });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    // The failed removal is swallowed (logged) and must not poison the queue.
+    await managed.handleSignal(signal({ kind: "cron_deleted", deletedCronIds: ["c1"] }));
+    expect(managed.isLive()).toBe(true);
+
+    // A subsequent turn_end is still processed and reaps as usual.
+    await managed.handleSignal(signal());
+    expect(managed.isLive()).toBe(false);
+    await tick();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
   it("exposes the resolved session id once learned", async () => {
     const reaper = new SessionReaper({ registry: fakeRegistry() });
     const managed = reaper.manage(fakeSession(), "team/agent");
@@ -342,5 +386,105 @@ describe("SessionReaper", () => {
     await vi.runAllTimersAsync();
     expect(managed.isLive()).toBe(false);
     expect(session.close).toHaveBeenCalledTimes(1);
+  });
+});
+
+/** In-memory persistence returning independent copies (like a real read). */
+function memoryPersistence(initial: SessionWakeEntry[] = []): WakePersistence & {
+  entries: SessionWakeEntry[];
+} {
+  let store = [...initial];
+  return {
+    get entries() {
+      return store;
+    },
+    load: async () => store.map((e) => ({ ...e })),
+    save: async (entries) => {
+      store = entries.map((e) => ({ ...e }));
+    },
+  };
+}
+
+describe("CronDelete retires a recurring wake end-to-end (#409)", () => {
+  it("recurring wake captured → resumed CronDelete → entry removed → no further fire", async () => {
+    // A real WakeRegistry over in-memory persistence, driven through the real
+    // Stop + PostToolUse hooks and the reaper — the full production path.
+    const NOW = new Date("2026-07-23T12:00:00.000Z");
+    // nextRunAt is in the past so the wake is immediately due once persisted.
+    const resolveNextRun = () => new Date(NOW.getTime() - 1000);
+    const persistence = memoryPersistence();
+    const fire = vi.fn().mockResolvedValue(undefined);
+    const registry = new WakeRegistry({ persistence, resolveNextRun, fire });
+    const reaper = new SessionReaper({ registry });
+
+    // Turn 1 (original): the agent creates a recurring cron; herdctl captures it
+    // at the turn boundary. A fresh managed handle models each turn's process.
+    const managed1 = reaper.manage(fakeSession(), "team/agent");
+    const sink1 = (s: SessionLifecycleSignal) => managed1.handleSignal(s);
+    const stop1 = buildLifecycleHooks(sink1)!.Stop![0].hooks[0];
+    await stop1(
+      {
+        hook_event_name: "Stop",
+        session_id: "sess-1",
+        transcript_path: "/tmp/t.jsonl",
+        cwd: "/tmp",
+        stop_hook_active: false,
+        session_crons: [{ id: "c1", schedule: "*/17 * * * *", recurring: true, prompt: "poll" }],
+        background_tasks: [],
+      } as unknown as HookInput,
+      undefined,
+      { signal: new AbortController().signal },
+    );
+    await tick();
+    expect(persistence.entries.map((e) => e.id)).toEqual(["c1"]);
+
+    // Turn 2 (herdctl-resumed): the session-only cron is NOT re-armed, so its
+    // Stop reports empty crons. The agent calls CronDelete(c1) mid-turn. Without
+    // the PostToolUse wiring the recurring wake would survive (reconcile keeps it
+    // on empty), and keep firing until the 7-day prune — the #409 bug.
+    const managed2 = reaper.manage(fakeSession(), "team/agent");
+    const sink2 = (s: SessionLifecycleSignal) => managed2.handleSignal(s);
+    const built2 = buildLifecycleHooks(sink2)!;
+    const postToolUse2 = built2.PostToolUse![0].hooks[0];
+    const stop2 = built2.Stop![0].hooks[0];
+    await postToolUse2(
+      {
+        hook_event_name: "PostToolUse",
+        session_id: "sess-1",
+        transcript_path: "/tmp/t.jsonl",
+        cwd: "/tmp",
+        tool_name: "CronDelete",
+        tool_input: { id: "c1" },
+        tool_response: { id: "c1" },
+        tool_use_id: "tu-1",
+      } as unknown as HookInput,
+      undefined,
+      { signal: new AbortController().signal },
+    );
+    await tick();
+    // The wake is gone.
+    expect(persistence.entries).toEqual([]);
+
+    // The turn ends with empty crons (resumed turn) — reconcile must not resurrect it.
+    await stop2(
+      {
+        hook_event_name: "Stop",
+        session_id: "sess-1",
+        transcript_path: "/tmp/t.jsonl",
+        cwd: "/tmp",
+        stop_hook_active: false,
+        session_crons: [],
+        background_tasks: [],
+      } as unknown as HookInput,
+      undefined,
+      { signal: new AbortController().signal },
+    );
+    await tick();
+    expect(persistence.entries).toEqual([]);
+
+    // No further fire: a scheduler tick past the old nextRunAt dispatches nothing.
+    const dispatched = await registry.dispatchDue(new Date(NOW.getTime() + 20 * 60_000));
+    expect(dispatched).toEqual([]);
+    expect(fire).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -16,6 +16,7 @@ import type {
   BackgroundTaskSummary,
   HookInput,
   Options,
+  PostToolUseHookInput,
   SessionCronSummary,
   StopHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -61,13 +62,38 @@ function isMainAgentStop(input: HookInput): input is StopHookInput {
   return input.hook_event_name === "Stop";
 }
 
+/** The SDK tool name that retires a session cron by id. */
+const CRON_DELETE_TOOL = "CronDelete";
+
 /**
- * Build the main-agent `Stop` hook that forwards each turn-boundary snapshot to
- * `sink`. The hook awaits the sink so cron capture completes before the turn
- * unwinds, then returns `{ continue: true }` to leave turn flow untouched.
+ * Pull the retired cron id out of a `CronDelete` PostToolUse input, or `null` if
+ * this isn't a well-formed `CronDelete`. `tool_input` is typed `unknown`, so we
+ * narrow structurally: `{ id: string }` (see the SDK's `CronDeleteInput`).
+ */
+function deletedCronId(input: PostToolUseHookInput): string | null {
+  if (input.tool_name !== CRON_DELETE_TOOL) return null;
+  const toolInput = input.tool_input;
+  if (typeof toolInput !== "object" || toolInput === null) return null;
+  const id = (toolInput as { id?: unknown }).id;
+  return typeof id === "string" && id.length > 0 ? id : null;
+}
+
+/**
+ * Build the SDK hooks that feed the session-reaper:
+ * - `Stop` — the main-agent turn boundary carrying the authoritative
+ *   `session_crons`/`background_tasks` snapshot (a `turn_end` signal).
+ * - `PostToolUse` — watches for `CronDelete` and emits a `cron_deleted` signal
+ *   so a herdctl-owned recurring wake can be retired. This is the only reliable
+ *   delete signal: on a herdctl-resumed turn the session-only cron is never
+ *   re-armed, so `reconcile` can't tell a delete from a naturally-empty report
+ *   and deliberately keeps recurring wakes — leaving them un-cancellable until
+ *   the 7-day prune (#409). The delete must therefore be reported explicitly.
+ *
+ * Both hooks return `{ continue: true }` and forward via `emit`, so a sink
+ * failure never rejects the hook (which would disrupt turn flow).
  */
 export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"] {
-  const callback = async (input: HookInput) => {
+  const stopCallback = async (input: HookInput) => {
     if (isMainAgentStop(input)) {
       const sessionCrons: SessionCronSummary[] = input.session_crons ?? [];
       const backgroundTasks: BackgroundTaskSummary[] = input.background_tasks ?? [];
@@ -78,10 +104,27 @@ export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"]
     return { continue: true };
   };
 
-  // Only `Stop` is registered — see {@link isMainAgentStop} for why a
-  // `SubagentStop` must not reach the reaper as a turn boundary.
+  const postToolUseCallback = async (input: HookInput) => {
+    if (input.hook_event_name === "PostToolUse") {
+      const id = deletedCronId(input as PostToolUseHookInput);
+      if (id !== null) {
+        emit(sink, {
+          kind: "cron_deleted",
+          sessionId: input.session_id,
+          sessionCrons: [],
+          backgroundTasks: [],
+          deletedCronIds: [id],
+        });
+      }
+    }
+    return { continue: true };
+  };
+
+  // Only `Stop` is registered for the turn boundary — see {@link isMainAgentStop}
+  // for why a `SubagentStop` must not reach the reaper as one.
   return {
-    Stop: [{ hooks: [callback] }],
+    Stop: [{ hooks: [stopCallback] }],
+    PostToolUse: [{ hooks: [postToolUseCallback] }],
   };
 }
 

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -6,7 +6,10 @@
  * On each signal the reaper (1) reconciles the session's pending crons into the
  * {@link WakeRegistry} so they survive the reap, then (2) applies the one-rule
  * {@link decideReap} policy: keep the process alive while continuous-class
- * background work runs, otherwise close it immediately.
+ * background work runs, otherwise close it immediately. A `cron_deleted` signal
+ * (the agent ran `CronDelete`) instead routes to {@link WakeRegistry.remove} so a
+ * herdctl-owned recurring wake is retired rather than firing until its 7-day
+ * prune (#409).
  *
  * The reaper also answers "is this session live?" for the registry, so a due
  * wake never spawns a second process for a session that is still open (gap 6).
@@ -130,6 +133,25 @@ export class SessionReaper {
     if (signal.kind === "activity") {
       managed.cancelPendingReap();
       managed.setAwaitingTasks(false);
+      return;
+    }
+
+    // The agent ran a `CronDelete` this turn: explicitly retire the herdctl-owned
+    // wake(s) it named, so a recurring wake stops firing. This is the only signal
+    // that can express a delete — `reconcile` can't infer it on a resumed turn
+    // (the session-only cron isn't re-armed, so its absence looks identical to a
+    // delete) and so deliberately keeps recurring wakes (#409). Firing continues
+    // regardless of the surrounding reap decision, so handle it and return.
+    if (signal.kind === "cron_deleted") {
+      for (const id of signal.deletedCronIds ?? []) {
+        try {
+          await this.registry.remove(id);
+        } catch (error) {
+          this.logger.warn(
+            `Failed to retire wake ${id} after CronDelete in session ${signal.sessionId} (${managed.agent}): ${(error as Error).message}`,
+          );
+        }
+      }
       return;
     }
 

--- a/packages/core/src/session/types.ts
+++ b/packages/core/src/session/types.ts
@@ -35,14 +35,25 @@ export interface SessionLifecycleSignal {
    *   (empty) and must not be reconciled.
    * - `activity` — the session started producing output again (a new turn is
    *   underway); carries no snapshot, only clears the idle-waiting state.
+   * - `cron_deleted` — the agent ran a `CronDelete` tool call mid-turn;
+   *   `deletedCronIds` carries the ids it retired. The Stop hook's
+   *   `session_crons` snapshot can't convey this on a herdctl-resumed turn (the
+   *   session-only cron was never re-armed, so its absence is indistinguishable
+   *   from a delete), so the delete must be reported explicitly. See #409.
    */
-  kind: "turn_end" | "background_tasks_changed" | "activity";
+  kind: "turn_end" | "background_tasks_changed" | "activity" | "cron_deleted";
   /** The resolved session id the wakeups/tasks belong to. */
   sessionId: string;
   /** Pending timer-class wakeups. Empty when none are scheduled. */
   sessionCrons: SessionCronSummary[];
   /** In-flight continuous-class background work. Empty when the session is idle. */
   backgroundTasks: BackgroundTaskSummary[];
+  /**
+   * Cron ids the agent explicitly retired via `CronDelete` this turn. Only
+   * populated on a `cron_deleted` signal; the reaper routes each to
+   * {@link WakeRegistry.remove} so a herdctl-owned recurring wake stops firing.
+   */
+  deletedCronIds?: string[];
 }
 
 /**


### PR DESCRIPTION
Closes #409.

## Problem

A **recurring** session wake (`CronCreate` / `/loop` / `ScheduleWakeup`) captured into herdctl's durable `session_wakes` set could not be cancelled from within the session. `CronDelete` deletes the harness's in-memory cron — so the agent's `CronList` reports **no jobs** — but herdctl kept firing the persisted wake on its `nextRunAt` schedule until the 7-day prune, silently re-injecting the prompt every interval.

`reconcileSessionWakes` **deliberately keeps** a recurring wake that's absent from a turn's `session_crons` report: on a herdctl-resumed turn the CLI's session-only cron is never re-armed, so its absence is indistinguishable from a delete, and dropping-on-absence would delete every recurring wake on its first re-fire. The comment there says recurring wakes are instead retired by the 7-day prune **or "an explicit `removeWake` (a detected `CronDelete`)"** — but `WakeRegistry.remove(id)` had **zero callers**. The "gap 4b" detection was scaffolded and never wired.

As the issue notes, `CronDelete` fundamentally **cannot be inferred by `reconcile`** on a resumed turn (no observable present→absent transition), so the delete has to be reported explicitly.

## Fix (gap 4b wiring)

- **`buildLifecycleHooks`** now also registers a **`PostToolUse`** hook that detects `CronDelete` and emits a new **`cron_deleted`** lifecycle signal carrying the deleted id (narrowed structurally from the SDK's `CronDeleteInput` `{ id: string }`).
- **`SessionReaper.processSignal`** handles `cron_deleted` by routing each id to **`WakeRegistry.remove(id)`** — mid-turn work, so it neither reconciles nor reaps the still-live session. A failed removal is logged and swallowed (never poisons the signal queue).
- New `cron_deleted` kind + optional `deletedCronIds` on `SessionLifecycleSignal`.

Capturing the delete from the tool call works on **both live and resumed turns** — strictly better than snapshot inference, which can't distinguish the resumed-empty case at all.

## Tests

- `session-hooks`: emits `cron_deleted` with the id; ignores non-`CronDelete` tools and malformed/empty ids; Stop/PostToolUse callbacks ignore each other's events.
- `session-reaper`: routes `cron_deleted` → `registry.remove` without reconciling/reaping; a failed removal doesn't wedge the queue.
- **End-to-end regression** (the issue's proposed test #3): recurring wake captured at turn boundary → herdctl-resumed turn issues `CronDelete` via the real `PostToolUse` hook → `session_wakes` entry removed → a later `dispatchDue` past the old `nextRunAt` fires nothing.

`pnpm typecheck` clean; `pnpm lint` clean on changed files; all session tests pass (`pnpm test`: 3402 passed — the single unrelated `state/directory.test.ts` failure is a local root-permission artifact and passes under CI's non-root user).

## Notes / follow-ups

- Scope is the concrete `CronDelete(id)` path (proposed fix #1). `ScheduleWakeup({ stop: true })` for `/loop` teardown carries **no id**, so mapping it to a specific durable wake is ambiguous — left as a follow-up.
- Proposed fix #2 (`WakeRegistry.forgetSession` on permanent session close) is a consumer/Paddock-layer concern: herdctl doesn't currently model a "session permanently archived" event distinct from a reap (which must keep wakes), and the method is already public for a consumer to call. Not wired here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deleted recurring schedules are now retired immediately after using `CronDelete`.
  - Prevented deleted schedules from triggering unexpected future wake-ups.
  - Improved handling for both active and resumed sessions.
  - Invalid or incomplete deletion events are safely ignored without interrupting session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->