### PR TITLE
feat(state): filter listJobs by a set of agents, and page /api/jobs inside it (#418)

### DIFF
--- a/.changeset/feat-418-listjobs-agents-filter.md
+++ b/.changeset/feat-418-listjobs-agents-filter.md
@@ -4,8 +4,8 @@
 
 feat(state): filter `listJobs` by a SET of agents, and page the dashboard's `/api/jobs` inside it
 
-#415 made `listJobs` index-backed, but only for callers that can express what
-they want as a filter. A caller that needs several agents' jobs had no way to
+Issue `#415` made `listJobs` index-backed, but only for callers that can express
+what they want as a filter. A caller that needs several agents' jobs had no way to
 say so — `ListJobsFilter` had `agent` (exactly one) and nothing else — so it had
 to list the directory unfiltered and filter in JS, which reads, parses and
 Zod-validates every record in the directory to return a handful.

--- a/.changeset/feat-418-listjobs-agents-filter.md
+++ b/.changeset/feat-418-listjobs-agents-filter.md
@@ -1,0 +1,46 @@
+---
+"@herdctl/core": minor
+---
+
+feat(state): filter `listJobs` by a SET of agents, and page the dashboard's `/api/jobs` inside it
+
+#415 made `listJobs` index-backed, but only for callers that can express what
+they want as a filter. A caller that needs several agents' jobs had no way to
+say so — `ListJobsFilter` had `agent` (exactly one) and nothing else — so it had
+to list the directory unfiltered and filter in JS, which reads, parses and
+Zod-validates every record in the directory to return a handful.
+
+`ListJobsFilter` gains **`agents?: string[]`**. It combines with `agent` as an
+AND, and an empty array matches nothing (rather than being treated as "no
+filter", which would silently turn "I have no agents to look up" back into a
+full directory scan). Measured on a 2,016-record, 47.4 MB jobs directory, warm:
+
+| call | time |
+| --- | --- |
+| `listJobs(dir)` + JS filter + `.slice(200)` | 1,935–2,095 ms |
+| `listJobs(dir, { agents, limit: 200 })` | 125–146 ms |
+
+**~15×**, and the results are identical — the returned ids and their order were
+diffed against the JS-filtering shape on that real corpus, and in a unit test
+that interleaves four agents across time so any per-agent grouping would
+reorder.
+
+Note that `agents` alone is not enough to get this win. With `limit` undefined
+the index retains every match, so callers must pass **both** `agents` and
+`limit`; the `listJobs` docs now say so, with the numbers.
+
+**`packages/web`'s `/api/jobs` now pages inside `listJobs`** instead of asking
+for everything and slicing. It is a paginated, user-facing endpoint that
+returns at most 100 records, and it was hydrating the entire jobs directory on
+every request — the exact pathology #415 set out to remove, in our own
+dashboard. `total` now comes from `ListJobsResult.total` (the pre-pagination
+match count, added by #415 for precisely this) rather than from the length of a
+list that is no longer the full result.
+
+Unblocks [paddock#535](https://github.com/edspencer/paddock/issues/535), whose
+`listRunsForAgents` is the same bug downstream.
+
+The remaining unfiltered callers named in #418 are deliberately left alone here:
+`applyRetention` genuinely wants every record, and deleting the caller-less
+public `buildAttributionIndex` is a breaking change that deserves its own
+decision rather than riding along with a perf fix.

--- a/packages/core/src/state/__tests__/job-metadata.test.ts
+++ b/packages/core/src/state/__tests__/job-metadata.test.ts
@@ -417,6 +417,125 @@ describe("listJobs", () => {
     });
   });
 
+  describe("filtering by agents (set)", () => {
+    it("returns jobs for every listed agent and nothing else", async () => {
+      await createJob(tempDir, { agent: "agent-a", trigger_type: "manual" });
+      await createJob(tempDir, { agent: "agent-b", trigger_type: "manual" });
+      await createJob(tempDir, { agent: "agent-c", trigger_type: "manual" });
+
+      const result = await listJobs(tempDir, { agents: ["agent-a", "agent-c"] });
+
+      expect(result.jobs).toHaveLength(2);
+      expect(result.jobs.map((j) => j.agent).sort()).toEqual(["agent-a", "agent-c"]);
+    });
+
+    it("treats an EMPTY array as matching nothing, not as no filter", async () => {
+      // The alternative reading — empty means unfiltered — would silently turn a
+      // caller's "I have no agents to look up" into "hydrate the whole directory",
+      // which is the exact pathology this filter exists to remove.
+      await createJob(tempDir, { agent: "agent-a", trigger_type: "manual" });
+
+      const result = await listJobs(tempDir, { agents: [] });
+
+      expect(result.jobs).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it("ignores listed agents that have no jobs", async () => {
+      await createJob(tempDir, { agent: "agent-a", trigger_type: "manual" });
+
+      const result = await listJobs(tempDir, { agents: ["agent-a", "never-ran"] });
+
+      expect(result.jobs).toHaveLength(1);
+      expect(result.jobs[0].agent).toBe("agent-a");
+    });
+
+    it("combines with `agent` as an AND, narrowing to the intersection", async () => {
+      await createJob(tempDir, { agent: "agent-a", trigger_type: "manual" });
+      await createJob(tempDir, { agent: "agent-b", trigger_type: "manual" });
+
+      const both = await listJobs(tempDir, {
+        agent: "agent-a",
+        agents: ["agent-a", "agent-b"],
+      });
+      expect(both.jobs).toHaveLength(1);
+      expect(both.jobs[0].agent).toBe("agent-a");
+
+      const disjoint = await listJobs(tempDir, { agent: "agent-a", agents: ["agent-b"] });
+      expect(disjoint.jobs).toEqual([]);
+    });
+
+    it("combines with status", async () => {
+      const job = await createJob(tempDir, { agent: "agent-a", trigger_type: "manual" });
+      await updateJob(tempDir, job.id, { status: "completed" });
+      await createJob(tempDir, { agent: "agent-b", trigger_type: "manual" });
+
+      const result = await listJobs(tempDir, {
+        agents: ["agent-a", "agent-b"],
+        status: "completed",
+      });
+
+      expect(result.jobs).toHaveLength(1);
+      expect(result.jobs[0].agent).toBe("agent-a");
+    });
+
+    it("reports the pre-pagination match count in `total`", async () => {
+      for (let i = 0; i < 5; i++) {
+        await createJob(tempDir, { agent: "agent-a", trigger_type: "manual" });
+      }
+      await createJob(tempDir, { agent: "agent-z", trigger_type: "manual" });
+
+      const result = await listJobs(tempDir, { agents: ["agent-a"], limit: 2 });
+
+      expect(result.jobs).toHaveLength(2);
+      expect(result.total).toBe(5);
+    });
+
+    /**
+     * The migration guard for downstream callers (paddock#535).
+     *
+     * The shape this filter replaces is "list the directory unfiltered, filter to
+     * a set of agents in JS, then slice" — which hydrates every record to return a
+     * handful. Swapping it for `{ agents, limit }` is only safe if it yields the
+     * SAME records in the SAME order, so assert that equivalence against the old
+     * shape directly rather than trusting that both paths happen to sort.
+     */
+    it("returns the identical set AND order as filtering in JS", async () => {
+      const agents = ["keeper-x", "trigger-x-nightly", "sweeper-x", "keeper-other"];
+      // Interleaved across time, so any per-agent grouping would reorder the result.
+      for (let i = 0; i < 24; i++) {
+        await writeJobFile(tempDir, {
+          id: `job-2024-01-15-i${String(i).padStart(5, "0")}`,
+          agent: agents[i % agents.length],
+          trigger_type: "manual",
+          status: "completed",
+          started_at: new Date(Date.UTC(2024, 0, 15, 0, i)).toISOString(),
+          schedule: null,
+          exit_reason: null,
+          session_id: null,
+          forked_from: null,
+          finished_at: null,
+          duration_seconds: null,
+          prompt: null,
+          summary: null,
+          output_file: null,
+        });
+      }
+      const wanted = ["keeper-x", "trigger-x-nightly"];
+      const limit = 7;
+
+      // The old shape: unfiltered, filtered in JS, then sliced.
+      const unfiltered = await listJobs(tempDir);
+      const oldWay = unfiltered.jobs.filter((j) => wanted.includes(j.agent)).slice(0, limit);
+
+      // The new shape: pushed down into the index.
+      const newWay = (await listJobs(tempDir, { agents: wanted, limit })).jobs;
+
+      expect(newWay.map((j) => j.id)).toEqual(oldWay.map((j) => j.id));
+      expect(newWay).toHaveLength(limit);
+    });
+  });
+
   describe("filtering by status", () => {
     it("returns only jobs with specified status", async () => {
       const job1 = await createJob(tempDir, {

--- a/packages/core/src/state/job-metadata.ts
+++ b/packages/core/src/state/job-metadata.ts
@@ -52,6 +52,23 @@ export type JobMetadataUpdates = Partial<
 export interface ListJobsFilter {
   /** Filter by agent name */
   agent?: string;
+  /**
+   * Filter by a SET of agent names — the multi-agent form of {@link agent}.
+   *
+   * A caller that wants several agents' jobs (a dashboard grouping runs by
+   * agent, Paddock's Triggers tab pulling one project's agent plus each of its
+   * scoped trigger agents) otherwise has to list the directory unfiltered and
+   * filter in JS, which defeats the index entirely: every record is read,
+   * parsed and validated only to be discarded.
+   *
+   * Combines with {@link agent} as an AND, so passing both narrows to their
+   * intersection. An EMPTY array matches nothing, which is the useful reading —
+   * "jobs for these zero agents" is empty, not unfiltered.
+   *
+   * Pass {@link limit} alongside this. On its own it still leaves `limit`
+   * undefined, and the retention rule below then holds every match in memory.
+   */
+  agents?: string[];
   /** Filter by job status */
   status?: JobStatus;
   /** Filter jobs started on or after this date (ISO string or Date) */
@@ -301,13 +318,20 @@ export async function getJob(
 /**
  * List all jobs, optionally filtered
  *
- * Supports filtering by agent, status, and date range. Returns jobs
- * sorted by started_at in descending order (most recent first).
+ * Supports filtering by one agent, a SET of agents, status, and date range.
+ * Returns jobs sorted by started_at in descending order (most recent first).
  *
  * Filtering, sorting and pagination run against a cached, mtime-keyed index of
  * each job file's `agent`/`status`/`started_at` (see `job-index.ts`), so only the
  * records actually returned are read and parsed in full. Passing `limit` is
  * therefore much cheaper than slicing the result.
+ *
+ * **Push your filter and your limit down here rather than slicing the result.**
+ * With `limit` undefined the index retains every match, so `listJobs(dir)`
+ * followed by a JS `.filter().slice()` reads, parses and validates the entire
+ * directory to return a handful of records. Measured on a 2,016-record dir:
+ * `listJobs(dir)` 2,400 ms versus `listJobs(dir, { agents, limit: 200 })`
+ * 160 ms. `agents` without `limit` still retains everything — pass both.
  *
  * @param jobsDir - Path to the jobs directory
  * @param filter - Optional filter criteria
@@ -328,6 +352,12 @@ export async function getJob(
  *   startedAfter: yesterday,
  *   limit: 20
  * });
+ *
+ * // The most recent 200 jobs across a SET of agents, in one indexed pass
+ * const { jobs } = await listJobs('/path/to/.herdctl/jobs', {
+ *   agents: ['keeper-paddock', 'trigger-paddock-night-watch'],
+ *   limit: 200
+ * });
  * ```
  */
 export async function listJobs(
@@ -340,9 +370,14 @@ export async function listJobs(
   // Parse date filters once
   const startedAfter = filter.startedAfter ? toDate(filter.startedAfter).getTime() : undefined;
   const startedBefore = filter.startedBefore ? toDate(filter.startedBefore).getTime() : undefined;
+  // Built once, not per record: `matches` runs for every file in the directory.
+  // Deliberately `undefined` vs `Set` rather than checking `.length`, so an
+  // EMPTY `agents` array is a filter that matches nothing rather than no filter.
+  const agentSet = filter.agents ? new Set(filter.agents) : undefined;
 
   const matches = (record: JobIndexRecord): boolean => {
     if (filter.agent && record.agent !== filter.agent) return false;
+    if (agentSet && !agentSet.has(record.agent)) return false;
     if (filter.status && record.status !== filter.status) return false;
     if (startedAfter !== undefined && record.startedAtMs < startedAfter) return false;
     if (startedBefore !== undefined && record.startedAtMs > startedBefore) return false;

--- a/packages/web/src/server/__tests__/routes.test.ts
+++ b/packages/web/src/server/__tests__/routes.test.ts
@@ -265,7 +265,7 @@ describe("Job Routes", () => {
         },
       ];
 
-      mockListJobs.mockResolvedValue({ jobs: mockJobs, errors: [] });
+      mockListJobs.mockResolvedValue({ jobs: mockJobs, errors: [], total: 2 });
 
       const response = await server.inject({
         method: "GET",
@@ -280,6 +280,15 @@ describe("Job Routes", () => {
       expect(body.offset).toBe(0);
     });
 
+    /**
+     * Pagination lives INSIDE listJobs, not in this route.
+     *
+     * These used to slice `result.jobs` after the fact, which meant the route
+     * asked for the whole jobs directory — every record read, parsed and
+     * validated — to return at most 100. The mock therefore now behaves like the
+     * real `listJobs`: it applies offset/limit itself and reports the
+     * pre-pagination match count as `total`.
+     */
     it("respects limit and offset query params", async () => {
       const manyJobs = Array.from({ length: 10 }, (_, i) => ({
         id: `job-${i}`,
@@ -289,7 +298,11 @@ describe("Job Routes", () => {
         started_at: "2025-01-01T00:00:00Z",
       }));
 
-      mockListJobs.mockResolvedValue({ jobs: manyJobs, errors: [] });
+      mockListJobs.mockImplementation(async (_dir: string, filter: any) => {
+        const offset = filter?.offset ?? 0;
+        const limit = filter?.limit ?? manyJobs.length;
+        return { jobs: manyJobs.slice(offset, offset + limit), errors: [], total: manyJobs.length };
+      });
 
       const response = await server.inject({
         method: "GET",
@@ -305,8 +318,38 @@ describe("Job Routes", () => {
       expect(body.offset).toBe(2);
     });
 
+    it("pushes pagination DOWN into listJobs rather than slicing its result", async () => {
+      // The regression this guards: with `limit` undefined, listJobs retains and
+      // hydrates every match, so a paginated endpoint that slices afterwards
+      // reads the entire jobs directory on every request (2,400 ms vs 160 ms on
+      // a 2,016-record dir).
+      mockListJobs.mockResolvedValue({ jobs: [], errors: [], total: 0 });
+
+      await server.inject({ method: "GET", url: "/api/jobs?limit=10&offset=30" });
+
+      expect(mockListJobs).toHaveBeenCalledWith("/tmp/test-state/jobs", {
+        limit: 10,
+        offset: 30,
+      });
+    });
+
+    it("reports the pre-pagination match count as `total`, not the page size", async () => {
+      mockListJobs.mockResolvedValue({
+        jobs: [
+          { id: "job-1", agent: "coder", status: "completed", started_at: "2025-01-01T00:00:00Z" },
+        ],
+        errors: [],
+        total: 137,
+      });
+
+      const response = await server.inject({ method: "GET", url: "/api/jobs?limit=1" });
+
+      expect(response.json().jobs).toHaveLength(1);
+      expect(response.json().total).toBe(137);
+    });
+
     it("clamps limit to max 100", async () => {
-      mockListJobs.mockResolvedValue({ jobs: [], errors: [] });
+      mockListJobs.mockResolvedValue({ jobs: [], errors: [], total: 0 });
 
       const response = await server.inject({
         method: "GET",
@@ -315,6 +358,12 @@ describe("Job Routes", () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.json().limit).toBe(100);
+      // The clamped value is what reaches listJobs, so the cap actually bounds
+      // the work rather than just the reported number.
+      expect(mockListJobs).toHaveBeenCalledWith("/tmp/test-state/jobs", {
+        limit: 100,
+        offset: 0,
+      });
     });
 
     it("passes filter params to listJobs", async () => {
@@ -325,9 +374,12 @@ describe("Job Routes", () => {
         url: "/api/jobs?agentName=coder&status=running",
       });
 
+      // The default page is passed down too, not applied afterwards.
       expect(mockListJobs).toHaveBeenCalledWith("/tmp/test-state/jobs", {
         agent: "coder",
         status: "running",
+        limit: 50,
+        offset: 0,
       });
     });
 

--- a/packages/web/src/server/__tests__/routes.test.ts
+++ b/packages/web/src/server/__tests__/routes.test.ts
@@ -8,7 +8,7 @@
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { AgentNotFoundError } from "@herdctl/core";
+import { AgentNotFoundError, type ListJobsFilter } from "@herdctl/core";
 import Fastify, { type FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { registerAgentRoutes } from "../routes/agents.js";
@@ -265,7 +265,7 @@ describe("Job Routes", () => {
         },
       ];
 
-      mockListJobs.mockResolvedValue({ jobs: mockJobs, errors: [], total: 2 });
+      mockListJobs.mockResolvedValue({ jobs: mockJobs, errors: 0, total: 2 });
 
       const response = await server.inject({
         method: "GET",
@@ -298,10 +298,10 @@ describe("Job Routes", () => {
         started_at: "2025-01-01T00:00:00Z",
       }));
 
-      mockListJobs.mockImplementation(async (_dir: string, filter: any) => {
+      mockListJobs.mockImplementation(async (_dir: string, filter: ListJobsFilter) => {
         const offset = filter?.offset ?? 0;
         const limit = filter?.limit ?? manyJobs.length;
-        return { jobs: manyJobs.slice(offset, offset + limit), errors: [], total: manyJobs.length };
+        return { jobs: manyJobs.slice(offset, offset + limit), errors: 0, total: manyJobs.length };
       });
 
       const response = await server.inject({
@@ -323,7 +323,7 @@ describe("Job Routes", () => {
       // hydrates every match, so a paginated endpoint that slices afterwards
       // reads the entire jobs directory on every request (2,400 ms vs 160 ms on
       // a 2,016-record dir).
-      mockListJobs.mockResolvedValue({ jobs: [], errors: [], total: 0 });
+      mockListJobs.mockResolvedValue({ jobs: [], errors: 0, total: 0 });
 
       await server.inject({ method: "GET", url: "/api/jobs?limit=10&offset=30" });
 
@@ -338,7 +338,7 @@ describe("Job Routes", () => {
         jobs: [
           { id: "job-1", agent: "coder", status: "completed", started_at: "2025-01-01T00:00:00Z" },
         ],
-        errors: [],
+        errors: 0,
         total: 137,
       });
 
@@ -349,7 +349,7 @@ describe("Job Routes", () => {
     });
 
     it("clamps limit to max 100", async () => {
-      mockListJobs.mockResolvedValue({ jobs: [], errors: [], total: 0 });
+      mockListJobs.mockResolvedValue({ jobs: [], errors: 0, total: 0 });
 
       const response = await server.inject({
         method: "GET",
@@ -367,7 +367,7 @@ describe("Job Routes", () => {
     });
 
     it("passes filter params to listJobs", async () => {
-      mockListJobs.mockResolvedValue({ jobs: [], errors: [] });
+      mockListJobs.mockResolvedValue({ jobs: [], errors: 0 });
 
       await server.inject({
         method: "GET",

--- a/packages/web/src/server/routes/jobs.ts
+++ b/packages/web/src/server/routes/jobs.ts
@@ -97,16 +97,22 @@ export function registerJobRoutes(
         filter.status = status;
       }
 
-      // List all matching jobs (listJobs already sorts by started_at desc)
-      const result = await listJobsFn(jobsDir, filter);
+      // Page inside listJobs rather than slicing its result. With `limit`
+      // undefined it retains every match, so this paginated endpoint read,
+      // parsed and validated the ENTIRE jobs directory on every request to
+      // return at most 100 records — measured at 2,400 ms versus 160 ms on a
+      // 2,016-record dir. `total` keeps reporting the pre-pagination match
+      // count, which `ListJobsResult` returns for exactly this reason.
+      filter.limit = clampedLimit;
+      filter.offset = clampedOffset;
 
-      // Apply pagination
-      const paginatedJobs = result.jobs.slice(clampedOffset, clampedOffset + clampedLimit);
+      // listJobs sorts by started_at desc, then applies offset/limit.
+      const result = await listJobsFn(jobsDir, filter);
 
       const agents = fleetManager.getAgents();
       return reply.send({
-        jobs: paginatedJobs.map((j) => mapJobToSummary(j, agents)),
-        total: result.jobs.length,
+        jobs: result.jobs.map((j) => mapJobToSummary(j, agents)),
+        total: result.total,
         limit: clampedLimit,
         offset: clampedOffset,
         errors: result.errors,


### PR DESCRIPTION
Closes #418 (items 1 and 2). Unblocks edspencer/paddock#535.

## The problem

#415 made `listJobs` index-backed, but only for callers that can express what they want as a **filter**. `ListJobsFilter` had `agent` — exactly one — so a caller needing *several* agents' jobs had no way to say so. It had to list the directory unfiltered and filter in JS:

```ts
const { jobs } = await listJobs(jobsDir);          // hydrates EVERYTHING
const filtered = jobs.filter((j) => wanted.has(j.agent));
return filtered.slice(0, limit);
```

With `limit` undefined, `retain = matches`, so every record in the directory is read, YAML-parsed and Zod-validated — to return a handful.

## The change

**1. `ListJobsFilter` gains `agents?: string[]`.**

- ANDs with `agent` (passing both narrows to the intersection).
- An **empty array matches nothing**, deliberately. The other reading — empty means unfiltered — would silently turn a caller's "I have no agents to look up" back into a full directory scan.

**2. `packages/web`'s `/api/jobs` pages inside `listJobs`** instead of asking for everything and slicing. It is a paginated, user-facing endpoint returning at most 100 records, and it was hydrating the entire jobs directory on every request — #415's own pathology, in our own dashboard. `total` now comes from `ListJobsResult.total` (the pre-pagination match count #415 added for exactly this) rather than the length of a list that is no longer the full result.

## Measured

Against an isolated production-scale copy (2,016 records, 47.4 MB of `.yaml`), warm, two reps:

| call | time |
|---|---|
| `listJobs(dir)` + JS filter + `.slice(200)` | **1,935–2,095 ms** |
| `listJobs(dir, { agents, limit: 200 })` | **125–146 ms** |

**~15×.**

> The absolute numbers run about 2× higher than the 1,106 ms recorded in #418 — that measurement was taken on a quieter box. The ratio is what reproduces.

## Correctness

The downstream caller cares about **order**, not just membership, so equivalence is asserted rather than assumed:

- On the **real corpus**: returned ids and their order diffed against the JS-filtering shape — identical for n=200.
- In a **unit test**: four agents interleaved across 24 timestamps so that any per-agent grouping would reorder the result, then `{ agents, limit }` diffed against `listJobs(dir)` + `.filter()` + `.slice()`.

Also covered: empty array matches nothing, unknown agents ignored, AND-composition with `agent` and with `status`, and `total` as the pre-pagination count.

## Note for callers

`agents` **alone is not enough**. With `limit` still undefined, `retain = matches` and every match is hydrated regardless. Callers must pass **both**. The `listJobs` doc comment now says so with the numbers, since the failure mode is silent — you get correct results at full cost.

## Deliberately out of scope

Both named in #418:

- **`applyRetention`** genuinely wants every record — correct as-is.
- **Deleting `buildAttributionIndex`** is a breaking change to a public export with ~25 tests and a mock anchor. It deserves its own decision and probably a deprecation cycle, rather than riding along with a perf fix.

## Tests

- `packages/core` `job-metadata.test.ts`: **47 passed** (7 new)
- `packages/web` `routes.test.ts`: **42 passed** (2 new; 3 updated — they asserted the old slice-after-the-fact shape, so the mock now behaves like the real `listJobs` and applies `offset`/`limit` itself)
- `packages/core` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering for jobs associated with multiple agents.
  * Combined agent filters are supported, including empty-list behavior.

* **Performance**
  * Improved job listing pagination by applying limits and offsets earlier.
  * Job totals now reflect all matching results, not just the current page.

* **Bug Fixes**
  * Improved pagination behavior alongside job filters.
  * Added safeguards for maximum page sizes and default pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->