### PR TITLE
fix(core): skip unreadable transcript entries instead of blanking the session listing (#424)

### DIFF
--- a/.changeset/beige-lizards-flow.md
+++ b/.changeset/beige-lizards-flow.md
@@ -1,0 +1,12 @@
+---
+"@herdctl/core": patch
+---
+
+Harden session discovery against a single unreadable transcript entry. An entry that
+`stat()`s as a valid `.jsonl` file but is actually a directory (so `open(2)` succeeds
+and `read(2)` throws `EISDIR`) previously threw out of the per-session enrichment and
+took down the whole listing — `getAgentSessions` lost the agent's entire list, and
+`getAllSessions` lost every agent's list because the throw escaped a loop nested in the
+loop over directories. Both paths now isolate per-entry enrichment (sidechain / auto-name
+/ preview) in a try/catch, skip the bad entry, and log a warning so a corrupt transcript
+folder is diagnosable, while good transcripts next to it still come back.

--- a/packages/core/src/state/__tests__/session-discovery-unreadable.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery-unreadable.test.ts
@@ -1,0 +1,214 @@
+import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// =============================================================================
+// Mocks
+//
+// This suite deliberately leaves the REAL `jsonl-parser` in place so the
+// enrichment path streams real files. That's the whole point: a directory named
+// `<uuid>.jsonl` reproduces the genuine EISDIR that `open(2)`-succeeds /
+// `read(2)`-fails yields on Linux (issue #424) — a mock can't reproduce that.
+//
+// `cli-session-path` is mocked in ONE respect only: `getCliSessionDir` /
+// `getCliSessionFile` normally derive their path from `os.homedir()`, NOT from
+// the service's `claudeHomePath`. In production those coincide (`claudeHomePath`
+// IS `~/.claude`), so the poison directory that the listing finds is the same
+// file the enrichment then reads. Under test we point both at the temp fixture
+// via `hoisted.claudeHome`; everything else in the module stays real.
+//
+// Attribution and the metadata store ARE mocked: attribution so the good
+// transcript is attributed to the agent under test, and the metadata store so
+// every cache lookup misses (forcing real extraction) without touching disk.
+// =============================================================================
+
+const hoisted = vi.hoisted(() => ({ claudeHome: "" }));
+
+vi.mock("../../runner/runtime/cli-session-path.js", async (importActual) => {
+  const actual = await importActual<typeof import("../../runner/runtime/cli-session-path.js")>();
+  const { join: joinPath } = await import("node:path");
+  return {
+    ...actual,
+    getCliSessionDir: (workspacePath: string) =>
+      joinPath(hoisted.claudeHome, "projects", actual.encodePathForCli(workspacePath)),
+    getCliSessionFile: (workspacePath: string, sessionId: string) =>
+      joinPath(
+        hoisted.claudeHome,
+        "projects",
+        actual.encodePathForCli(workspacePath),
+        `${sessionId}.jsonl`,
+      ),
+  };
+});
+
+vi.mock("../session-attribution.js", () => {
+  const fn = vi.fn();
+  return {
+    buildAttributionIndex: fn,
+    AttributionIndexBuilder: class MockAttributionIndexBuilder {
+      build = fn;
+    },
+  };
+});
+
+const mockGetCustomName = vi.fn().mockResolvedValue(undefined);
+const mockGetAutoName = vi.fn().mockResolvedValue(undefined);
+const mockBatchSetAutoNames = vi.fn().mockResolvedValue(undefined);
+const mockGetPreview = vi.fn().mockResolvedValue(undefined);
+const mockBatchSetPreviews = vi.fn().mockResolvedValue(undefined);
+const mockGetSidechain = vi.fn().mockResolvedValue(undefined);
+const mockBatchSetSidechains = vi.fn().mockResolvedValue(undefined);
+const mockGetUsage = vi.fn().mockResolvedValue(undefined);
+const mockSetUsage = vi.fn().mockResolvedValue(undefined);
+vi.mock("../session-metadata.js", () => ({
+  SessionMetadataStore: class MockSessionMetadataStore {
+    getCustomName = mockGetCustomName;
+    getAutoName = mockGetAutoName;
+    batchSetAutoNames = mockBatchSetAutoNames;
+    getPreview = mockGetPreview;
+    batchSetPreviews = mockBatchSetPreviews;
+    getSidechain = mockGetSidechain;
+    batchSetSidechains = mockBatchSetSidechains;
+    getUsage = mockGetUsage;
+    setUsage = mockSetUsage;
+  },
+}));
+
+import { buildAttributionIndex } from "../session-attribution.js";
+import { SessionDiscoveryService } from "../session-discovery.js";
+
+const mockBuildAttributionIndex = vi.mocked(buildAttributionIndex);
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+async function createTempDir(prefix: string): Promise<string> {
+  const baseDir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(baseDir, { recursive: true });
+  return await realpath(baseDir);
+}
+
+/** A minimal but valid transcript: one plain user line, not a sidechain. */
+async function writeGoodTranscript(dir: string, sessionId: string, cwd: string): Promise<void> {
+  const line = JSON.stringify({
+    type: "user",
+    isSidechain: false,
+    timestamp: "2026-08-01T00:00:00.000Z",
+    cwd,
+    message: { role: "user", content: "hello from a healthy transcript" },
+  });
+  await writeFile(join(dir, `${sessionId}.jsonl`), `${line}\n`);
+}
+
+/** A poison entry: a DIRECTORY named `<uuid>.jsonl`. `stat()`s as a valid file,
+ * throws EISDIR on read. */
+async function writePoisonEntry(dir: string, sessionId: string): Promise<void> {
+  await mkdir(join(dir, `${sessionId}.jsonl`), { recursive: true });
+}
+
+function mockAttribution(attributedIds: Set<string>, agentName: string) {
+  const getAttribute = (sessionId: string) => ({
+    origin: "native" as const,
+    agentName: attributedIds.has(sessionId) ? agentName : undefined,
+    triggerType: undefined,
+  });
+  return {
+    getAttribute,
+    getAttributes: (ids: string[]) => new Map(ids.map((id) => [id, getAttribute(id)])),
+    size: 0,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("SessionDiscoveryService — unreadable transcript entries (issue #424)", () => {
+  let claudeHomePath: string;
+  let tempStateDir: string;
+  const workingDir = "/Users/ed/Code/myproject";
+  const encodedPath = "-Users-ed-Code-myproject";
+  const goodId = "11111111-1111-1111-1111-111111111111";
+  const poisonId = "22222222-2222-2222-2222-222222222222";
+
+  beforeEach(async () => {
+    const home = await createTempDir("claude-home-unreadable");
+    claudeHomePath = join(home, ".claude");
+    await mkdir(claudeHomePath, { recursive: true });
+    hoisted.claudeHome = claudeHomePath;
+    tempStateDir = await createTempDir("state-dir-unreadable");
+    mockBuildAttributionIndex.mockResolvedValue(mockAttribution(new Set([goodId]), "my-agent"));
+  });
+
+  afterEach(async () => {
+    await rm(join(claudeHomePath, ".."), { recursive: true, force: true });
+    await rm(tempStateDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("getAgentSessions returns the good session even when a sibling entry is an unreadable directory", async () => {
+    const projectDir = join(claudeHomePath, "projects", encodedPath);
+    await mkdir(projectDir, { recursive: true });
+    await writeGoodTranscript(projectDir, goodId, workingDir);
+    await writePoisonEntry(projectDir, poisonId);
+
+    const discovery = new SessionDiscoveryService({ claudeHomePath, stateDir: tempStateDir });
+
+    const sessions = await discovery.getAgentSessions("my-agent", workingDir, false);
+
+    const ids = sessions.map((s) => s.sessionId);
+    expect(ids).toContain(goodId);
+    expect(ids).not.toContain(poisonId);
+  });
+
+  it("getAllSessions returns the good session even when a sibling entry is an unreadable directory", async () => {
+    const projectDir = join(claudeHomePath, "projects", encodedPath);
+    await mkdir(projectDir, { recursive: true });
+    await writeGoodTranscript(projectDir, goodId, workingDir);
+    await writePoisonEntry(projectDir, poisonId);
+
+    const discovery = new SessionDiscoveryService({ claudeHomePath, stateDir: tempStateDir });
+
+    const groups = await discovery.getAllSessions([
+      { name: "my-agent", workingDirectory: workingDir, dockerEnabled: false },
+    ]);
+
+    const allIds = groups.flatMap((g) => g.sessions.map((s) => s.sessionId));
+    expect(allIds).toContain(goodId);
+    expect(allIds).not.toContain(poisonId);
+  });
+
+  it("getAllSessions still lists other directories when one directory holds an unreadable entry", async () => {
+    // Two sibling project directories; the poison lives in one of them. Before the
+    // fix, one bad entry aborted enrichment for every directory in the listing.
+    const otherWorkingDir = "/Users/ed/Code/other";
+    const otherEncoded = "-Users-ed-Code-other";
+    const otherId = "33333333-3333-3333-3333-333333333333";
+
+    const projectDir = join(claudeHomePath, "projects", encodedPath);
+    const otherDir = join(claudeHomePath, "projects", otherEncoded);
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(otherDir, { recursive: true });
+    await writeGoodTranscript(projectDir, goodId, workingDir);
+    await writePoisonEntry(projectDir, poisonId);
+    await writeGoodTranscript(otherDir, otherId, otherWorkingDir);
+
+    mockBuildAttributionIndex.mockResolvedValue(
+      mockAttribution(new Set([goodId, otherId]), "my-agent"),
+    );
+
+    const discovery = new SessionDiscoveryService({ claudeHomePath, stateDir: tempStateDir });
+
+    const groups = await discovery.getAllSessions([
+      { name: "my-agent", workingDirectory: workingDir, dockerEnabled: false },
+      { name: "other-agent", workingDirectory: otherWorkingDir, dockerEnabled: false },
+    ]);
+
+    const allIds = groups.flatMap((g) => g.sessions.map((s) => s.sessionId));
+    expect(allIds).toContain(goodId);
+    expect(allIds).toContain(otherId);
+    expect(allIds).not.toContain(poisonId);
+  });
+});

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -757,6 +757,41 @@ describe("SessionDiscoveryService", () => {
       ]);
     });
 
+    it("skips an entry whose enrichment fails after the visible count and keeps sessionCount in sync (issue #424)", async () => {
+      // Two sessions in one directory. Both pass the sidechain check (which only
+      // reads the first line), so both are counted as visible — but the "bad"
+      // one then fails a deeper whole-file read (auto-name resolution). The entry
+      // must be skipped AND backed out of visibleSessionCount, so sessionCount
+      // still matches the sessions actually returned.
+      const projectDir = join(tempClaudeHome, "projects", "-Users-ed-Code-myproject");
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "session-good");
+      await createSessionFile(projectDir, "session-bad");
+
+      mockIsSidechainSession.mockResolvedValue(false);
+      // resolveAutoName streams the whole transcript; make it reject only for the
+      // bad session (matched by the sessionId embedded in the resolved file path).
+      mockExtractLastSummary.mockImplementation((filePath: string) =>
+        filePath.includes("session-bad")
+          ? Promise.reject(new Error("EISDIR: illegal operation on a directory, read"))
+          : Promise.resolve(undefined),
+      );
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      const groups = await service.getAllSessions([]);
+
+      expect(groups).toHaveLength(1);
+      const ids = groups[0].sessions.map((s) => s.sessionId);
+      expect(ids).toEqual(["session-good"]);
+      // The key assertion: the count of the skipped entry was backed out.
+      expect(groups[0].sessionCount).toBe(groups[0].sessions.length);
+      expect(groups[0].sessionCount).toBe(1);
+    });
+
     it("matches agent directories to fleet agents by encoded path", async () => {
       const projectDir = join(tempClaudeHome, "projects", "-Users-ed-Code-myproject");
       await mkdir(projectDir, { recursive: true });

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -1067,6 +1067,11 @@ export class SessionDiscoveryService {
 
       for (const { sessionId, mtime } of dir.sessionFiles) {
         const mtimeStr = mtime.toISOString();
+        // Tracks whether this entry was already counted as visible, so a later
+        // enrichment failure (which lands in the catch below and skips the entry)
+        // can back the count out — keeping `sessionCount` in sync with the
+        // sessions actually returned.
+        let countedAsVisible = false;
 
         try {
           // Filter out sidechain (sub-agent) sessions — see comment in getAgentSessions().
@@ -1112,6 +1117,7 @@ export class SessionDiscoveryService {
           // Count visible sessions BEFORE pagination filtering — sessionCount should reflect
           // total visible sessions for this agent, not just the paginated subset
           visibleSessionCount++;
+          countedAsVisible = true;
 
           // Skip sessions not in the selected set when limit is active (pagination)
           if (selectedSessionIds && !selectedSessionIds.has(sessionId)) {
@@ -1172,6 +1178,14 @@ export class SessionDiscoveryService {
           // the loop over directories, every *other* directory's enrichment too).
           // Logged at warn so a corrupt transcript folder is diagnosable instead
           // of just quietly smaller.
+          //
+          // If the entry was already counted as visible (the sidechain check
+          // reads only the first line, so a transcript can pass it yet fail a
+          // later whole-file read for auto-name/preview), back that count out so
+          // `sessionCount` still matches the sessions actually returned.
+          if (countedAsVisible) {
+            visibleSessionCount--;
+          }
           logger.warn(
             `Skipping unreadable session entry ${sessionId} in ${dir.decodedPath}: ${(error as Error).message}`,
           );

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -673,79 +673,29 @@ export class SessionDiscoveryService {
       filesToEnrich,
       SESSION_ENRICHMENT_CONCURRENCY,
       async ({ sessionId, mtime, workingDirectory: sessionWorkingDir }) => {
-        const mtimeStr = mtime.toISOString();
-
-        // Filter out sidechain (sub-agent) sessions. Claude Code marks sessions
-        // as sidechain when they're Task tool sub-agents or when --resume is used.
-        // These are mostly prompt-cache warmup sessions ("Warmup" + single response)
-        // that clutter the UI with no useful content. The flag comes from the first
-        // JSONL line and is cached (keyed on mtime) so we don't re-open every
-        // transcript on each listing. Record the (possibly refreshed) flag even for
-        // excluded sessions so the next listing can skip re-reading them.
-        const { isSidechain, needsUpdate: sidechainNeedsUpdate } = await this.resolveSidechain(
-          agentName,
-          sessionId,
-          mtimeStr,
-          sessionWorkingDir,
-          dockerEnabled,
-        );
-        const sidechainUpdate = sidechainNeedsUpdate
-          ? { sessionId, isSidechain, mtime: mtimeStr }
-          : undefined;
-        if (isSidechain) {
-          return { session: null, sidechainUpdate };
+        try {
+          return await this.enrichAgentSession(
+            agentName,
+            sessionId,
+            mtime,
+            sessionWorkingDir,
+            dockerEnabled,
+            attributionIndex,
+          );
+        } catch (error) {
+          // Enrichment of ONE session must never take down the whole listing.
+          // A per-entry read failure — most notably an entry that stat()s as a
+          // valid `.jsonl` but is actually a directory, so open(2) succeeds and
+          // read(2) throws EISDIR (issue #424) — is treated as "skip this entry"
+          // rather than allowed to reject `mapWithConcurrency` (which rejects
+          // like Promise.all). Logged at warn so a corrupt transcript folder is
+          // diagnosable instead of just quietly smaller. Returning a null session
+          // with no cache updates drops the entry from the listing.
+          logger.warn(
+            `Skipping unreadable session entry ${sessionId} for agent ${agentName}: ${(error as Error).message}`,
+          );
+          return { session: null };
         }
-
-        const attribution = attributionIndex.getAttribute(sessionId);
-
-        // Only show sessions that are attributed to this specific agent.
-        // When multiple agents share a working directory, this prevents the same
-        // native CLI sessions from appearing under every agent. Unattributed sessions
-        // are still visible in the global recent sessions list and All Chats view.
-        if (attribution.agentName !== agentName) {
-          return { session: null, sidechainUpdate };
-        }
-
-        const customName = await this.sessionMetadataStore.getCustomName(agentName, sessionId);
-
-        // Resolve autoName with caching — pass docker flag so it reads the right file
-        const { autoName, needsUpdate } = await this.resolveAutoName(
-          agentName,
-          sessionId,
-          mtimeStr,
-          sessionWorkingDir,
-          dockerEnabled,
-        );
-
-        // Resolve preview with caching — pass docker flag so it reads the right file
-        const { preview, needsUpdate: previewNeedsUpdate } = await this.resolvePreview(
-          agentName,
-          sessionId,
-          mtimeStr,
-          sessionWorkingDir,
-          dockerEnabled,
-        );
-
-        const session: DiscoveredSession = {
-          sessionId,
-          workingDirectory: sessionWorkingDir,
-          mtime: mtimeStr,
-          origin: attribution.origin,
-          agentName: attribution.agentName ?? agentName,
-          resumable: !dockerEnabled,
-          customName,
-          autoName,
-          preview,
-        };
-        return {
-          session,
-          sidechainUpdate,
-          // Record the update even when the value is empty so the negative result
-          // (no summary / no preview) is cached against this mtime — see
-          // resolveAutoName/resolvePreview.
-          autoNameUpdate: needsUpdate ? { sessionId, autoName, mtime: mtimeStr } : undefined,
-          previewUpdate: previewNeedsUpdate ? { sessionId, preview, mtime: mtimeStr } : undefined,
-        };
       },
     );
 
@@ -783,6 +733,104 @@ export class SessionDiscoveryService {
     }
 
     return sessions;
+  }
+
+  /**
+   * Enrich a single agent session: resolve its sidechain flag, attribution,
+   * custom/auto name, and preview into a {@link DiscoveredSession} (or a null
+   * session when the entry is a sidechain / attributed to a different agent).
+   *
+   * Extracted from {@link getAgentSessions} so its call site can wrap it in a
+   * per-entry try/catch: any read failure here (e.g. EISDIR from an entry that
+   * is actually a directory, issue #424) skips just this entry instead of
+   * rejecting the whole concurrent enrichment.
+   */
+  private async enrichAgentSession(
+    agentName: string,
+    sessionId: string,
+    mtime: Date,
+    sessionWorkingDir: string,
+    dockerEnabled: boolean,
+    attributionIndex: AttributionIndex,
+  ): Promise<{
+    session: DiscoveredSession | null;
+    sidechainUpdate?: { sessionId: string; isSidechain: boolean; mtime: string };
+    autoNameUpdate?: { sessionId: string; autoName?: string; mtime: string };
+    previewUpdate?: { sessionId: string; preview?: string; mtime: string };
+  }> {
+    const mtimeStr = mtime.toISOString();
+
+    // Filter out sidechain (sub-agent) sessions. Claude Code marks sessions
+    // as sidechain when they're Task tool sub-agents or when --resume is used.
+    // These are mostly prompt-cache warmup sessions ("Warmup" + single response)
+    // that clutter the UI with no useful content. The flag comes from the first
+    // JSONL line and is cached (keyed on mtime) so we don't re-open every
+    // transcript on each listing. Record the (possibly refreshed) flag even for
+    // excluded sessions so the next listing can skip re-reading them.
+    const { isSidechain, needsUpdate: sidechainNeedsUpdate } = await this.resolveSidechain(
+      agentName,
+      sessionId,
+      mtimeStr,
+      sessionWorkingDir,
+      dockerEnabled,
+    );
+    const sidechainUpdate = sidechainNeedsUpdate
+      ? { sessionId, isSidechain, mtime: mtimeStr }
+      : undefined;
+    if (isSidechain) {
+      return { session: null, sidechainUpdate };
+    }
+
+    const attribution = attributionIndex.getAttribute(sessionId);
+
+    // Only show sessions that are attributed to this specific agent.
+    // When multiple agents share a working directory, this prevents the same
+    // native CLI sessions from appearing under every agent. Unattributed sessions
+    // are still visible in the global recent sessions list and All Chats view.
+    if (attribution.agentName !== agentName) {
+      return { session: null, sidechainUpdate };
+    }
+
+    const customName = await this.sessionMetadataStore.getCustomName(agentName, sessionId);
+
+    // Resolve autoName with caching — pass docker flag so it reads the right file
+    const { autoName, needsUpdate } = await this.resolveAutoName(
+      agentName,
+      sessionId,
+      mtimeStr,
+      sessionWorkingDir,
+      dockerEnabled,
+    );
+
+    // Resolve preview with caching — pass docker flag so it reads the right file
+    const { preview, needsUpdate: previewNeedsUpdate } = await this.resolvePreview(
+      agentName,
+      sessionId,
+      mtimeStr,
+      sessionWorkingDir,
+      dockerEnabled,
+    );
+
+    const session: DiscoveredSession = {
+      sessionId,
+      workingDirectory: sessionWorkingDir,
+      mtime: mtimeStr,
+      origin: attribution.origin,
+      agentName: attribution.agentName ?? agentName,
+      resumable: !dockerEnabled,
+      customName,
+      autoName,
+      preview,
+    };
+    return {
+      session,
+      sidechainUpdate,
+      // Record the update even when the value is empty so the negative result
+      // (no summary / no preview) is cached against this mtime — see
+      // resolveAutoName/resolvePreview.
+      autoNameUpdate: needsUpdate ? { sessionId, autoName, mtime: mtimeStr } : undefined,
+      previewUpdate: previewNeedsUpdate ? { sessionId, preview, mtime: mtimeStr } : undefined,
+    };
   }
 
   /**
@@ -1020,100 +1068,114 @@ export class SessionDiscoveryService {
       for (const { sessionId, mtime } of dir.sessionFiles) {
         const mtimeStr = mtime.toISOString();
 
-        // Filter out sidechain (sub-agent) sessions — see comment in getAgentSessions().
-        // Cached (keyed on mtime) so we don't re-open every transcript per listing.
-        const { isSidechain, needsUpdate: sidechainNeedsUpdate } = await this.resolveSidechain(
-          dir.metadataKey,
-          sessionId,
-          mtimeStr,
-          dir.decodedPath,
-          dir.dockerEnabled,
-        );
-        if (sidechainNeedsUpdate) {
-          sidechainUpdates.push({ sessionId, isSidechain, mtime: mtimeStr });
-        }
-        if (isSidechain) {
-          continue;
-        }
-
-        // Issue #148: when several real working directories collide on this
-        // encoded transcript directory, drop sessions whose recorded cwd belongs
-        // to a *different* colliding directory so they aren't cross-attributed.
-        // Only runs when a collision was detected (dir.disambiguateWorkingDir set).
-        // Reads from the actually-scanned directory so it honours claudeHomePath.
-        if (dir.disambiguateWorkingDir !== undefined && dir.sessionDirPath !== undefined) {
-          const transcriptPath = path.join(dir.sessionDirPath, `${sessionId}.jsonl`);
-          const belongs = await sessionBelongsToWorkingDirectory(
-            transcriptPath,
-            dir.disambiguateWorkingDir,
+        try {
+          // Filter out sidechain (sub-agent) sessions — see comment in getAgentSessions().
+          // Cached (keyed on mtime) so we don't re-open every transcript per listing.
+          const { isSidechain, needsUpdate: sidechainNeedsUpdate } = await this.resolveSidechain(
+            dir.metadataKey,
+            sessionId,
+            mtimeStr,
+            dir.decodedPath,
+            dir.dockerEnabled,
           );
-          if (!belongs) {
+          if (sidechainNeedsUpdate) {
+            sidechainUpdates.push({ sessionId, isSidechain, mtime: mtimeStr });
+          }
+          if (isSidechain) {
             continue;
           }
+
+          // Issue #148: when several real working directories collide on this
+          // encoded transcript directory, drop sessions whose recorded cwd belongs
+          // to a *different* colliding directory so they aren't cross-attributed.
+          // Only runs when a collision was detected (dir.disambiguateWorkingDir set).
+          // Reads from the actually-scanned directory so it honours claudeHomePath.
+          if (dir.disambiguateWorkingDir !== undefined && dir.sessionDirPath !== undefined) {
+            const transcriptPath = path.join(dir.sessionDirPath, `${sessionId}.jsonl`);
+            const belongs = await sessionBelongsToWorkingDirectory(
+              transcriptPath,
+              dir.disambiguateWorkingDir,
+            );
+            if (!belongs) {
+              continue;
+            }
+          }
+
+          const attribution = attributionIndex.getAttribute(sessionId);
+
+          // For docker directories, only include sessions attributed to this specific agent
+          // (since all docker agents share the same docker-sessions directory)
+          if (dir.dockerEnabled && attribution.agentName !== dir.agentName) {
+            continue;
+          }
+
+          // Count visible sessions BEFORE pagination filtering — sessionCount should reflect
+          // total visible sessions for this agent, not just the paginated subset
+          visibleSessionCount++;
+
+          // Skip sessions not in the selected set when limit is active (pagination)
+          if (selectedSessionIds && !selectedSessionIds.has(sessionId)) {
+            continue;
+          }
+
+          // Get custom name (works for both attributed and unattributed sessions)
+          const customName = await this.sessionMetadataStore.getCustomName(
+            dir.metadataKey,
+            sessionId,
+          );
+
+          // Resolve autoName with caching
+          const { autoName, needsUpdate } = await this.resolveAutoName(
+            dir.metadataKey,
+            sessionId,
+            mtimeStr,
+            dir.decodedPath,
+            dir.dockerEnabled,
+          );
+
+          // Record even an empty result so the negative case is cached (see
+          // resolveAutoName). autoName may be undefined here.
+          if (needsUpdate) {
+            autoNameUpdates.push({ sessionId, autoName, mtime: mtimeStr });
+          }
+
+          // Resolve preview with caching
+          const { preview, needsUpdate: previewNeedsUpdate } = await this.resolvePreview(
+            dir.metadataKey,
+            sessionId,
+            mtimeStr,
+            dir.decodedPath,
+            dir.dockerEnabled,
+          );
+
+          if (previewNeedsUpdate) {
+            previewUpdates.push({ sessionId, preview, mtime: mtimeStr });
+          }
+
+          sessions.push({
+            sessionId,
+            workingDirectory: dir.decodedPath,
+            mtime: mtimeStr,
+            origin: attribution.origin,
+            agentName: attribution.agentName ?? dir.agentName,
+            resumable: !dir.dockerEnabled,
+            customName,
+            autoName,
+            preview,
+          });
+        } catch (error) {
+          // Enrichment of ONE session must never take down the whole listing.
+          // A per-entry read failure — most notably an entry that stat()s as a
+          // valid `.jsonl` but is actually a directory, so open(2) succeeds and
+          // read(2) throws EISDIR (issue #424) — is skipped rather than allowed
+          // to abort this directory's loop (and, because this loop is nested in
+          // the loop over directories, every *other* directory's enrichment too).
+          // Logged at warn so a corrupt transcript folder is diagnosable instead
+          // of just quietly smaller.
+          logger.warn(
+            `Skipping unreadable session entry ${sessionId} in ${dir.decodedPath}: ${(error as Error).message}`,
+          );
         }
-
-        const attribution = attributionIndex.getAttribute(sessionId);
-
-        // For docker directories, only include sessions attributed to this specific agent
-        // (since all docker agents share the same docker-sessions directory)
-        if (dir.dockerEnabled && attribution.agentName !== dir.agentName) {
-          continue;
-        }
-
-        // Count visible sessions BEFORE pagination filtering — sessionCount should reflect
-        // total visible sessions for this agent, not just the paginated subset
-        visibleSessionCount++;
-
-        // Skip sessions not in the selected set when limit is active (pagination)
-        if (selectedSessionIds && !selectedSessionIds.has(sessionId)) {
-          continue;
-        }
-
-        // Get custom name (works for both attributed and unattributed sessions)
-        const customName = await this.sessionMetadataStore.getCustomName(
-          dir.metadataKey,
-          sessionId,
-        );
-
-        // Resolve autoName with caching
-        const { autoName, needsUpdate } = await this.resolveAutoName(
-          dir.metadataKey,
-          sessionId,
-          mtimeStr,
-          dir.decodedPath,
-          dir.dockerEnabled,
-        );
-
-        // Record even an empty result so the negative case is cached (see
-        // resolveAutoName). autoName may be undefined here.
-        if (needsUpdate) {
-          autoNameUpdates.push({ sessionId, autoName, mtime: mtimeStr });
-        }
-
-        // Resolve preview with caching
-        const { preview, needsUpdate: previewNeedsUpdate } = await this.resolvePreview(
-          dir.metadataKey,
-          sessionId,
-          mtimeStr,
-          dir.decodedPath,
-          dir.dockerEnabled,
-        );
-
-        if (previewNeedsUpdate) {
-          previewUpdates.push({ sessionId, preview, mtime: mtimeStr });
-        }
-
-        sessions.push({
-          sessionId,
-          workingDirectory: dir.decodedPath,
-          mtime: mtimeStr,
-          origin: attribution.origin,
-          agentName: attribution.agentName ?? dir.agentName,
-          resumable: !dir.dockerEnabled,
-          customName,
-          autoName,
-          preview,
-        });
       }
 
       // Batch write any cache updates for this directory


### PR DESCRIPTION
Fixes #424.

## Problem

A single unreadable entry inside a Claude Code transcript folder — the simplest repro being a **directory** named `<uuid>.jsonl` — made session listing throw outright:

- **`getAgentSessions`** lost the agent's whole list (the throw rejected `mapWithConcurrency`, which rejects like `Promise.all`).
- **`getAllSessions`** lost **every** agent's list, because the throw escaped a per-session loop that is itself nested in the loop over directories.

Callers got an exception, not a partial result — good transcripts sitting next to the bad entry were lost.

### Why the existing guards miss it

On Linux `open(2)` on a directory **succeeds** and only `read(2)` fails, so `createLineReader`'s `stream.on("error")` handler never fires — the `EISDIR` surfaces later on the `for await` inside `isSidechainSession`. `listSessionFiles` can't screen it either: it filters on the `.jsonl` **name**, and `stat()` on a directory succeeds, so the entry is admitted with a valid mtime and size.

## Fix

The principle from the issue: **enrichment of ONE session must never take down the listing.** Both listing paths now isolate per-entry enrichment in a `try/catch`, skip the bad entry, and `logger.warn` it. This covers **all three** enrichment doors (`resolveSidechain`, `resolveAutoName`, `resolvePreview`), not just the sidechain check that happens to throw first — wrapping the whole per-session body closes every door at once.

- `getAgentSessions`: per-session work extracted into `enrichAgentSession`; the `mapWithConcurrency` callback wraps it and returns a skip sentinel (`{ session: null }`, no cache updates) on failure.
- `getAllSessions`: the per-session loop body is wrapped; a failure logs and continues to the next entry (and next directory).

The `sessionBelongsToWorkingDirectory` / `readSessionCwd` disambiguation path was already hardened (it uses `Promise.race` + `try/catch`), so it needed no change.

## Design decision — report vs. silently drop

The issue asked me to decide deliberately whether a skipped entry should be *reported* via a `skipped`/`errors` channel on the result, or dropped.

**Chosen: skip + `logger.warn`, no change to the public return shape.** Reasoning:

1. `getAgentSessions` returns `DiscoveredSession[]` and `getAllSessions` returns `DirectoryGroup[]` — both public and consumed by the thin CLI/web clients. Adding a channel means changing those return types, which is a **breaking change requiring a major bump** for what is a bug fix (repo follows semver strictly).
2. A `warn` log carrying the entry path + reason makes a corrupt folder **fully diagnosable** — meeting the "diagnosable instead of quietly smaller" goal — without the API churn.
3. It matches this file's existing convention: `listSessionFiles` / `getAllSessions` already `logger.warn`/`logger.debug` on `readdir`/`stat` failures rather than surfacing them in the return value.

If a structured channel is wanted later, it can land as its own deliberate major.

## Tests

New `session-discovery-unreadable.test.ts` reproduces the **genuine** `EISDIR` (real `jsonl-parser`, a poison directory next to a good transcript) for both entry points, plus a multi-directory case proving one bad entry no longer aborts sibling directories. Confirmed **red before / green after** — all three fail with `Error: EISDIR: illegal operation on a directory, read` on `main`, and pass with the fix.

> Note: the test mocks `cli-session-path`'s `getCliSessionDir`/`getCliSessionFile` to route through the temp `claudeHomePath`. Those helpers derive their path from `os.homedir()`, not the service's `claudeHomePath`; in production the two coincide (so the poison dir found by the listing is the same file enrichment reads), and the mock restores that invariant under test — otherwise enrichment reads the real home and never hits the fixture.

## Verification

- `pnpm --filter @herdctl/core typecheck` — clean
- `pnpm --filter @herdctl/core test` — 3484 passed; the **only** failure is the pre-existing `directory.test.ts > "throws StateDirectoryCreateError when parent directory is not writable"` (runs-as-root chmod artifact, unrelated).
- `biome check` on the changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session listings now remain available when individual transcript entries are unreadable.
  * Invalid or inaccessible entries are skipped with a warning instead of preventing other valid sessions from appearing.
  * Session discovery continues across project directories, including when some entries cannot be processed.

* **Tests**
  * Added coverage for unreadable transcript files and directories masquerading as transcript files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->