### PR TITLE
perf(core): index-backed listJobs so filtered/paged listings stop parsing every job record (#415)

### DIFF
--- a/.changeset/lucky-pumas-cheat.md
+++ b/.changeset/lucky-pumas-cheat.md
@@ -1,0 +1,36 @@
+---
+"@herdctl/core": minor
+---
+
+perf(state): make `listJobs` skip work it throws away
+
+`listJobs` read and Zod-validated every `job-*.yaml` sequentially and only then
+applied `filter.agent`, so listing one agent's jobs on a 1,996-record directory
+spent ~1.2s parsing 1,996 records to return 463 of them. `limit` was applied to
+the finished result, so paging saved nothing.
+
+Filtering, sorting and pagination now run against an incremental, mtime-keyed
+index of each job file's `agent`/`status`/`started_at` (the same approach
+`AttributionIndexBuilder` already used for session attribution), and only the
+records actually returned are read and parsed in full. Measured on a 1,996-record,
+46.6 MB jobs directory, warm:
+
+| call | before | after |
+| --- | --- | --- |
+| `listJobs(dir, { agent })` | 1127 ms | 141 ms |
+| `listJobs(dir, { agent, limit: 50 })` | 1139 ms | 31 ms |
+| `listJobs(dir, { limit: 1 })` | 1364 ms | 31 ms |
+| `listJobs(dir)` | 1407 ms | 1094 ms |
+
+The index costs ~2 MB for 1,996 records and is validated against file mtime and
+size on every call, so results stay correct without explicit invalidation. Full
+job records are deliberately not cached — records returned to callers are still
+freshly parsed on every call, exactly as before.
+
+Additions (all backwards compatible):
+
+- `ListJobsFilter` gains `limit` and `offset`. Prefer these over slicing the
+  result: only the returned page is read and parsed.
+- `ListJobsResult` gains `total`, the match count before `limit`/`offset`.
+- `JobManager.getJobs()` pushes `limit`/`offset` down instead of slicing.
+- New `clearJobIndexCache(jobsDir?)` export, for tests and for releasing memory.

--- a/docs/src/content/docs/architecture/job-system.md
+++ b/docs/src/content/docs/architecture/job-system.md
@@ -355,8 +355,25 @@ Available filters:
 | `status` | `JobStatus` | Filter by job status |
 | `startedAfter` | `string` or `Date` | Jobs started on or after this date |
 | `startedBefore` | `string` or `Date` | Jobs started on or before this date |
+| `limit` | `number` | Maximum number of jobs to return |
+| `offset` | `number` | Number of matching jobs to skip before applying `limit` |
 
-Results are sorted by `started_at` in descending order (most recent first). The `errors` count indicates how many job files failed to parse (corrupted or incompatible format).
+Results are sorted by `started_at` in descending order (most recent first). The `errors` count indicates how many job files failed to parse (corrupted or incompatible format). `total` reports how many jobs matched the filter before `limit` and `offset` were applied.
+
+### The Job Index
+
+Job records are dominated by two large free-text fields — on a real instance `prompt` and `summary` account for around 99% of the bytes — so YAML-parsing every record just to decide which ones to return is by far the most expensive part of a listing.
+
+`listJobs()` therefore filters, sorts and paginates against an index of each job file's `agent`, `status` and `started_at` (`packages/core/src/state/job-index.ts`), and reads the full record only for the jobs it is about to return. The index is cached per jobs directory and keyed on each file's mtime and size, so repeated listings only re-parse files that are new or have changed.
+
+Two consequences worth knowing:
+
+- **Pass `limit`/`offset` rather than slicing the result.** Only the returned page is read and parsed, so `listJobs(jobsDir, { limit: 50 })` is dramatically cheaper than `listJobs(jobsDir)` followed by `.slice(0, 50)`. `JobManager.getJobs()` already passes them down.
+- **Full records are never cached.** Every job handed back is freshly parsed, so callers never share mutable objects with the cache. Caching parsed records instead would cost roughly 70× the memory of the index.
+
+The cache needs no explicit invalidation — it revalidates against the filesystem on every call. `clearJobIndexCache(jobsDir?)` exists for tests and for releasing the memory.
+
+This mirrors the incremental `AttributionIndexBuilder` used by session discovery, with one difference: the attribution index is TTL-based, while the job index is validated against file mtime and size.
 
 ## Job Events
 
@@ -441,6 +458,7 @@ packages/core/src/
 │   │   ├── job-metadata.ts    # JobMetadataSchema, generateJobId(), createJobMetadata()
 │   │   └── job-output.ts      # JobOutputMessageSchema, JobOutputInput types
 │   ├── job-metadata.ts        # createJob(), updateJob(), getJob(), listJobs(), deleteJob()
+│   ├── job-index.ts           # refreshJobIndex(), clearJobIndexCache() — mtime-keyed listing index
 │   └── job-output.ts          # appendJobOutput(), readJobOutput(), readJobOutputAll()
 └── fleet-manager/
     ├── job-control.ts         # JobControl class: trigger(), cancelJob(), forkJob()

