### PR TITLE
fix(core): stop SessionMetadataStore clobbering an unreadable metadata file (#419)

### DIFF
--- a/.changeset/fix-419-metadata-no-clobber.md
+++ b/.changeset/fix-419-metadata-no-clobber.md
@@ -1,0 +1,32 @@
+---
+"@herdctl/core": patch
+---
+
+fix(core): stop SessionMetadataStore from replacing an unreadable metadata file with an empty one (#419)
+
+`loadMetadata()` collapsed three outcomes into the same `null`: the file was
+absent (legitimate — storage is sparse), the file could not be read (EACCES /
+EIO / EISDIR / a truncated read), or the file parsed but failed schema
+validation. Every setter treated `null` as "start fresh", so the next
+`atomicWriteJson` replaced the **whole** agent file with an empty structure —
+silently destroying every `customName`, `preview`, `autoName`, `isSidechain`
+and `usage` entry for that agent. One failed read followed by one write (a
+listing warming its caches is enough) wiped the file, and because the atomic
+write succeeded it looked clean.
+
+Reads and writes now distinguish absent from unreadable:
+
+- **Absent** → an empty structure is created, exactly as before.
+- **Unreadable / corrupt** → writes refuse and throw the new
+  `SessionMetadataUnreadableError`, leaving the damaged file untouched so its
+  bytes stay recoverable. Getters keep returning `null`/`undefined` (graceful
+  read degradation is unchanged).
+
+Session-discovery's background cache-warming (`batchSet*` / `setUsage`) tolerates
+that refusal and continues — a poisoned metadata file for one agent no longer
+aborts a whole listing; the cache just stays cold until the file is repaired.
+The transient failure is never cached, so a temporary read error does not become
+sticky.
+
+`SessionMetadataUnreadableError` and `isSessionMetadataUnreadableError` are
+exported from `@herdctl/core`.

--- a/packages/core/src/state/__tests__/session-discovery-combined-424-419.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery-combined-424-419.test.ts
@@ -1,0 +1,207 @@
+import { mkdir, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// =============================================================================
+// #424 × #419 — both failure modes live at once
+//
+// This suite proves the two fixes *cooperate* rather than merely coexist. It is
+// deliberately a HIGH-fidelity integration test:
+//
+//   - The REAL `jsonl-parser` is used (no mock) so a directory named
+//     `<uuid>.jsonl` reproduces the genuine `open(2)`-succeeds / `read(2)`-throws
+//     EISDIR that only surfaces at read time on Linux — the #424 trigger.
+//   - The REAL `SessionMetadataStore` is used (no mock) so a corrupt
+//     `session-metadata/<agent>.json` reproduces the genuine #419 trigger: the
+//     store must refuse to overwrite it when the listing warms its caches.
+//
+// Only `session-attribution` and `cli-session-path` are stubbed, exactly as the
+// #424 suite (`session-discovery-unreadable.test.ts`) does: attribution so the
+// good transcript is attributed to the agent under test, and `getCliSessionFile`
+// / `getCliSessionDir` so per-session reads resolve to the temp fixture instead
+// of the real `os.homedir()`. In production those coincide; the mock restores
+// that invariant AND keeps the test off the live `~/.claude` tree.
+// =============================================================================
+
+const hoisted = vi.hoisted(() => ({ claudeHome: "" }));
+
+vi.mock("../../runner/runtime/cli-session-path.js", async (importActual) => {
+  const actual = await importActual<typeof import("../../runner/runtime/cli-session-path.js")>();
+  const { join: joinPath } = await import("node:path");
+  return {
+    ...actual,
+    getCliSessionDir: (workspacePath: string) =>
+      joinPath(hoisted.claudeHome, "projects", actual.encodePathForCli(workspacePath)),
+    getCliSessionFile: (workspacePath: string, sessionId: string) =>
+      joinPath(
+        hoisted.claudeHome,
+        "projects",
+        actual.encodePathForCli(workspacePath),
+        `${sessionId}.jsonl`,
+      ),
+  };
+});
+
+vi.mock("../session-attribution.js", () => {
+  const fn = vi.fn();
+  return {
+    buildAttributionIndex: fn,
+    AttributionIndexBuilder: class MockAttributionIndexBuilder {
+      build = fn;
+    },
+  };
+});
+
+import { buildAttributionIndex } from "../session-attribution.js";
+import { SessionDiscoveryService } from "../session-discovery.js";
+
+const mockBuildAttributionIndex = vi.mocked(buildAttributionIndex);
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+async function createTempDir(prefix: string): Promise<string> {
+  const baseDir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(baseDir, { recursive: true });
+  return await realpath(baseDir);
+}
+
+/** A minimal but valid transcript: one plain user line, not a sidechain. */
+async function writeGoodTranscript(dir: string, sessionId: string, cwd: string): Promise<void> {
+  const line = JSON.stringify({
+    type: "user",
+    isSidechain: false,
+    timestamp: "2026-08-01T00:00:00.000Z",
+    cwd,
+    message: { role: "user", content: "hello from a healthy transcript" },
+  });
+  await writeFile(join(dir, `${sessionId}.jsonl`), `${line}\n`);
+}
+
+/** A poison entry: a DIRECTORY named `<uuid>.jsonl` — the #424 trigger. */
+async function writePoisonEntry(dir: string, sessionId: string): Promise<void> {
+  await mkdir(join(dir, `${sessionId}.jsonl`), { recursive: true });
+}
+
+function mockAttribution(attributedIds: Set<string>, agentName: string) {
+  const getAttribute = (sessionId: string) => ({
+    origin: "native" as const,
+    agentName: attributedIds.has(sessionId) ? agentName : undefined,
+    triggerType: undefined,
+  });
+  return {
+    getAttribute,
+    getAttributes: (ids: string[]) => new Map(ids.map((id) => [id, getAttribute(id)])),
+    size: 0,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("SessionDiscoveryService — #424 poison entry AND #419 corrupt metadata, simultaneously", () => {
+  let tempHome: string;
+  let claudeHomePath: string;
+  let tempStateDir: string;
+  const agentName = "my-agent";
+  const workingDir = "/Users/ed/Code/myproject";
+  const encodedPath = "-Users-ed-Code-myproject";
+  const goodId = "11111111-1111-1111-1111-111111111111";
+  const poisonId = "22222222-2222-2222-2222-222222222222";
+
+  // A metadata file that WAS a healthy store for this agent but is now truncated
+  // mid-write, so JSON.parse fails. The user-set customName bytes are still on
+  // disk and recoverable — unless #419's fix is absent and a listing overwrites
+  // the file. `metadataKey` is `agentName` (session-discovery: `metadataKey =
+  // agentName ?? "adhoc"`), so `<agent>.json` is exactly what the listing writes.
+  const CORRUPT_METADATA =
+    `{"version":1,"agentName":"${agentName}","sessions":{` +
+    `"${goodId}":{"customName":"Precious user-set name"`;
+
+  async function seedCorruptMetadata(): Promise<string> {
+    const metadataDir = join(tempStateDir, "session-metadata");
+    await mkdir(metadataDir, { recursive: true });
+    const filePath = join(metadataDir, `${agentName}.json`);
+    await writeFile(filePath, CORRUPT_METADATA, "utf-8");
+    return filePath;
+  }
+
+  beforeEach(async () => {
+    tempHome = await createTempDir("home-combined");
+    tempStateDir = await createTempDir("state-combined");
+    claudeHomePath = join(tempHome, ".claude");
+    // Route the mocked getCliSessionDir/File at the temp fixture (never ~/.claude).
+    hoisted.claudeHome = claudeHomePath;
+    mockBuildAttributionIndex.mockResolvedValue(mockAttribution(new Set([goodId]), agentName));
+
+    // Fixture: a good transcript beside a poison directory entry.
+    const projectDir = join(claudeHomePath, "projects", encodedPath);
+    await mkdir(projectDir, { recursive: true });
+    await writeGoodTranscript(projectDir, goodId, workingDir);
+    await writePoisonEntry(projectDir, poisonId);
+  });
+
+  afterEach(async () => {
+    await rm(tempHome, { recursive: true, force: true });
+    await rm(tempStateDir, { recursive: true, force: true });
+    hoisted.claudeHome = "";
+    vi.restoreAllMocks();
+  });
+
+  it("getAgentSessions returns the good session AND leaves the corrupt metadata file byte-for-byte intact", async () => {
+    const filePath = await seedCorruptMetadata();
+
+    const discovery = new SessionDiscoveryService({ claudeHomePath, stateDir: tempStateDir });
+
+    const sessions = await discovery.getAgentSessions(agentName, workingDir, false);
+
+    // #424: the poison entry is skipped, the good session survives.
+    expect(sessions.map((s) => s.sessionId)).toEqual([goodId]);
+
+    // #419: warming the caches for the good session tried to write <agent>.json,
+    // the store refused, and the damaged bytes are untouched — still recoverable.
+    const after = await readFile(filePath, "utf-8");
+    expect(after).toBe(CORRUPT_METADATA);
+    expect(after).toContain("Precious user-set name");
+  });
+
+  it("getAllSessions returns the good session, keeps sessionCount in sync, AND preserves the corrupt file", async () => {
+    const filePath = await seedCorruptMetadata();
+
+    const discovery = new SessionDiscoveryService({ claudeHomePath, stateDir: tempStateDir });
+
+    const groups = await discovery.getAllSessions([
+      { name: agentName, workingDirectory: workingDir, dockerEnabled: false },
+    ]);
+
+    const allIds = groups.flatMap((g) => g.sessions.map((s) => s.sessionId));
+    // #424: only the good session is listed; the poison entry is gone.
+    expect(allIds).toContain(goodId);
+    expect(allIds).not.toContain(poisonId);
+
+    // The reported count agrees with the sessions actually returned — a *refused
+    // write* is not a *skipped read entry*, so it must not perturb the count.
+    for (const g of groups) {
+      expect(g.sessionCount).toBe(g.sessions.length);
+    }
+
+    // #419: the corrupt metadata file is preserved byte-for-byte.
+    expect(await readFile(filePath, "utf-8")).toBe(CORRUPT_METADATA);
+  });
+
+  it("does not create or leave any stray/temp metadata file — only the original corrupt one remains", async () => {
+    await seedCorruptMetadata();
+
+    const discovery = new SessionDiscoveryService({ claudeHomePath, stateDir: tempStateDir });
+    await discovery.getAllSessions([
+      { name: agentName, workingDirectory: workingDir, dockerEnabled: false },
+    ]);
+
+    const files = await readdir(join(tempStateDir, "session-metadata"));
+    // Exactly the corrupt file — no empty replacement, no lingering atomic temp.
+    expect(files).toEqual([`${agentName}.json`]);
+  });
+});

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -40,8 +40,14 @@ const mockGetSidechain = vi.fn().mockResolvedValue(undefined);
 const mockBatchSetSidechains = vi.fn().mockResolvedValue(undefined);
 const mockGetUsage = vi.fn().mockResolvedValue(undefined);
 const mockSetUsage = vi.fn().mockResolvedValue(undefined);
-vi.mock("../session-metadata.js", () => {
+// Spread the ACTUAL module so the real `SessionMetadataUnreadableError` and
+// `isSessionMetadataUnreadableError` survive the mock — `persistCacheUpdates`
+// (in session-discovery) calls the guard, and mislabelling it would silently
+// break the #419 refusal path here. Only the store class is replaced.
+vi.mock("../session-metadata.js", async (importActual) => {
+  const actual = await importActual<typeof import("../session-metadata.js")>();
   return {
+    ...actual,
     SessionMetadataStore: class MockSessionMetadataStore {
       getCustomName = mockGetCustomName;
       getAutoName = mockGetAutoName;
@@ -67,6 +73,8 @@ import {
 // Import after mocks
 import { buildAttributionIndex } from "../session-attribution.js";
 import { SessionDiscoveryService } from "../session-discovery.js";
+// Resolves to the REAL class via the `...actual` spread in the mock above.
+import { SessionMetadataUnreadableError } from "../session-metadata.js";
 
 const mockBuildAttributionIndex = vi.mocked(buildAttributionIndex);
 const mockExtractFirstMessagePreview = vi.mocked(extractFirstMessagePreview);
@@ -726,6 +734,80 @@ describe("SessionDiscoveryService", () => {
         const sessions = await service.getAgentSessions("my-agent", workingDir, true);
         expect(sessions.map((s) => s.sessionId)).toEqual(["session-docker"]);
       });
+    });
+  });
+
+  // ===========================================================================
+  // #419 × #424 composition
+  //
+  // #419 makes the metadata setters THROW `SessionMetadataUnreadableError`
+  // instead of silently replacing an unreadable file with an empty one. #424
+  // (#428) wraps per-entry *read* enrichment in try/catch and skips the bad
+  // entry. These must compose so a refused *write* is handled downstream by
+  // `persistCacheUpdates` (warn, keep the listing) and is NOT swallowed by the
+  // per-entry read guard — which would drop the session and mislabel a data-
+  // preserving write refusal as a skipped unreadable entry.
+  //
+  // The write is issued AFTER the per-entry enrichment loop, so its throw lands
+  // in `persistCacheUpdates`, not the read guard. If a future refactor moved the
+  // metadata write inside `enrichAgentSession` (inside the read guard), these go
+  // red: the session would vanish from the listing.
+  // ===========================================================================
+  describe("#419 × #424 composition — a refused metadata write keeps the listing intact", () => {
+    it("getAgentSessions still returns the session when its cache write is refused as unreadable", async () => {
+      const workingDir = "/Users/ed/Code/myproject";
+      const encodedPath = "-Users-ed-Code-myproject";
+      const projectDir = join(tempClaudeHome, "projects", encodedPath);
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "session-abc");
+
+      // Warming the derived caches for this good session tries to persist the
+      // freshly-extracted autoName; the store refuses because the metadata file
+      // is unreadable (rather than clobbering it — #419).
+      mockBatchSetAutoNames.mockRejectedValue(
+        new SessionMetadataUnreadableError("my-agent", "corrupt"),
+      );
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      // Must not reject, and must not drop the (successfully read) session.
+      const sessions = await service.getAgentSessions("my-agent", workingDir, false);
+
+      expect(sessions.map((s) => s.sessionId)).toEqual(["session-abc"]);
+      // The write was actually attempted (so the refusal really was exercised).
+      expect(mockBatchSetAutoNames).toHaveBeenCalled();
+    });
+
+    it("getAllSessions keeps the session and its sessionCount when a cache write is refused", async () => {
+      const workingDir = "/Users/ed/Code/myproject";
+      const encodedPath = "-Users-ed-Code-myproject";
+      const projectDir = join(tempClaudeHome, "projects", encodedPath);
+      await mkdir(projectDir, { recursive: true });
+      await createSessionFile(projectDir, "session-abc");
+
+      mockBatchSetAutoNames.mockRejectedValue(
+        new SessionMetadataUnreadableError("my-agent", "corrupt"),
+      );
+
+      const service = new SessionDiscoveryService({
+        claudeHomePath: tempClaudeHome,
+        stateDir: tempStateDir,
+      });
+
+      const groups = await service.getAllSessions([
+        { name: "my-agent", workingDirectory: workingDir, dockerEnabled: false },
+      ]);
+
+      const group = groups.find((g) => g.encodedPath === encodedPath);
+      expect(group).toBeDefined();
+      expect(group!.sessions.map((s) => s.sessionId)).toEqual(["session-abc"]);
+      // A refused *write* is not a skipped *read* entry: the visible count still
+      // reflects the session that was successfully read and returned.
+      expect(group!.sessionCount).toBe(1);
+      expect(mockBatchSetAutoNames).toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/state/__tests__/session-metadata.test.ts
+++ b/packages/core/src/state/__tests__/session-metadata.test.ts
@@ -2,7 +2,11 @@ import { mkdir, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { SessionMetadataStore } from "../session-metadata.js";
+import {
+  isSessionMetadataUnreadableError,
+  SessionMetadataStore,
+  SessionMetadataUnreadableError,
+} from "../session-metadata.js";
 
 // Helper to create a temp directory
 async function createTempDir(): Promise<string> {
@@ -803,6 +807,211 @@ describe("SessionMetadataStore", () => {
       expect(pruned).toBe(1);
       const metadata = await store.getAgentMetadata("adhoc");
       expect(Object.keys(metadata!.sessions).sort()).toEqual(["dirA-1", "dirA-2", "dirB-1"]);
+    });
+  });
+
+  // ===========================================================================
+  // #419 — writes must never replace an unreadable file with an empty one.
+  //
+  // Before the fix, loadMetadata() collapsed "absent", "read error", and
+  // "corrupt/invalid schema" into the same `null`. Every setter then treated
+  // `null` as "start fresh", so the very next atomicWriteJson replaced the WHOLE
+  // agent file with an empty structure — silently destroying every customName,
+  // preview, autoName, isSidechain and usage entry for that agent.
+  //
+  // The invariant these tests pin down: an ABSENT file may be created; an
+  // UNREADABLE file must be refused (throw), and its bytes left untouched.
+  // ===========================================================================
+  describe("#419 — never clobber an unreadable metadata file", () => {
+    const metadataDirName = "session-metadata";
+
+    /** Write raw bytes straight to an agent's metadata file (bypassing the store). */
+    async function writeRawFile(agentName: string, contents: string): Promise<string> {
+      const metadataDir = join(tempDir, metadataDirName);
+      await mkdir(metadataDir, { recursive: true });
+      const filePath = join(metadataDir, `${agentName}.json`);
+      await writeFile(filePath, contents, "utf-8");
+      return filePath;
+    }
+
+    // A file that WAS a healthy metadata file with two user-set custom names, but
+    // has since been truncated mid-write (disk-full, crash, partial rsync). The
+    // custom-name bytes are still on disk and recoverable — unless we overwrite.
+    const TRUNCATED_BUT_RECOVERABLE =
+      '{"version":1,"agentName":"keeper-paddock","sessions":{' +
+      '"s-1":{"customName":"Ship the release"},' +
+      '"s-2":{"customName":"Investigate #419"';
+
+    describe("absent file (legitimate sparse storage) is still created", () => {
+      it("setCustomName creates an empty structure when no file exists", async () => {
+        await store.setCustomName("fresh-agent", "s-1", "Brand New");
+        expect(await store.getCustomName("fresh-agent", "s-1")).toBe("Brand New");
+      });
+
+      it("setAutoName creates an empty structure when no file exists", async () => {
+        await store.setAutoName("fresh-agent", "s-1", "Auto", "2026-08-01T00:00:00.000Z");
+        expect((await store.getAutoName("fresh-agent", "s-1"))!.autoName).toBe("Auto");
+      });
+    });
+
+    describe("malformed JSON", () => {
+      it("setCustomName throws SessionMetadataUnreadableError and does NOT replace the file", async () => {
+        const filePath = await writeRawFile("keeper-paddock", TRUNCATED_BUT_RECOVERABLE);
+
+        await expect(
+          store.setCustomName("keeper-paddock", "s-3", "New Name"),
+        ).rejects.toBeInstanceOf(SessionMetadataUnreadableError);
+
+        // The damaged bytes are untouched — the recoverable custom names survive.
+        const after = await readFile(filePath, "utf-8");
+        expect(after).toBe(TRUNCATED_BUT_RECOVERABLE);
+        expect(after).toContain("Ship the release");
+        expect(after).toContain("Investigate #419");
+      });
+
+      it("batchSetAutoNames (the discovery cache path) also refuses to overwrite", async () => {
+        const filePath = await writeRawFile("keeper-paddock", TRUNCATED_BUT_RECOVERABLE);
+
+        await expect(
+          store.batchSetAutoNames("keeper-paddock", [
+            { sessionId: "s-9", autoName: "Cache Warm", mtime: "2026-08-01T00:00:00.000Z" },
+          ]),
+        ).rejects.toBeInstanceOf(SessionMetadataUnreadableError);
+
+        expect(await readFile(filePath, "utf-8")).toBe(TRUNCATED_BUT_RECOVERABLE);
+      });
+
+      it("tags the error with the agent name and a 'corrupt' reason", async () => {
+        await writeRawFile("keeper-paddock", "{ not json");
+        const error = await store
+          .setUsage(
+            "keeper-paddock",
+            "s-1",
+            { inputTokens: 1, turnCount: 1, hasData: true },
+            "2026-08-01T00:00:00.000Z",
+          )
+          .catch((e) => e);
+
+        expect(isSessionMetadataUnreadableError(error)).toBe(true);
+        expect(error.agentName).toBe("keeper-paddock");
+        expect(error.reason).toBe("corrupt");
+      });
+    });
+
+    describe("valid JSON that fails schema validation", () => {
+      it("refuses to overwrite a file with an unknown version", async () => {
+        const raw = JSON.stringify({
+          version: 2,
+          agentName: "keeper-paddock",
+          sessions: { "s-1": { customName: "Keep me" } },
+        });
+        const filePath = await writeRawFile("keeper-paddock", raw);
+
+        await expect(
+          store.setPreview("keeper-paddock", "s-2", "hello", "2026-08-01T00:00:00.000Z"),
+        ).rejects.toBeInstanceOf(SessionMetadataUnreadableError);
+
+        expect(await readFile(filePath, "utf-8")).toBe(raw);
+      });
+
+      it("refuses to overwrite a file with a malformed session entry", async () => {
+        // Valid JSON, valid top-level shape, but one entry has a wrong-typed field.
+        const raw = JSON.stringify({
+          version: 1,
+          agentName: "keeper-paddock",
+          sessions: { "s-1": { customName: "Keep me", isSidechain: "not-a-boolean" } },
+        });
+        const filePath = await writeRawFile("keeper-paddock", raw);
+
+        await expect(store.setCustomName("keeper-paddock", "s-2", "New")).rejects.toBeInstanceOf(
+          SessionMetadataUnreadableError,
+        );
+
+        expect(await readFile(filePath, "utf-8")).toBe(raw);
+      });
+    });
+
+    describe("read error that is not ENOENT", () => {
+      // A directory sitting where the metadata file should be makes readFile throw
+      // EISDIR — a deterministic, portable stand-in for the class of non-ENOENT
+      // read failures (EACCES, EIO, a truncated read that never settles). The file
+      // "exists" as far as stat is concerned but cannot be read.
+      it("throws (read-error) rather than treating an unreadable path as absent", async () => {
+        const metadataDir = join(tempDir, metadataDirName);
+        await mkdir(join(metadataDir, "keeper-paddock.json"), { recursive: true });
+
+        const error = await store.setCustomName("keeper-paddock", "s-1", "New").catch((e) => e);
+
+        expect(isSessionMetadataUnreadableError(error)).toBe(true);
+        expect(error.reason).toBe("read-error");
+        // The directory is still there — nothing was written over it.
+        expect((await stat(join(metadataDir, "keeper-paddock.json"))).isDirectory()).toBe(true);
+      });
+    });
+
+    describe("round-trip: existing custom names survive a failed read + write attempt", () => {
+      it("a fresh store (cold cache) preserves recoverable data when a write is attempted", async () => {
+        const filePath = await writeRawFile("keeper-paddock", TRUNCATED_BUT_RECOVERABLE);
+
+        // A brand-new store guarantees the failure isn't masked by a warm cache.
+        const coldStore = new SessionMetadataStore(tempDir);
+
+        await expect(
+          coldStore.setAutoName("keeper-paddock", "s-1", "Auto", "2026-08-01T00:00:00.000Z"),
+        ).rejects.toBeInstanceOf(SessionMetadataUnreadableError);
+
+        // The bytes are byte-for-byte identical: no data destroyed.
+        expect(await readFile(filePath, "utf-8")).toBe(TRUNCATED_BUT_RECOVERABLE);
+      });
+
+      it("does not create a fresh empty file for the agent", async () => {
+        await writeRawFile("keeper-paddock", "{ corrupt");
+
+        await store.setCustomName("keeper-paddock", "s-1", "New").catch(() => {
+          /* expected */
+        });
+
+        // Exactly one file exists (the corrupt one); no sibling temp file lingers
+        // and the corrupt file was not swapped out for an empty structure.
+        const files = await readdir(join(tempDir, metadataDirName));
+        expect(files).toEqual(["keeper-paddock.json"]);
+        expect(await readFile(join(tempDir, metadataDirName, "keeper-paddock.json"), "utf-8")).toBe(
+          "{ corrupt",
+        );
+      });
+    });
+
+    describe("getters degrade gracefully (unchanged read behavior)", () => {
+      it("getCustomName returns undefined (does not throw) for an unreadable file", async () => {
+        await writeRawFile("keeper-paddock", "{ corrupt");
+        await expect(store.getCustomName("keeper-paddock", "s-1")).resolves.toBeUndefined();
+      });
+
+      it("getAgentMetadata returns null (does not throw) for an unreadable file", async () => {
+        await writeRawFile("keeper-paddock", "{ corrupt");
+        await expect(store.getAgentMetadata("keeper-paddock")).resolves.toBeNull();
+      });
+    });
+
+    describe("a transient read failure is not sticky", () => {
+      it("recovers on the next call once the file becomes readable again", async () => {
+        // First: file is a directory (unreadable). A write is refused.
+        const metadataDir = join(tempDir, metadataDirName);
+        const dirPath = join(metadataDir, "keeper-paddock.json");
+        await mkdir(dirPath, { recursive: true });
+
+        await expect(store.setCustomName("keeper-paddock", "s-1", "New")).rejects.toBeInstanceOf(
+          SessionMetadataUnreadableError,
+        );
+
+        // Now the obstruction clears (e.g. the bogus directory is removed). Because
+        // the failure was never cached, the very next call succeeds against a fresh
+        // (absent) file rather than staying wedged.
+        await rm(dirPath, { recursive: true, force: true });
+
+        await store.setCustomName("keeper-paddock", "s-1", "Recovered");
+        expect(await store.getCustomName("keeper-paddock", "s-1")).toBe("Recovered");
+      });
     });
   });
 });

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -98,11 +98,13 @@ export {
 } from "./session-discovery.js";
 // Re-export session metadata functions
 export {
+  isSessionMetadataUnreadableError,
   type SessionMetadataEntry,
   SessionMetadataEntrySchema,
   type SessionMetadataFile,
   SessionMetadataFileSchema,
   SessionMetadataStore,
+  SessionMetadataUnreadableError,
 } from "./session-metadata.js";
 // Re-export session validation functions
 export {

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -33,7 +33,7 @@ import {
   AttributionIndexBuilder,
   type SessionOrigin,
 } from "./session-attribution.js";
-import { SessionMetadataStore } from "./session-metadata.js";
+import { isSessionMetadataUnreadableError, SessionMetadataStore } from "./session-metadata.js";
 import { mapWithConcurrency } from "./utils/concurrency.js";
 
 // =============================================================================
@@ -772,17 +772,44 @@ export class SessionDiscoveryService {
     }
 
     // Batch write any cache updates
-    if (autoNameUpdates.length > 0) {
-      await this.sessionMetadataStore.batchSetAutoNames(agentName, autoNameUpdates);
-    }
-    if (previewUpdates.length > 0) {
-      await this.sessionMetadataStore.batchSetPreviews(agentName, previewUpdates);
-    }
-    if (sidechainUpdates.length > 0) {
-      await this.sessionMetadataStore.batchSetSidechains(agentName, sidechainUpdates);
-    }
+    await this.persistCacheUpdates(async () => {
+      if (autoNameUpdates.length > 0) {
+        await this.sessionMetadataStore.batchSetAutoNames(agentName, autoNameUpdates);
+      }
+      if (previewUpdates.length > 0) {
+        await this.sessionMetadataStore.batchSetPreviews(agentName, previewUpdates);
+      }
+      if (sidechainUpdates.length > 0) {
+        await this.sessionMetadataStore.batchSetSidechains(agentName, sidechainUpdates);
+      }
+    });
 
     return sessions;
+  }
+
+  /**
+   * Persist enrichment cache updates, tolerating a refusal to overwrite an
+   * unreadable/corrupt metadata file (issue #419).
+   *
+   * These writes only warm derived caches (autoName / preview / sidechain /
+   * usage) — never user data. A poisoned metadata file for one agent must not
+   * abort a whole listing, so a {@link SessionMetadataUnreadableError} is logged
+   * and swallowed: the cache simply stays cold and the next listing re-extracts.
+   * The store leaves the damaged file untouched, so nothing is lost. Any other
+   * error (e.g. a genuine write failure) still propagates unchanged.
+   */
+  private async persistCacheUpdates(writes: () => Promise<void>): Promise<void> {
+    try {
+      await writes();
+    } catch (error) {
+      if (isSessionMetadataUnreadableError(error)) {
+        logger.warn(
+          `Skipping session-metadata cache update for "${error.agentName}": ${error.message}`,
+        );
+        return;
+      }
+      throw error;
+    }
   }
 
   /**
@@ -1117,15 +1144,17 @@ export class SessionDiscoveryService {
       }
 
       // Batch write any cache updates for this directory
-      if (autoNameUpdates.length > 0) {
-        await this.sessionMetadataStore.batchSetAutoNames(dir.metadataKey, autoNameUpdates);
-      }
-      if (previewUpdates.length > 0) {
-        await this.sessionMetadataStore.batchSetPreviews(dir.metadataKey, previewUpdates);
-      }
-      if (sidechainUpdates.length > 0) {
-        await this.sessionMetadataStore.batchSetSidechains(dir.metadataKey, sidechainUpdates);
-      }
+      await this.persistCacheUpdates(async () => {
+        if (autoNameUpdates.length > 0) {
+          await this.sessionMetadataStore.batchSetAutoNames(dir.metadataKey, autoNameUpdates);
+        }
+        if (previewUpdates.length > 0) {
+          await this.sessionMetadataStore.batchSetPreviews(dir.metadataKey, previewUpdates);
+        }
+        if (sidechainUpdates.length > 0) {
+          await this.sessionMetadataStore.batchSetSidechains(dir.metadataKey, sidechainUpdates);
+        }
+      });
 
       if (sessions.length > 0) {
         groups.push({
@@ -1303,7 +1332,9 @@ export class SessionDiscoveryService {
     }
 
     const usage = await extractSessionUsage(filePath);
-    await this.sessionMetadataStore.setUsage(agentName, sessionId, usage, mtimeStr);
+    await this.persistCacheUpdates(() =>
+      this.sessionMetadataStore.setUsage(agentName, sessionId, usage, mtimeStr),
+    );
     return usage;
   }
 

--- a/packages/core/src/state/session-metadata.ts
+++ b/packages/core/src/state/session-metadata.ts
@@ -78,6 +78,56 @@ export const SessionMetadataFileSchema = z.object({
 export type SessionMetadataEntry = z.infer<typeof SessionMetadataEntrySchema>;
 export type SessionMetadataFile = z.infer<typeof SessionMetadataFileSchema>;
 
+/**
+ * Thrown by write operations when an agent's existing metadata file exists but
+ * could not be read or parsed.
+ *
+ * Rather than silently replacing an unreadable file with a fresh empty one —
+ * which would destroy every `customName`/`preview`/`autoName`/`isSidechain`/
+ * `usage` entry it held (issue #419) — the store refuses to write and surfaces
+ * this error. The damaged file is left untouched on disk so its bytes remain
+ * recoverable.
+ */
+export class SessionMetadataUnreadableError extends Error {
+  public readonly agentName: string;
+  /** Why the file was rejected: a read failure, or a schema/JSON parse failure. */
+  public readonly reason: "read-error" | "corrupt";
+
+  constructor(agentName: string, reason: "read-error" | "corrupt", cause?: Error) {
+    super(
+      `Refusing to overwrite session metadata for "${agentName}": the existing file is ` +
+        `${reason === "corrupt" ? "corrupt" : "unreadable"} (${cause?.message ?? "unknown error"}). ` +
+        `Left it untouched to avoid destroying its contents.`,
+    );
+    this.name = "SessionMetadataUnreadableError";
+    this.agentName = agentName;
+    this.reason = reason;
+    this.cause = cause;
+  }
+}
+
+/**
+ * Type guard for {@link SessionMetadataUnreadableError}.
+ */
+export function isSessionMetadataUnreadableError(
+  error: unknown,
+): error is SessionMetadataUnreadableError {
+  return error instanceof SessionMetadataUnreadableError;
+}
+
+/**
+ * Internal result of attempting to read an agent's metadata file.
+ *
+ * Distinguishes the three outcomes that a plain `SessionMetadataFile | null`
+ * used to collapse together: the file is legitimately absent (sparse storage is
+ * by design), or it exists but is unreadable/corrupt. Only the last must block
+ * writes — treating it as "empty" is the #419 data-loss bug.
+ */
+type MetadataReadResult =
+  | { status: "loaded"; metadata: SessionMetadataFile }
+  | { status: "absent" }
+  | { status: "unreadable"; reason: "read-error" | "corrupt"; error: Error };
+
 // =============================================================================
 // SessionMetadataStore
 // =============================================================================
@@ -125,40 +175,87 @@ export class SessionMetadataStore {
   }
 
   /**
-   * Load metadata for an agent from disk (or cache)
+   * Read an agent's metadata file (or cache), distinguishing absent from
+   * unreadable.
+   *
+   * The cache only ever holds successfully-parsed files, so a transient read
+   * failure is never cached — it does not become sticky and a later read
+   * retries the file.
    */
-  private async loadMetadata(agentName: string): Promise<SessionMetadataFile | null> {
+  private async readMetadata(agentName: string): Promise<MetadataReadResult> {
     // Check cache first
     const cached = this.cache.get(agentName);
     if (cached !== undefined) {
-      return cached;
+      return { status: "loaded", metadata: cached };
     }
 
     const filePath = this.getFilePath(agentName);
     const result = await safeReadJson<unknown>(filePath);
 
     if (!result.success) {
-      // File not found is expected for sparse storage
+      // File not found is expected for sparse storage.
       if (result.error.code === "ENOENT") {
-        return null;
+        return { status: "absent" };
       }
 
+      // Any other failure means the file exists but we can't turn it into
+      // trustworthy metadata — an I/O error (EACCES, EIO, EISDIR, ...) or a
+      // JSON.parse failure on truncated/garbled bytes. Crucially this is NOT
+      // "absent": a write here would clobber real data. Distinguish the two only
+      // for diagnostics — an errno `code` marks an I/O failure; its absence marks
+      // a content/parse failure surfaced as a SyntaxError.
+      const reason = result.error.code ? "read-error" : "corrupt";
       logger.warn(`Failed to read metadata file for ${agentName}: ${result.error.message}`);
-      return null;
+      return { status: "unreadable", reason, error: result.error };
     }
 
     // Validate the file structure
     const parseResult = SessionMetadataFileSchema.safeParse(result.data);
     if (!parseResult.success) {
-      logger.warn(
-        `Corrupted metadata file for ${agentName}: ${parseResult.error.message}. Returning null.`,
-      );
-      return null;
+      logger.warn(`Corrupted metadata file for ${agentName}: ${parseResult.error.message}.`);
+      return { status: "unreadable", reason: "corrupt", error: parseResult.error };
     }
 
     // Cache and return
     this.cache.set(agentName, parseResult.data);
-    return parseResult.data;
+    return { status: "loaded", metadata: parseResult.data };
+  }
+
+  /**
+   * Load metadata for reading.
+   *
+   * Returns `null` when the file is absent OR unreadable — read-side callers
+   * (getters) degrade gracefully rather than throwing; a temporarily unreadable
+   * file just means "no cached metadata to show right now". Write-side callers
+   * must use {@link loadForWrite} instead, which refuses to proceed on an
+   * unreadable file so it can never clobber real data (issue #419).
+   */
+  private async loadMetadata(agentName: string): Promise<SessionMetadataFile | null> {
+    const result = await this.readMetadata(agentName);
+    return result.status === "loaded" ? result.metadata : null;
+  }
+
+  /**
+   * Load metadata for a read-modify-write update.
+   *
+   * - Absent file → a fresh empty structure (sparse storage; correct to create).
+   * - Loaded file → the parsed contents, ready to mutate.
+   * - Unreadable/corrupt file → throws {@link SessionMetadataUnreadableError}
+   *   WITHOUT writing, leaving the damaged file untouched. Silently substituting
+   *   an empty structure here is exactly the #419 data-loss bug: the subsequent
+   *   {@link saveMetadata} (atomicWriteJson) would replace the whole file,
+   *   destroying every entry it held.
+   */
+  private async loadForWrite(agentName: string): Promise<SessionMetadataFile> {
+    const result = await this.readMetadata(agentName);
+    switch (result.status) {
+      case "loaded":
+        return result.metadata;
+      case "absent":
+        return this.createEmptyMetadata(agentName);
+      case "unreadable":
+        throw new SessionMetadataUnreadableError(agentName, result.reason, result.error);
+    }
   }
 
   /**
@@ -216,11 +313,7 @@ export class SessionMetadataStore {
    * @param name - The custom name to set
    */
   async setCustomName(agentName: string, sessionId: string, name: string): Promise<void> {
-    let metadata = await this.loadMetadata(agentName);
-
-    if (!metadata) {
-      metadata = this.createEmptyMetadata(agentName);
-    }
+    const metadata = await this.loadForWrite(agentName);
 
     // Get or create the session entry
     const sessionEntry = metadata.sessions[sessionId] ?? {};
@@ -331,11 +424,7 @@ export class SessionMetadataStore {
     autoName: string,
     mtime: string,
   ): Promise<void> {
-    let metadata = await this.loadMetadata(agentName);
-
-    if (!metadata) {
-      metadata = this.createEmptyMetadata(agentName);
-    }
+    const metadata = await this.loadForWrite(agentName);
 
     // Get or create the session entry
     const sessionEntry = metadata.sessions[sessionId] ?? {};
@@ -372,11 +461,7 @@ export class SessionMetadataStore {
       return;
     }
 
-    let metadata = await this.loadMetadata(agentName);
-
-    if (!metadata) {
-      metadata = this.createEmptyMetadata(agentName);
-    }
+    const metadata = await this.loadForWrite(agentName);
 
     // Apply all updates. `autoName` may be undefined — that records a validated
     // *negative* result (this transcript has no summary at this mtime) so the
@@ -438,11 +523,7 @@ export class SessionMetadataStore {
     preview: string,
     mtime: string,
   ): Promise<void> {
-    let metadata = await this.loadMetadata(agentName);
-
-    if (!metadata) {
-      metadata = this.createEmptyMetadata(agentName);
-    }
+    const metadata = await this.loadForWrite(agentName);
 
     const sessionEntry = metadata.sessions[sessionId] ?? {};
 
@@ -477,11 +558,7 @@ export class SessionMetadataStore {
       return;
     }
 
-    let metadata = await this.loadMetadata(agentName);
-
-    if (!metadata) {
-      metadata = this.createEmptyMetadata(agentName);
-    }
+    const metadata = await this.loadForWrite(agentName);
 
     // `preview` may be undefined — records a validated negative result (no
     // plain-text user line at this mtime) so the next listing trusts the cache.
@@ -545,11 +622,7 @@ export class SessionMetadataStore {
       return;
     }
 
-    let metadata = await this.loadMetadata(agentName);
-
-    if (!metadata) {
-      metadata = this.createEmptyMetadata(agentName);
-    }
+    const metadata = await this.loadForWrite(agentName);
 
     for (const { sessionId, isSidechain, mtime } of entries) {
       const sessionEntry = metadata.sessions[sessionId] ?? {};
@@ -657,11 +730,7 @@ export class SessionMetadataStore {
     usage: NonNullable<SessionMetadataEntry["usage"]>,
     mtime: string,
   ): Promise<void> {
-    let metadata = await this.loadMetadata(agentName);
-
-    if (!metadata) {
-      metadata = this.createEmptyMetadata(agentName);
-    }
+    const metadata = await this.loadForWrite(agentName);
 
     const sessionEntry = metadata.sessions[sessionId] ?? {};
 


### PR DESCRIPTION
Fixes #419.

## The bug (verified against `src/`, not `dist/`)

`SessionMetadataStore.loadMetadata()` collapsed **three distinct outcomes into the same `null`**:

1. **ENOENT** — file absent. Legitimate; storage is sparse by design.
2. **Any other read error** (EACCES, EIO, EISDIR, a truncated read that never settled) — logged `warn`, returned `null`.
3. **Schema validation failure** (`safeParse`) — logged, returned `null`.

Every one of the **7 setters** then did `metadata ??= createEmptyMetadata()` and called `saveMetadata` → `atomicWriteJson`, which **replaces the whole file**. So for cases 2 and 3, the next write silently replaced the entire agent file with a fresh empty one, destroying every `customName`, `preview`, `autoName`, `isSidechain` and `usage` entry for that agent. Because the atomic write *succeeds*, it looked like a clean write — no error surfaced.

A single failed read followed by one write is enough, and **a session listing warming its caches performs exactly that read-then-write** — so this triggers in normal operation, not just under exotic disk faults.

Ed's report was accurate. One correction: the in-memory `this.cache` is typed `Map<string, SessionMetadataFile>` and **only ever stored successfully-parsed files** — it never cached `null`, so a transient failure wasn't already sticky. The fix preserves that property (and a test pins it down).

## The fix

- Reads and writes now go through an internal discriminated `readMetadata()` returning `{ status: "loaded" | "absent" | "unreadable" }`.
- **Absent → `createEmptyMetadata()`** — unchanged, correct for sparse storage.
- **Unreadable/corrupt → refuse to write.** A new `loadForWrite()` (used by all 7 setters) throws `SessionMetadataUnreadableError` **without writing**, leaving the damaged file byte-for-byte on disk so it stays recoverable.
- **Getters unchanged.** `loadMetadata()` still returns `null` on absent *or* unreadable, so `getCustomName`/`getAgentMetadata`/etc. degrade gracefully instead of throwing.
- **`session-discovery` background cache-warming** (`batchSet*` / `setUsage`) wraps its writes in `persistCacheUpdates`, which swallows only `SessionMetadataUnreadableError` (logs a warn) and rethrows anything else. A poisoned metadata file for one agent no longer aborts a whole listing — the cache just stays cold and re-extracts next time. This matters because discovery's cache-warming is itself a primary trigger of the bug.
- **User-initiated writes** (`fleet-manager.setSessionName` → `setCustomName`) let the error propagate, so a failure to persist a name surfaces loudly rather than nuking the file.
- `SessionMetadataUnreadableError` and `isSessionMetadataUnreadableError` are exported from `@herdctl/core`.

## Tests

New `#419` describe block in `session-metadata.test.ts`, each asserting **the file is NOT replaced**:
- absent file → empty metadata created (existing behaviour preserved)
- malformed / truncated JSON → throws, bytes untouched (incl. the discovery `batchSet*` path)
- valid JSON failing `safeParse` (`version: 2`; malformed session entry) → throws, bytes untouched
- non-ENOENT read error (EISDIR via a directory at the file path) → throws with `reason: "read-error"`, obstruction untouched
- **round-trip:** a cold-cache store attempting a write against a truncated-but-recoverable file preserves it byte-for-byte
- getters still return `undefined`/`null` (no throw) for an unreadable file
- a transient failure is not sticky — the next call recovers once the file is readable again

`pnpm typecheck`, `pnpm build`, and the core suite pass (3494 passed). The one failing test locally — `directory.test.ts › throws StateDirectoryCreateError when parent directory is not writable` — is pre-existing and environmental: it `chmod 0o444`s a dir and expects a write to fail, which root bypasses. It's untouched by this change and passes in CI (non-root).

## Relationship to #428 (`fix/424-unreadable-session-entry`)

Overlapping file, independent bug. **#428 fixes #424** ("one unreadable transcript entry throws and blanks the whole listing") by isolating per-entry *read* enrichment in try/catch. **This PR fixes #419** ("a failed *read* makes the metadata file get overwritten with an empty one") in `session-metadata.ts`, which #428 does not touch (its test mocks the store out entirely, so it never exercises the overwrite path — I verified #428 does **not** fix #419).

The two are complementary and follow the same house convention #428 settled on — *skip/tolerate + `logger.warn`, don't blank a listing* — for the background path; the only place this PR throws is the store setter, so genuine user writes fail loudly instead of destroying data. Both edit `session-discovery.ts`, so whichever lands second will need a trivial merge resolution (my `persistCacheUpdates` wraps the batch writes that run *after* #428's per-entry try/catch). Happy to rebase on #428 if it lands first.

## Deliberately NOT bundled (separate tickets)

- **#426** — `session-discovery.ts` `usageMtime >= mtimeStr` should be `===` (and keyed on `{mtime, size}` like `job-index.ts`); `>=` validates an entry stamped *newer* than its file forever, and mtime moves backwards on `cp`/`rsync` without `-p` and on restic restores. Lives in the same file #428 edits.
- **#427** — `setUsage` has no `batchSetUsage`, so every call rewrites the whole file (~389 MB of writes to warm 1,520 sessions).

Both are genuinely separable and neither blocks #419 landing on its own, so they're left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