--- a/docs/src/content/docs/architecture/state-management.md
+++ b/docs/src/content/docs/architecture/state-management.md
@@ -668,6 +668,7 @@ packages/core/src/state/
 ├── directory.ts          # initStateDirectory(), getStateDirectory(), validateStateDirectory()
 ├── fleet-state.ts        # readFleetState(), writeFleetState(), updateAgentState()
 ├── job-metadata.ts       # createJob(), updateJob(), getJob(), listJobs()
+├── job-index.ts          # refreshJobIndex(), clearJobIndexCache() — mtime-keyed index backing listJobs()
 ├── job-output.ts         # appendJobOutput(), readJobOutput()
 ├── session.ts            # getSessionInfo(), updateSessionInfo(), clearSession()
 ├── session-validation.ts # Working directory and runtime type validation

--- a/packages/core/src/fleet-manager/job-manager.ts
+++ b/packages/core/src/fleet-manager/job-manager.ts
@@ -230,32 +230,23 @@ export class JobManager {
    */
   async getJobs(filter: JobFilter = {}): Promise<JobListResult> {
     // Map our filter to the state module's filter
+    // Pagination is pushed down so only the returned page is read and parsed.
     const stateFilter: ListJobsFilter = {
       agent: filter.agent,
       status: filter.status,
       startedAfter: filter.startedAfter,
       startedBefore: filter.startedBefore,
+      limit: filter.limit,
+      offset: filter.offset,
     };
 
     const result = await listJobsFromState(this.jobsDir, stateFilter, {
       logger: this.logger,
     });
 
-    // Apply pagination
-    const total = result.jobs.length;
-    let jobs = result.jobs;
-
-    if (filter.offset !== undefined && filter.offset > 0) {
-      jobs = jobs.slice(filter.offset);
-    }
-
-    if (filter.limit !== undefined && filter.limit > 0) {
-      jobs = jobs.slice(0, filter.limit);
-    }
-
     return {
-      jobs,
-      total,
+      jobs: result.jobs,
+      total: result.total ?? result.jobs.length,
       errors: result.errors,
     };
   }

--- a/packages/core/src/state/__tests__/job-index.test.ts
+++ b/packages/core/src/state/__tests__/job-index.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the incremental job index backing `listJobs`.
+ *
+ * These cover the performance contract (don't re-read files whose contents the
+ * caller will not receive) as well as the correctness properties that contract
+ * must not break: fresh records, correct invalidation, and error accounting.
+ */
+
+import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Count every job-file read that reaches the filesystem layer, so tests can
+// assert on how much work a listing actually performs.
+const reads = vi.hoisted(() => ({ paths: [] as string[] }));
+
+vi.mock("../utils/reads.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils/reads.js")>();
+  return {
+    ...actual,
+    safeReadYaml: (filePath: string, options?: unknown) => {
+      reads.paths.push(filePath);
+      return actual.safeReadYaml(filePath, options as never);
+    },
+  };
+});
+
+const { clearJobIndexCache } = await import("../job-index.js");
+const { createJob, listJobs, updateJob } = await import("../job-metadata.js");
+const { stringify } = await import("yaml");
+
+type JobLogger = import("../job-metadata.js").JobLogger;
+type JobMetadata = import("../schemas/job-metadata.js").JobMetadata;
+
+function createMockLogger(): JobLogger & { warnings: string[] } {
+  const warnings: string[] = [];
+  return { warnings, warn: (message: string) => warnings.push(message) };
+}
+
+/** Names of job files read since the last {@link resetReads}. */
+function jobFilesRead(): string[] {
+  return reads.paths.filter((p) => p.includes("job-")).map((p) => p.split("/").pop() as string);
+}
+
+function resetReads(): void {
+  reads.paths.length = 0;
+}
+
+describe("listJobs job index", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    const baseDir = join(
+      tmpdir(),
+      `herdctl-job-index-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(baseDir, { recursive: true });
+    tempDir = await realpath(baseDir);
+    clearJobIndexCache();
+    resetReads();
+  });
+
+  afterEach(async () => {
+    clearJobIndexCache();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  /** Create `count` jobs for `agent`, each with a distinct started_at. */
+  async function seed(agent: string, count: number, hourOffset = 0): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      const job: JobMetadata = {
+        id: `job-2024-01-15-${agent.slice(0, 1)}${String(i).padStart(5, "0")}`,
+        agent,
+        trigger_type: "manual",
+        status: "completed",
+        started_at: new Date(Date.UTC(2024, 0, 15, hourOffset + i)).toISOString(),
+        schedule: null,
+        exit_reason: null,
+        session_id: null,
+        forked_from: null,
+        finished_at: null,
+        duration_seconds: null,
+        // Large field: the thing we do not want to parse needlessly.
+        prompt: "x".repeat(4096),
+        summary: null,
+        output_file: null,
+      };
+      await writeFile(join(tempDir, `${job.id}.yaml`), stringify(job), "utf-8");
+    }
+  }
+
+  describe("re-reading", () => {
+    it("does not re-read job files that the filter excludes", async () => {
+      await seed("wanted", 2);
+      await seed("unwanted", 18, 12);
+
+      // Cold pass: every file must be read once to build the index.
+      await listJobs(tempDir, { agent: "wanted" });
+      expect(new Set(jobFilesRead()).size).toBe(20);
+
+      // Warm pass: only the two matching records are needed.
+      resetReads();
+      const result = await listJobs(tempDir, { agent: "wanted" });
+
+      expect(result.jobs).toHaveLength(2);
+      expect(result.jobs.every((j) => j.agent === "wanted")).toBe(true);
+      expect(jobFilesRead()).toHaveLength(2);
+      expect(jobFilesRead().every((f) => f.startsWith("job-2024-01-15-w"))).toBe(true);
+    });
+
+    it("does not re-read job files beyond the requested limit", async () => {
+      await seed("agent", 20);
+
+      await listJobs(tempDir);
+      resetReads();
+
+      const result = await listJobs(tempDir, { limit: 3 });
+
+      expect(result.jobs).toHaveLength(3);
+      expect(jobFilesRead()).toHaveLength(3);
+    });
+
+    it("re-reads a job file after it changes", async () => {
+      const job = await createJob(tempDir, { agent: "agent", trigger_type: "manual" });
+      await listJobs(tempDir);
+
+      await updateJob(tempDir, job.id, { status: "completed", summary: "done" });
+
+      const result = await listJobs(tempDir);
+      expect(result.jobs[0].status).toBe("completed");
+      expect(result.jobs[0].summary).toBe("done");
+    });
+
+    it("picks up jobs created after the first listing", async () => {
+      await seed("agent", 2);
+      expect((await listJobs(tempDir)).jobs).toHaveLength(2);
+
+      await createJob(tempDir, { agent: "agent", trigger_type: "manual" });
+
+      expect((await listJobs(tempDir)).jobs).toHaveLength(3);
+    });
+
+    it("forgets jobs whose files have been deleted", async () => {
+      await seed("agent", 3);
+      await listJobs(tempDir);
+
+      await rm(join(tempDir, "job-2024-01-15-a00001.yaml"));
+
+      const result = await listJobs(tempDir);
+      expect(result.jobs).toHaveLength(2);
+      expect(result.errors).toBe(0);
+    });
+
+    it("returns freshly parsed records rather than shared cached objects", async () => {
+      await seed("agent", 2);
+
+      const first = await listJobs(tempDir);
+      const second = await listJobs(tempDir);
+
+      expect(second.jobs[0]).toEqual(first.jobs[0]);
+      expect(second.jobs[0]).not.toBe(first.jobs[0]);
+    });
+  });
+
+  describe("pagination", () => {
+    beforeEach(async () => {
+      await seed("agent", 5);
+    });
+
+    it("applies limit after sorting by started_at descending", async () => {
+      const result = await listJobs(tempDir, { limit: 2 });
+
+      expect(result.jobs.map((j) => j.id)).toEqual([
+        "job-2024-01-15-a00004",
+        "job-2024-01-15-a00003",
+      ]);
+    });
+
+    it("applies offset", async () => {
+      const result = await listJobs(tempDir, { offset: 3 });
+
+      expect(result.jobs.map((j) => j.id)).toEqual([
+        "job-2024-01-15-a00001",
+        "job-2024-01-15-a00000",
+      ]);
+    });
+
+    it("applies limit and offset together", async () => {
+      const result = await listJobs(tempDir, { limit: 2, offset: 1 });
+
+      expect(result.jobs.map((j) => j.id)).toEqual([
+        "job-2024-01-15-a00003",
+        "job-2024-01-15-a00002",
+      ]);
+    });
+
+    it("reports the pre-pagination match count as total", async () => {
+      await seed("other", 2, 12);
+
+      const result = await listJobs(tempDir, { agent: "agent", limit: 1 });
+
+      expect(result.jobs).toHaveLength(1);
+      expect(result.total).toBe(5);
+    });
+
+    it("ignores non-positive limit and offset", async () => {
+      expect((await listJobs(tempDir, { limit: 0 })).jobs).toHaveLength(5);
+      expect((await listJobs(tempDir, { offset: -1 })).jobs).toHaveLength(5);
+    });
+  });
+
+  describe("error accounting", () => {
+    it("keeps counting and reporting corrupt files on cached listings", async () => {
+      await seed("agent", 1);
+      await writeFile(join(tempDir, "job-2024-01-15-corupt.yaml"), "invalid: [yaml", "utf-8");
+
+      const cold = createMockLogger();
+      const coldResult = await listJobs(tempDir, {}, { logger: cold });
+      expect(coldResult.jobs).toHaveLength(1);
+      expect(coldResult.errors).toBe(1);
+      expect(cold.warnings).toHaveLength(1);
+
+      const warm = createMockLogger();
+      const warmResult = await listJobs(tempDir, {}, { logger: warm });
+      expect(warmResult.jobs).toHaveLength(1);
+      expect(warmResult.errors).toBe(1);
+      expect(warm.warnings).toEqual(cold.warnings);
+    });
+
+    it("counts corrupt files even when they cannot match the filter", async () => {
+      await seed("agent", 1);
+      await writeFile(join(tempDir, "job-2024-01-15-corupt.yaml"), "invalid: [yaml", "utf-8");
+
+      const result = await listJobs(tempDir, { agent: "agent", limit: 1 });
+
+      expect(result.jobs).toHaveLength(1);
+      expect(result.errors).toBe(1);
+    });
+
+    it("recovers once a corrupt file is repaired", async () => {
+      await writeFile(join(tempDir, "job-2024-01-15-corupt.yaml"), "invalid: [yaml", "utf-8");
+      expect((await listJobs(tempDir)).errors).toBe(1);
+
+      await seed("agent", 0);
+      const job: JobMetadata = {
+        id: "job-2024-01-15-corupt",
+        agent: "agent",
+        trigger_type: "manual",
+        status: "completed",
+        started_at: "2024-01-15T10:00:00.000Z",
+        schedule: null,
+        exit_reason: null,
+        session_id: null,
+        forked_from: null,
+        finished_at: null,
+        duration_seconds: null,
+        prompt: null,
+        summary: null,
+        output_file: null,
+      };
+      await writeFile(join(tempDir, "job-2024-01-15-corupt.yaml"), stringify(job), "utf-8");
+
+      const result = await listJobs(tempDir);
+      expect(result.errors).toBe(0);
+      expect(result.jobs).toHaveLength(1);
+    });
+  });
+});

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -31,6 +31,7 @@ export {
   type WriteFleetStateOptions,
   writeFleetState,
 } from "./fleet-state.js";
+export { clearJobIndexCache } from "./job-index.js";
 // Re-export job metadata functions
 export {
   createJob,

--- a/packages/core/src/state/job-index.ts
+++ b/packages/core/src/state/job-index.ts
@@ -1,0 +1,299 @@
+/**
+ * Incremental index over the job metadata directory
+ *
+ * `listJobs` needs three cheap facts about every `job-*.yaml` in order to filter,
+ * sort and paginate — `agent`, `status` and `started_at` — but obtaining them the
+ * naive way means YAML-parsing the whole record, and job records are dominated by
+ * two large free-text fields (`prompt` and `summary` are ~99% of the bytes on a
+ * real instance). This module keeps those three facts — `started_at` reduced to
+ * epoch ms — in an mtime-keyed cache, so repeated listings only re-parse files
+ * that are new or have changed, mirroring the approach `AttributionIndexBuilder`
+ * already uses for session attribution.
+ *
+ * Deliberately **not** cached: the full job record. Holding parsed records for a
+ * 2,000-job directory measured at ~142 MB of heap, versus ~2 MB for the index
+ * alone, so full records are always re-read for the (usually small) set of jobs a
+ * caller actually asked for. That also means every record `listJobs` hands out is
+ * freshly parsed, exactly as before — callers never share mutable objects with the
+ * cache.
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { type JobMetadata, JobMetadataSchema, type JobStatus } from "./schemas/job-metadata.js";
+import { safeReadYaml } from "./utils/reads.js";
+
+// =============================================================================
+// Tuning
+// =============================================================================
+
+/**
+ * Maximum number of job files stat-ed / read concurrently.
+ *
+ * Sequential I/O is what makes the cold pass slow; unbounded concurrency risks
+ * exhausting file descriptors on very large directories. 32 captures nearly all
+ * of the available speed-up on the measured instance.
+ */
+const IO_CONCURRENCY = 32;
+
+/**
+ * How many distinct job directories to keep indexes for. A process normally
+ * touches one, but tests and multi-fleet hosts touch several; this bounds the
+ * cache without needing explicit invalidation.
+ */
+const MAX_CACHED_DIRS = 16;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * The subset of a job record `listJobs` can filter and sort on without reading
+ * the record's large text fields.
+ */
+export interface JobIndexRecord {
+  agent: string;
+  status: JobStatus;
+  /** `started_at` pre-parsed to epoch ms, for sorting and date filters */
+  startedAtMs: number;
+}
+
+/** One job file's entry in the index. */
+export interface JobIndexEntry {
+  /** File name within the jobs dir (e.g. `job-2026-01-15-abc123.yaml`) */
+  file: string;
+  /** Indexed fields, or `null` if the file could not be read or validated */
+  record: JobIndexRecord | null;
+  /** Warning to emit for an unreadable/corrupt file (set iff `record` is null) */
+  warning?: string;
+}
+
+/** Result of refreshing the index for one directory. */
+export interface JobIndexRefresh {
+  /** Entries in `readdir` order, so callers inherit its (stable) tie-breaking */
+  entries: JobIndexEntry[];
+  /**
+   * Full records parsed during *this* refresh and worth keeping, keyed by file
+   * name. Lets a caller reuse the parse it just paid for instead of reading the
+   * file a second time.
+   */
+  fresh: Map<string, JobMetadata>;
+}
+
+/** Options for {@link refreshJobIndex}. */
+export interface RefreshJobIndexOptions {
+  /**
+   * Predicate deciding whether a freshly parsed record is worth holding onto in
+   * {@link JobIndexRefresh.fresh}. Records that can't satisfy the caller's filter
+   * are dropped immediately so a cold pass doesn't retain the whole directory.
+   */
+  retain?: (record: JobIndexRecord) => boolean;
+}
+
+interface CachedFile {
+  /** File mtime (epoch ms) when last parsed — the cache-invalidation key */
+  mtimeMs: number;
+  /** File size when last parsed, guarding against same-mtime rewrites */
+  size: number;
+  record: JobIndexRecord | null;
+  warning?: string;
+}
+
+// =============================================================================
+// Cache
+// =============================================================================
+
+/** Per-directory file caches, keyed by resolved jobs dir path. */
+const dirCaches = new Map<string, Map<string, CachedFile>>();
+
+function cacheForDir(jobsDir: string): Map<string, CachedFile> {
+  const key = resolve(jobsDir);
+  const existing = dirCaches.get(key);
+
+  // Re-insert to mark most-recently-used.
+  if (existing) {
+    dirCaches.delete(key);
+    dirCaches.set(key, existing);
+    return existing;
+  }
+
+  const created = new Map<string, CachedFile>();
+  dirCaches.set(key, created);
+
+  while (dirCaches.size > MAX_CACHED_DIRS) {
+    const oldest = dirCaches.keys().next().value;
+    if (oldest === undefined) break;
+    dirCaches.delete(oldest);
+  }
+
+  return created;
+}
+
+/**
+ * Drop cached job index state.
+ *
+ * The index is validated against file mtime and size on every use, so clearing it
+ * is never required for correctness — it exists for tests and for callers that
+ * want to release the memory.
+ *
+ * @param jobsDir - Directory to forget; omit to forget every directory
+ */
+export function clearJobIndexCache(jobsDir?: string): void {
+  if (jobsDir === undefined) {
+    dirCaches.clear();
+    return;
+  }
+  dirCaches.delete(resolve(jobsDir));
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Return a standalone copy of a string.
+ *
+ * The `yaml` parser produces scalars by slicing the whole document text, and V8
+ * represents those as SlicedStrings that keep the entire ~24 KB source alive.
+ * Caching them verbatim measured at 99 MB for 1,996 records versus 2.1 MB for
+ * detached copies, so copy before storing.
+ */
+function detachString(value: string): string {
+  return JSON.parse(JSON.stringify(value)) as string;
+}
+
+/** Map over items with a bounded number of concurrent workers, preserving order. */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = next++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index], index);
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, worker);
+  await Promise.all(workers);
+
+  return results;
+}
+
+/** Is this directory entry a job metadata file? */
+function isJobFile(name: string): boolean {
+  return name.startsWith("job-") && name.endsWith(".yaml");
+}
+
+/** Project a validated job record down to its indexed fields. */
+function toIndexRecord(job: JobMetadata): JobIndexRecord {
+  return {
+    agent: detachString(job.agent),
+    status: job.status,
+    startedAtMs: new Date(job.started_at).getTime(),
+  };
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Refresh (and return) the index for a jobs directory.
+ *
+ * Stats every job file — cheap — and re-reads only files that are new or whose
+ * mtime/size changed. Entries for files that have disappeared are dropped.
+ *
+ * @param jobsDir - Path to the jobs directory
+ * @param options - Refresh options
+ * @returns Index entries in `readdir` order plus any records parsed on this pass
+ * @throws The underlying `readdir` error (including ENOENT) if the directory
+ *   cannot be listed — callers decide how to treat a missing directory
+ */
+export async function refreshJobIndex(
+  jobsDir: string,
+  options: RefreshJobIndexOptions = {},
+): Promise<JobIndexRefresh> {
+  const { retain } = options;
+
+  let jobFiles: string[];
+  try {
+    jobFiles = (await readdir(jobsDir)).filter(isJobFile);
+  } catch (error) {
+    // The directory is gone (or unreadable) — don't keep an index for it.
+    clearJobIndexCache(jobsDir);
+    throw error;
+  }
+
+  const cache = cacheForDir(jobsDir);
+  const present = new Set(jobFiles);
+  for (const cachedFile of cache.keys()) {
+    if (!present.has(cachedFile)) {
+      cache.delete(cachedFile);
+    }
+  }
+
+  const fresh = new Map<string, JobMetadata>();
+
+  const entries = await mapWithConcurrency(
+    jobFiles,
+    IO_CONCURRENCY,
+    async (file): Promise<JobIndexEntry> => {
+      const filePath = join(jobsDir, file);
+
+      let mtimeMs: number;
+      let size: number;
+      try {
+        const stats = await stat(filePath);
+        mtimeMs = stats.mtimeMs;
+        size = stats.size;
+      } catch (error) {
+        // Vanished (or became unreadable) between readdir and stat. Reported as
+        // an unreadable file, which is how the pre-index code surfaced it.
+        cache.delete(file);
+        return {
+          file,
+          record: null,
+          warning: `Failed to read job file ${filePath}: ${(error as Error).message}`,
+        };
+      }
+
+      const cached = cache.get(file);
+      if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
+        return { file, record: cached.record, warning: cached.warning };
+      }
+
+      const result = await safeReadYaml<unknown>(filePath);
+      if (!result.success) {
+        const warning = `Failed to read job file ${filePath}: ${result.error.message}`;
+        cache.set(file, { mtimeMs, size, record: null, warning });
+        return { file, record: null, warning };
+      }
+
+      const parsed = JobMetadataSchema.safeParse(result.data);
+      if (!parsed.success) {
+        const warning = `Corrupted job file ${filePath}: ${parsed.error.message}`;
+        cache.set(file, { mtimeMs, size, record: null, warning });
+        return { file, record: null, warning };
+      }
+
+      const record = toIndexRecord(parsed.data);
+      cache.set(file, { mtimeMs, size, record });
+
+      // Hold the full record only while it might still be wanted, so a cold pass
+      // over a filtered listing doesn't retain the entire directory.
+      if (!retain || retain(record)) {
+        fresh.set(file, parsed.data);
+      }
+
+      return { file, record };
+    },
+  );
+
+  return { entries, fresh };
+}

--- a/packages/core/src/state/job-metadata.ts
+++ b/packages/core/src/state/job-metadata.ts
@@ -5,9 +5,9 @@
  * .herdctl/jobs/job-<id>.yaml
  */
 
-import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { StateFileError } from "./errors.js";
+import { type JobIndexRecord, mapWithConcurrency, refreshJobIndex } from "./job-index.js";
 import {
   type CreateJobOptions,
   createJobMetadata,
@@ -58,6 +58,15 @@ export interface ListJobsFilter {
   startedAfter?: string | Date;
   /** Filter jobs started on or before this date (ISO string or Date) */
   startedBefore?: string | Date;
+  /**
+   * Maximum number of jobs to return, applied after filtering and sorting.
+   *
+   * Prefer this over slicing the result: only the jobs actually returned are
+   * read and parsed in full, so a small page costs a small amount of work.
+   */
+  limit?: number;
+  /** Number of matching jobs to skip before applying `limit` */
+  offset?: number;
 }
 
 /**
@@ -68,11 +77,21 @@ export interface ListJobsResult {
   jobs: JobMetadata[];
   /** Number of jobs that failed to parse */
   errors: number;
+  /**
+   * Number of jobs matching the filter before `limit`/`offset` were applied.
+   *
+   * Always populated by {@link listJobs}; optional so that hand-constructed
+   * results (test doubles, adapters) remain valid.
+   */
+  total?: number;
 }
 
 // =============================================================================
 // Helper Functions
 // =============================================================================
+
+/** Maximum number of job records read concurrently when hydrating a page. */
+const HYDRATE_CONCURRENCY = 32;
 
 /**
  * Get the file path for a job
@@ -285,10 +304,15 @@ export async function getJob(
  * Supports filtering by agent, status, and date range. Returns jobs
  * sorted by started_at in descending order (most recent first).
  *
+ * Filtering, sorting and pagination run against a cached, mtime-keyed index of
+ * each job file's `agent`/`status`/`started_at` (see `job-index.ts`), so only the
+ * records actually returned are read and parsed in full. Passing `limit` is
+ * therefore much cheaper than slicing the result.
+ *
  * @param jobsDir - Path to the jobs directory
  * @param filter - Optional filter criteria
  * @param options - Optional operation options
- * @returns List of matching jobs and count of parse errors
+ * @returns Matching jobs, the pre-pagination match count, and the count of parse errors
  *
  * @example
  * ```typescript
@@ -297,11 +321,12 @@ export async function getJob(
  *   agent: 'my-agent'
  * });
  *
- * // List failed jobs from the last 24 hours
+ * // Most recent 20 failed jobs from the last 24 hours
  * const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
- * const { jobs } = await listJobs('/path/to/.herdctl/jobs', {
+ * const { jobs, total } = await listJobs('/path/to/.herdctl/jobs', {
  *   status: 'failed',
- *   startedAfter: yesterday
+ *   startedAfter: yesterday,
+ *   limit: 20
  * });
  * ```
  */
@@ -312,14 +337,31 @@ export async function listJobs(
 ): Promise<ListJobsResult> {
   const { logger = console } = options;
 
-  // Read directory
-  let files: string[];
+  // Parse date filters once
+  const startedAfter = filter.startedAfter ? toDate(filter.startedAfter).getTime() : undefined;
+  const startedBefore = filter.startedBefore ? toDate(filter.startedBefore).getTime() : undefined;
+
+  const matches = (record: JobIndexRecord): boolean => {
+    if (filter.agent && record.agent !== filter.agent) return false;
+    if (filter.status && record.status !== filter.status) return false;
+    if (startedAfter !== undefined && record.startedAtMs < startedAfter) return false;
+    if (startedBefore !== undefined && record.startedAtMs > startedBefore) return false;
+    return true;
+  };
+
+  // On a cold pass the index refresh parses records anyway, so hold on to the
+  // ones that could be returned instead of reading them twice. When a page was
+  // requested we can't yet tell which records make the page, and holding every
+  // match to keep a handful would defeat the point — re-read the page instead.
+  const retain = filter.limit === undefined ? matches : () => false;
+
+  let index: Awaited<ReturnType<typeof refreshJobIndex>>;
   try {
-    files = await readdir(jobsDir);
+    index = await refreshJobIndex(jobsDir, { retain });
   } catch (error) {
     // Directory doesn't exist - return empty list
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { jobs: [], errors: 0 };
+      return { jobs: [], errors: 0, total: 0 };
     }
     throw new StateFileError(
       `Failed to read jobs directory: ${(error as Error).message}`,
@@ -329,70 +371,82 @@ export async function listJobs(
     );
   }
 
-  // Filter to job YAML files
-  const jobFiles = files.filter((f) => f.startsWith("job-") && f.endsWith(".yaml"));
-
-  const jobs: JobMetadata[] = [];
   let errors = 0;
 
-  // Parse date filters once
-  const startedAfter = filter.startedAfter ? toDate(filter.startedAfter) : undefined;
-  const startedBefore = filter.startedBefore ? toDate(filter.startedBefore) : undefined;
-
-  // Read and filter each job
-  for (const file of jobFiles) {
-    const filePath = join(jobsDir, file);
-    const result = await safeReadYaml<unknown>(filePath);
-
-    if (!result.success) {
-      logger.warn(`Failed to read job file ${filePath}: ${result.error.message}`);
+  // Filter on the index — no large-record parsing needed to decide what to keep.
+  const candidates: { file: string; record: JobIndexRecord }[] = [];
+  for (const entry of index.entries) {
+    if (!entry.record) {
+      logger.warn(entry.warning ?? `Failed to read job file ${join(jobsDir, entry.file)}`);
       errors++;
       continue;
     }
-
-    const parseResult = JobMetadataSchema.safeParse(result.data);
-    if (!parseResult.success) {
-      logger.warn(`Corrupted job file ${filePath}: ${parseResult.error.message}`);
-      errors++;
-      continue;
+    if (matches(entry.record)) {
+      candidates.push({ file: entry.file, record: entry.record });
     }
-
-    const job = parseResult.data;
-
-    // Apply filters
-    if (filter.agent && job.agent !== filter.agent) {
-      continue;
-    }
-
-    if (filter.status && job.status !== filter.status) {
-      continue;
-    }
-
-    if (startedAfter) {
-      const jobDate = new Date(job.started_at);
-      if (jobDate < startedAfter) {
-        continue;
-      }
-    }
-
-    if (startedBefore) {
-      const jobDate = new Date(job.started_at);
-      if (jobDate > startedBefore) {
-        continue;
-      }
-    }
-
-    jobs.push(job);
   }
 
-  // Sort by started_at descending (most recent first)
+  const total = candidates.length;
+
+  // Sort by started_at descending (most recent first). Array.sort is stable, so
+  // equal timestamps keep directory order, as they did when sorting records.
+  candidates.sort((a, b) => b.record.startedAtMs - a.record.startedAtMs);
+
+  const offset = filter.offset !== undefined && filter.offset > 0 ? filter.offset : 0;
+  const end =
+    filter.limit !== undefined && filter.limit > 0 ? offset + filter.limit : candidates.length;
+  const page = candidates.slice(offset, end);
+
+  // Read the full records for this page only, reusing any parse the index refresh
+  // already paid for.
+  const hydrated = await mapWithConcurrency(
+    page,
+    HYDRATE_CONCURRENCY,
+    async ({ file }): Promise<JobMetadata | string> => {
+      const alreadyParsed = index.fresh.get(file);
+      if (alreadyParsed) return alreadyParsed;
+
+      const filePath = join(jobsDir, file);
+      const result = await safeReadYaml<unknown>(filePath);
+      if (!result.success) {
+        return `Failed to read job file ${filePath}: ${result.error.message}`;
+      }
+
+      const parseResult = JobMetadataSchema.safeParse(result.data);
+      if (!parseResult.success) {
+        return `Corrupted job file ${filePath}: ${parseResult.error.message}`;
+      }
+
+      return parseResult.data;
+    },
+  );
+
+  const jobs: JobMetadata[] = [];
+  for (const outcome of hydrated) {
+    // A job file can change between being indexed and being read. Re-checking the
+    // filter against the record we actually return keeps the guarantee that every
+    // returned job satisfies the filter.
+    if (typeof outcome === "string") {
+      logger.warn(outcome);
+      errors++;
+    } else if (
+      matches({
+        agent: outcome.agent,
+        status: outcome.status,
+        startedAtMs: new Date(outcome.started_at).getTime(),
+      })
+    ) {
+      jobs.push(outcome);
+    }
+  }
+
   jobs.sort((a, b) => {
     const dateA = new Date(a.started_at).getTime();
     const dateB = new Date(b.started_at).getTime();
     return dateB - dateA;
   });
 
-  return { jobs, errors };
+  return { jobs, errors, total };
 }
 
 /**


### PR DESCRIPTION
Fixes #415.

## What was actually slow

The issue's measurements pointed at three causes (sequential reads, post-parse
filtering, no cache). Profiling the components on the same 1,996-record /
46.6 MB directory refined that picture, and it changed the design:

| component (1,996 records) | median |
| --- | --- |
| `readdir` + filter | 2.8 ms |
| `stat` every file (concurrent) | 18 ms |
| `readFile` every file (concurrent) | 215 ms |
| **`yaml.parse` every file** | **735 ms** |
| `JobMetadataSchema.safeParse` every record | **12 ms** |

So zod validation — the thing the issue suggested skipping for records that get
discarded — is ~1% of the cost. The cost is `yaml.parse`, and **99% of the bytes
it chews through are `prompt` (85.7%) and `summary` (13.2%)**, the two fields a
list caller rarely reads.

That reframes the fix: the goal is **not to parse records that will not be
returned**, rather than to cache parsed records.

I also measured the "just cache the parsed records" option, since that's the
obvious reading of "reuse the existing incremental mtime-cached index":

| cache design | heap for 1,996 records |
| --- | --- |
| full parsed records | **142 MB** |
| index fields only | **2 MB** |

142 MB retained forever, growing with job count, inside a process that also runs
agents, is not something a library should do silently. (Most of that isn't even
the data: `yaml` produces scalars via `String.prototype.slice`, and V8 keeps those
as SlicedStrings pinning the whole ~24 KB source — caching the *small* fields
naively still costs 99 MB. The index detaches its strings, hence 2 MB.)

## What this does

Filtering, sorting and pagination now run against an incremental, mtime+size-keyed
index of each job file's `agent` / `status` / `started_at`, mirroring what
`AttributionIndexBuilder` already does for session attribution. Only the records
actually returned are read and parsed in full, and a cold pass reuses the parse
the index refresh already paid for instead of reading twice.

Since `limit` previously bought nothing (it was applied to the finished result),
pagination is now pushed down to the read layer, which is where the largest win is.

## Measured, before vs after

Both builds run against the same real 1,996-record / 46.6 MB jobs directory, each
scenario in a fresh process; warm = median of 5 subsequent calls.

| call | before (cold / warm) | after (cold / warm) | warm speedup |
| --- | --- | --- | --- |
| `listJobs({ agent: 'keeper-paddock' })` | 1487 / 1127 ms | 1091 / **141 ms** | **8.0×** |
| `listJobs({ agent, limit: 50 })` | 1402 / 1139 ms | 1092 / **31 ms** | **37×** |
| `listJobs({ limit: 1 })` | 1580 / 1364 ms | 1087 / **31 ms** | **44×** |
| `listJobs({})` | 1640 / 1407 ms | 1342 / **1094 ms** | 1.3× |

Cold is modestly better (concurrency); the win is warm, which is what a polling
server actually does. The unfiltered, unpaginated call stays expensive by
construction — it asks for all 1,996 full records, i.e. 46.6 MB of YAML — and
that's the one shape no cache short of holding the whole corpus can help. In this
repo nothing actually needs it: `applyRetention` needs only `agent`+`id`+order,
`buildJobIndex` needs only `session_id`/`agent`/`trigger_type`, and the web
`/api/jobs` route is paginated.

Memory: the index costs **2.0 MB** for 1,996 records and is flat across repeated
calls (measured settled-heap delta after 3 and after 8 listings — identical).

## Behaviour preservation

Verified against the same real directory that the new implementation returns
**deep-equal records, in the same order, with the same `errors` count** as the old
one, for `{}`, `{agent}`, `{status}`, `{startedAfter}` and a combined
agent+status+startedBefore filter (1,996 / 463 / 12 / 1,955 / 402 records
respectively), and that `limit`/`offset` exactly match slicing the unlimited
result for four offset/limit combinations.

Specifically preserved:

- **Order** — `started_at` descending; the index is built in `readdir` order and
  `Array.sort` is stable, so ties break identically to before.
- **Corrupt/half-written files** — still skipped, still counted in `errors`, still
  never thrown. Warnings are cached and re-emitted on cached listings, so log
  output is unchanged too. Corrupt files are counted even when a filter or `limit`
  means they could never be returned, matching the old dir-wide count.
- **Object semantics** — full records are never cached, so every returned record is
  freshly parsed exactly as before. Nothing shares mutable state with the cache.
  (This matters: `fleet-manager/log-streaming.ts` sorts the returned array in place.)
- **Correctness under change** — entries are keyed on mtime *and* size; the filter
  is re-applied to the record actually read, so a file changing between index and
  read can't produce a job that doesn't match the filter.

## Regression test

`packages/core/src/state/__tests__/job-index.test.ts` (14 tests). It counts reads
reaching the filesystem layer and asserts the perf contract directly — a warm
`listJobs({agent})` over 20 files reads 2 files, and `{limit: 3}` reads 3 — plus
pagination, cache invalidation (create / update / delete), fresh-object identity,
and error accounting.

**Verified failing before the fix**: restoring the pre-fix `listJobs` fails 6 of
the 14, including both "does not re-read" tests (`expected 2, got 20` and
`expected 3, got 20`). The other 8 pass against both implementations by design —
they're the behaviour-preservation half.

## API additions (all backwards compatible)

- `ListJobsFilter.limit` / `.offset` — pagination pushed down to the read layer
- `ListJobsResult.total` — match count before `limit`/`offset` (optional, so
  hand-built results and test doubles stay valid)
- `JobManager.getJobs()` pushes `limit`/`offset` down instead of slicing
- `clearJobIndexCache(jobsDir?)` — for tests and for releasing memory

## Checks

`pnpm typecheck` clean across all 11 packages. `pnpm test` green everywhere; core
is 96/97 files with the single failure being pre-existing on `main`
(`directory.test.ts` "parent directory is not writable" — a chmod-based test that
can't fail for a root user, unrelated to this change). Core coverage thresholds
still met (`job-index.ts` 90% stmts / 88% branches, `job-metadata.ts` 92% / 87%).

## Out of scope

Paddock's own uncached scan in `packages/server/src/herdctl-jobs.ts` is a separate
problem in a different repo. Two follow-ups in this repo that this change now
makes trivial: the web `/api/jobs` route still slices `listJobs`' result rather
than passing `limit`/`offset` down, and `applyRetention` / `buildJobIndex` fetch
full records when they only need index fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
