### PR TITLE
fix(core): adopt only unattributed sessions, never a sibling agent's (#437)

### DIFF
--- a/.changeset/lucky-poems-fetch.md
+++ b/.changeset/lucky-poems-fetch.md
@@ -1,0 +1,50 @@
+---
+"@herdctl/core": patch
+---
+
+Fix session adoption offering — and silently losing — sessions owned by another agent (#437)
+
+`scanAdoptionCandidates` asked "is this session **native**?" when it needed to
+ask "is this session **unattributed**?". `triggerTypeToOrigin` folds `manual`,
+`webhook`, `chat` and `fork` into `origin: "native"`, so a session with a real
+job record under a *sibling* agent resolved to
+`{ origin: "native", agentName: "sweeper-x" }` — natively originated, but firmly
+someone else's. It passed the adoption gate and then failed the per-agent
+listing gate (`agentName !== agentName`).
+
+The result was an adoption record that could never win the precedence contest
+(job → platform → adopted → native): inert by construction. The import reported
+success, the session never appeared, and the burnt marker read as
+`already-adopted` on every retry — silent and unrecoverable. Measured on a real
+corpus, 1502 of 1531 candidates (98.1%) carried a sibling-agent job record; one
+workspace reported "imported 1382" and 26 appeared. Any app that points several
+agents at one working directory hits this every time.
+
+- **Only unattributed sessions are adoptable.** `listAdoptableSessions` and
+  `adoptSessionsFrom` now skip anything an agent already owns — including the
+  adopting agent itself, whose sessions are already visible and so have nothing
+  to import.
+- **One shared predicate.** The listing gate and the adoption gate encoded the
+  same question in two places and drifted; that drift *was* the bug. Both now
+  derive from `isOwnedByAgent` in `session-attribution.ts`, with the adopt-time
+  gate defined as "would the listing gate pass afterwards"
+  (`canAgentAdopt = isOwnedByAgent(attributionAfterAdoptionBy(...))`). Two
+  invariants follow and are covered by tests: anything the scan offers, the
+  adopt path accepts; anything the adopt path accepts is then visible.
+- **Refusal at the write site, not just the scan.** `adoptSession` throws the
+  new `SessionAdoptionRefusedError`, and `adoptSessionsFrom` re-checks each
+  candidate immediately before recording it and reports a skip instead. The scan
+  and the write are separate calls — separated by minutes of file copying in a
+  large import, well past the attribution cache TTL — so a sibling's run can
+  land in between. Turning that into a legible skip is what keeps it
+  recoverable.
+- **`AdoptSkippedSession.ownedBy`** (new, optional) names the owning agent on
+  `attributed-to-run` and `already-adopted` skips, so a UI can distinguish
+  "belongs to another agent" from "already yours". Deliberately a field rather
+  than a new `AdoptSkipReason` member, which would break consumers that switch
+  on the reason exhaustively.
+
+Behaviour change worth noting: `adoptSession` now throws where it previously
+returned an inert record, and `listAdoptableSessions` no longer offers sessions
+the agent already owns via a job record. Adopting genuine terminal `claude`
+history — the case adoption exists for — is unaffected.

--- a/docs/src/content/docs/architecture/session-discovery.md
+++ b/docs/src/content/docs/architecture/session-discovery.md
@@ -360,8 +360,8 @@ const discovery = new SessionDiscoveryService({
 | `getSessionMetadata(workDir, sessionId)` | Get metadata for a session (cached) |
 | `getSessionUsage(workDir, sessionId)` | Get token usage data for a session |
 | `invalidateCache(workDir?)` | Clear cached data for a specific directory or all caches |
-| `listAdoptableSessions(agentName, workDir, fromWorkingDir?)` | List native transcripts an agent could adopt (see [Session Adoption](#session-adoption)) |
-| `adoptSession(agentName, sessionId, opts)` | Record an adoption claim for a single session, moving nothing |
+| `listAdoptableSessions(agentName, workDir, fromWorkingDir?)` | List unattributed transcripts an agent could adopt (see [Session Adoption](#session-adoption)) |
+| `adoptSession(agentName, sessionId, opts)` | Record an adoption claim for a single session, moving nothing. Refuses if another agent owns it |
 | `adoptSessionsFrom(agentName, workDir, opts?)` | Place and claim every adoptable session found in a directory |
 | `unadoptSession(sessionId, opts?)` | Remove an adoption record, leaving the transcript on disk |
 
@@ -436,13 +436,34 @@ This is a **dedicated store rather than a forged job record**. A job record mean
 | Method | Purpose |
 |--------|---------|
 | `listAdoptableSessions(name, fromWorkingDir?)` | Candidates for adoption, newest first -- backs an "import my existing chats" picker |
-| `adoptSession(name, sessionId, opts?)` | Claim one session by ID. Records attribution only; moves nothing. Idempotent |
+| `adoptSession(name, sessionId, opts?)` | Claim one session by ID. Records attribution only; moves nothing. Idempotent; throws `SessionAdoptionRefusedError` if another agent owns it |
 | `adoptSessionsFrom(name, opts?)` | Place and claim every adoptable session in a directory |
 | `unadoptSession(name, sessionId)` | Release this agent's claim. The transcript stays on disk |
 
 An `AdoptableSession` is deliberately **not** a `DiscoveredSession`: half of that shape is meaningless before adoption. Its `origin` is by definition `native`, its `agentName` by definition undefined (that is *why* it is invisible), `resumable` is a property of the adopting agent rather than of the candidate, and `customName` is keyed per agent. What a picker needs is which session, what it looks like, when it was last touched, and where it came from -- so the shape is `sessionId`, `sourceCwd`, `mtime`, `autoName`, `preview` and `sizeBytes`. There is no message count: obtaining one means streaming the whole transcript, which is exactly the per-session cost the listing caches exist to avoid. `sizeBytes` comes free from the `stat()` the directory listing already performs.
 
 `unadoptSession()` returns `false` -- rather than removing anything -- when the session is not adopted, or when it is adopted by a *different* agent. One agent must not be able to drop another's claim.
+
+### Only unattributed sessions are adoptable
+
+Adoption is read **last** in the precedence order, so a claim on a session some other agent already owns is inert by construction: the record is written, the job or platform record still wins, and the session never appears under the adopting agent. Worse, the burnt record then reads as `already-adopted` and excludes the session from every retry.
+
+The gate is therefore "is this session **unattributed**?", not "is its origin `native`?". Those are not the same question, because `triggerTypeToOrigin()` folds `manual`, `webhook`, `chat` and `fork` into `native` -- a session with a real job record under a sibling agent is `{ origin: "native", agentName: "sweeper-x" }`, natively-originated but firmly someone else's. Where a keeper and its sweeper share one transcript directory, that is the overwhelming majority of the folder.
+
+One set of predicates in `session-attribution.ts` answers the question for every caller, and the adoption gate is defined *in terms of* the listing gate so the two cannot drift apart:
+
+| Predicate | Question | Used by |
+|-----------|----------|---------|
+| `isOwnedByAgent(attr, agent)` | Will this session appear under `agent`? | The per-agent listing gate |
+| `isUnattributed(attr)` | Does *nobody* own this session? | The adoption scan |
+| `attributionAfterAdoptionBy(attr, agent)` | What would attribution resolve to after `agent` adopted it? | -- |
+| `canAgentAdopt(attr, agent)` | Would that record actually take effect? | The adopt-time guard |
+
+`canAgentAdopt()` is literally `isOwnedByAgent(attributionAfterAdoptionBy(...))`, which gives two invariants: anything the scan offers, the adopt path accepts; and anything the adopt path accepts is visible to the adopting agent afterwards.
+
+`canAgentAdopt()` is deliberately looser than `isUnattributed()`. A session the agent already owns is not offered by the picker -- it is already there, so there is nothing to import -- but re-claiming it is a harmless no-op rather than something to refuse. A session another agent merely *adopted* is adoptable too: `recordAdoption()` overwrites, so adoption records do not outrank a later adoption the way job and platform records do.
+
+The guard runs at the **write** sites as well as at the scan. `adoptSession()` refuses with `SessionAdoptionRefusedError`; `adoptSessionsFrom()` re-checks each candidate immediately before recording it and reports a skip instead. The scan and the write are separate calls -- and in a large import, separated by minutes of file copying, well past the attribution cache TTL -- so a sibling agent's run can land in between and make the scan's verdict stale. Turning that into a legible skip is what keeps it recoverable.
 
 ### Placement
 
@@ -460,7 +481,7 @@ Copies preserve the source mtime deliberately: mtime drives both list ordering a
 
 **Existing destination files are never overwritten, and that is enforced by the placement syscall rather than by a pre-check.** The caller does `stat()` the destination first, but only to produce a tidy `destination-exists` skip: a check-then-act pre-check cannot see a writer that arrives a microsecond later, and it cannot see a destination `stat()` itself fails on -- a dangling symlink, which is exactly what an earlier cross-device `link` placement leaves behind once the user deletes the original, reads as ENOENT. So each mode creates the destination exclusively: `copy` uses `COPYFILE_EXCL`, `link` uses `link()`/`symlink()`, and `move` -- notably -- does **not** use `rename()`, which silently replaces an existing destination on every platform. It hard-links and then unlinks the source, which is the same net effect (one inode, mtime carried for free) but refuses an occupied destination. An `EEXIST` from any of them is reported as the same `destination-exists` skip. A `move` is the one placement that also destroys the source, so a clobber there would lose both copies of a chat.
 
-Every candidate that is not adopted appears in `skipped` with a reason a UI can show verbatim -- `sidechain`, `already-adopted`, `destination-exists`, `attributed-to-run`, `unreadable`, `placement-failed`, `record-failed` -- and one bad transcript never aborts the batch. With `dryRun: true` nothing at all is written, and the result describes what would have happened. "Nothing" includes the sidechain metadata *cache*: classifying a candidate as a sidechain is a fact the scan learns anyway, but writing it back would create `session-metadata/<agent>.json` on a preview, so the scan takes a flag that suppresses the cache write under a dry run.
+Every candidate that is not adopted appears in `skipped` with a reason a UI can show verbatim -- `sidechain`, `already-adopted`, `destination-exists`, `attributed-to-run`, `unreadable`, `placement-failed`, `record-failed` -- and one bad transcript never aborts the batch. A skip caused by an existing owner also carries `ownedBy`, the owning agent's qualified name; compare it against the adopting agent to tell "belongs to another agent" from "already yours". That is a field rather than a second skip reason so consumers that switch exhaustively on `AdoptSkipReason` keep compiling. With `dryRun: true` nothing at all is written, and the result describes what would have happened. "Nothing" includes the sidechain metadata *cache*: classifying a candidate as a sidechain is a fact the scan learns anyway, but writing it back would create `session-metadata/<agent>.json` on a preview, so the scan takes a flag that suppresses the cache write under a dry run.
 
 `adoptSessionsFrom()` returns an empty result when the agent has no configured `working_directory`, even when `fromWorkingDir` is given: placement needs the agent's own transcript folder as its destination, and the per-agent listing is scoped to that same directory. `listAdoptableSessions()` differs -- it falls back to `fromWorkingDir` -- so it can list candidates that `adoptSessionsFrom()` then adopts none of. Single-session `adoptSession()` moves nothing and needs no working directory.
 

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -918,6 +918,10 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
    *
    * Idempotent — re-adopting the same session rewrites the record cleanly.
    *
+   * Refuses a session that a *different* agent already owns through a job record
+   * or a platform binding: those outrank adoption, so the record would be inert
+   * and the session would never appear under this agent (herdctl#437).
+   *
    * @param name - The agent qualified or local name
    * @param sessionId - The Claude Code session ID to adopt
    * @param opts.sourceCwd - Working directory the transcript was recorded under.
@@ -926,6 +930,8 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
    * @throws {InvalidStateError} If the fleet manager is not yet initialized
    * @throws {AgentNotFoundError} If no agent with that name exists
    * @throws {PathTraversalError} If `sessionId` is not a safe identifier
+   * @throws {SessionAdoptionRefusedError} If another agent already owns the
+   *   session
    */
   async adoptSession(
     name: string,
@@ -946,9 +952,10 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
   }
 
   /**
-   * List the sessions an agent could adopt from a working directory: native,
-   * non-sidechain transcripts that aren't already adopted and aren't attributed
-   * to a real run.
+   * List the sessions an agent could adopt from a working directory:
+   * *unattributed*, non-sidechain transcripts — not already adopted, and not
+   * owned by any agent through a job record or a platform binding (including
+   * this one, which would already show them).
    *
    * Intended to back an "import my existing chats" picker — each entry carries a
    * title, a preview, an mtime and its source directory. Resolved against this
@@ -1004,7 +1011,15 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
    * Every candidate that is not adopted appears in `skipped` with a reason
    * (`"sidechain"`, `"already-adopted"`, `"destination-exists"`,
    * `"attributed-to-run"`, `"unreadable"`, `"placement-failed"`,
-   * `"record-failed"`), and one bad transcript never aborts the batch.
+   * `"record-failed"`), and one bad transcript never aborts the batch. A skip
+   * caused by an existing owner also carries `ownedBy` — compare it against the
+   * agent's own qualified name to tell "belongs to another agent" from "already
+   * yours".
+   *
+   * Only *unattributed* transcripts are adopted. A session another agent owns is
+   * skipped rather than claimed: adoption loses the precedence contest to job
+   * and platform records, so claiming it would report success and then never
+   * show the session (herdctl#437).
    *
    * With `dryRun: true` nothing at all is written — no transcripts placed, no
    * adoption records, not even a metadata cache file — and the result describes

--- a/packages/core/src/state/__tests__/session-adoption-sibling-agent.test.ts
+++ b/packages/core/src/state/__tests__/session-adoption-sibling-agent.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for herdctl#437 — adoption must offer only *unattributed* sessions.
+ *
+ * `scanAdoptionCandidates` used to gate on `attribution.origin !== "native"`,
+ * but `triggerTypeToOrigin` folds `manual`, `webhook`, `chat` and `fork` into
+ * `"native"`. So a session with a genuine job record under a **sibling agent**
+ * resolved to `{ origin: "native", agentName: "sweeper-x" }`: it passed the
+ * adoption gate (its origin really is native) and then failed the listing gate
+ * in `enrichAgentSession` (`attribution.agentName !== agentName`). The adoption
+ * record was written, lost the precedence contest (job → platform → adopted →
+ * native), and the session was reported as imported while never appearing —
+ * and, because the marker was burned, was excluded from every retry.
+ *
+ * Everything here is REAL: real transcripts, real job records, real adoption
+ * store, real attribution index. That is the whole point — the fixtures used
+ * while #423 was developed had **no job records at all**, which is why every
+ * earlier test passed.
+ *
+ * Working directories live under `/srv/herdctl437/...` rather than a temp path
+ * because `getAllSessions` filters out anything under `os.tmpdir()` as scratch.
+ * Only their *encoding* matters; they never have to exist on disk.
+ */
+
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import yaml from "yaml";
+import { encodePathForCli } from "../../runner/runtime/cli-session-path.js";
+import { getAdoption, listAdoptions, recordAdoption } from "../adopted-sessions.js";
+import { SessionAdoptionRefusedError } from "../errors.js";
+import type { TriggerType } from "../schemas/job-metadata.js";
+import { SessionDiscoveryService } from "../session-discovery.js";
+
+/** The agent doing the adopting. */
+const AGENT = "keeper-myproject";
+/** A different agent sharing the same transcript directory. */
+const SIBLING = "sweeper-myproject";
+
+/** Trigger types that `triggerTypeToOrigin` folds into `"native"`. */
+const NATIVE_TRIGGER_TYPES = ["manual", "webhook", "chat", "fork"] as const;
+
+/** A realistic CLI transcript for a session recorded in `workingDirectory`. */
+function transcript(workingDirectory: string, sessionId: string): string {
+  return `${JSON.stringify({
+    type: "user",
+    uuid: `u-${sessionId}`,
+    sessionId,
+    cwd: workingDirectory,
+    isSidechain: false,
+    timestamp: "2026-07-01T09:00:00.000Z",
+    message: { role: "user", content: `work in ${workingDirectory}` },
+  })}\n`;
+}
+
+describe("session adoption vs sibling-agent attribution (herdctl#437)", () => {
+  let tempRoot: string;
+  let claudeHome: string;
+  let stateDir: string;
+  /** The adopting agent's own working directory (adoption destination). */
+  let agentDir: string;
+  /** A different directory the user ran `claude` in (adoption source). */
+  let otherDir: string;
+  let jobSeq = 0;
+
+  const dirFor = (workingDirectory: string) =>
+    path.join(claudeHome, "projects", encodePathForCli(workingDirectory));
+
+  async function writeTranscript(
+    workingDirectory: string,
+    sessionId: string,
+    options: { mtime?: Date } = {},
+  ): Promise<string> {
+    const dir = dirFor(workingDirectory);
+    await mkdir(dir, { recursive: true });
+    const file = path.join(dir, `${sessionId}.jsonl`);
+    await writeFile(file, transcript(workingDirectory, sessionId));
+    if (options.mtime) {
+      await utimes(file, options.mtime, options.mtime);
+    }
+    return file;
+  }
+
+  /**
+   * Write a real `job-<id>.yaml` claiming `sessionId` for `agent`.
+   *
+   * This is the fixture the #423 tests never had. `AttributionIndexBuilder`
+   * reads these files straight out of `<stateDir>/jobs/`, so nothing is mocked.
+   */
+  async function writeJobRecord(
+    agent: string,
+    sessionId: string,
+    triggerType: TriggerType = "chat",
+  ): Promise<void> {
+    const jobsDir = path.join(stateDir, "jobs");
+    await mkdir(jobsDir, { recursive: true });
+    jobSeq += 1;
+    const id = `job-2026-07-01-${String(jobSeq).padStart(6, "0")}`;
+    await writeFile(
+      path.join(jobsDir, `${id}.yaml`),
+      yaml.stringify({
+        id,
+        agent,
+        trigger_type: triggerType,
+        status: "completed",
+        exit_reason: "success",
+        session_id: sessionId,
+        started_at: "2026-07-01T09:00:00.000Z",
+        finished_at: "2026-07-01T09:05:00.000Z",
+      }),
+    );
+  }
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), "session-adoption-437-"));
+    claudeHome = path.join(tempRoot, "claude-home");
+    stateDir = path.join(tempRoot, ".herdctl");
+    const unique = path.basename(tempRoot).replace(/[^A-Za-z0-9]/g, "");
+    agentDir = `/srv/herdctl437/${unique}/agent`;
+    otherDir = `/srv/herdctl437/${unique}/terminal`;
+    await mkdir(stateDir, { recursive: true });
+    await mkdir(path.join(claudeHome, "projects"), { recursive: true });
+    jobSeq = 0;
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true, maxRetries: 3 });
+  });
+
+  function makeService(options?: { cacheTtlMs?: number }) {
+    return new SessionDiscoveryService({ stateDir, claudeHomePath: claudeHome, ...options });
+  }
+
+  // ===========================================================================
+  // The scan gate
+  // ===========================================================================
+
+  describe("listAdoptableSessions", () => {
+    it("does not offer a session owned by a sibling agent", async () => {
+      await writeTranscript(otherDir, "sess-sibling");
+      await writeJobRecord(SIBLING, "sess-sibling", "chat");
+
+      const listed = await makeService().listAdoptableSessions(AGENT, agentDir, otherDir);
+
+      expect(listed.map((s) => s.sessionId)).toEqual([]);
+    });
+
+    it.each(
+      NATIVE_TRIGGER_TYPES,
+    )("does not offer a sibling-owned session with trigger_type %s (folds to origin native)", async (triggerType) => {
+      await writeTranscript(otherDir, `sess-${triggerType}`);
+      await writeJobRecord(SIBLING, `sess-${triggerType}`, triggerType);
+
+      const listed = await makeService().listAdoptableSessions(AGENT, agentDir, otherDir);
+
+      expect(listed.map((s) => s.sessionId)).toEqual([]);
+    });
+
+    it("still offers a genuinely unattributed transcript alongside an owned one", async () => {
+      await writeTranscript(otherDir, "sess-free");
+      await writeTranscript(otherDir, "sess-owned");
+      await writeJobRecord(SIBLING, "sess-owned", "chat");
+
+      const listed = await makeService().listAdoptableSessions(AGENT, agentDir, otherDir);
+
+      expect(listed.map((s) => s.sessionId)).toEqual(["sess-free"]);
+    });
+
+    it("does not offer a session the adopting agent already owns via its own job record", async () => {
+      // The same-agent case behaves DIFFERENTLY from the sibling case and would
+      // pass a naive regression test: this session is already visible under the
+      // agent, so an adoption record buys nothing. Pinned so the distinction
+      // cannot quietly collapse into "any job record is a sibling's".
+      await writeTranscript(agentDir, "sess-mine");
+      await writeJobRecord(AGENT, "sess-mine", "chat");
+
+      const service = makeService();
+      const listed = await service.listAdoptableSessions(AGENT, agentDir);
+      const visible = await service.getAgentSessions(AGENT, agentDir, false);
+
+      expect(listed.map((s) => s.sessionId)).toEqual([]);
+      // ...because it is already there, not because it is hidden.
+      expect(visible.map((s) => s.sessionId)).toEqual(["sess-mine"]);
+    });
+
+    it("control: a `web` job record was already excluded before the fix", async () => {
+      // `trigger_type: "web"` maps to origin "web", so the OLD `origin !==
+      // "native"` gate already caught it. A regression test built on this
+      // trigger type passes against the unfixed code and proves nothing — it is
+      // kept only to document why the four native-folding types above matter.
+      await writeTranscript(otherDir, "sess-web");
+      await writeJobRecord(SIBLING, "sess-web", "web");
+
+      const listed = await makeService().listAdoptableSessions(AGENT, agentDir, otherDir);
+
+      expect(listed.map((s) => s.sessionId)).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // The batch adopt path
+  // ===========================================================================
+
+  describe("adoptSessionsFrom", () => {
+    it("skips a sibling-owned session and names the owner", async () => {
+      await writeTranscript(otherDir, "sess-sibling");
+      await writeJobRecord(SIBLING, "sess-sibling", "chat");
+
+      const result = await makeService().adoptSessionsFrom(AGENT, agentDir, {
+        fromWorkingDir: otherDir,
+      });
+
+      expect(result.adopted).toEqual([]);
+      expect(result.skipped).toEqual([
+        expect.objectContaining({
+          sessionId: "sess-sibling",
+          reason: "attributed-to-run",
+          ownedBy: SIBLING,
+        }),
+      ]);
+      // Nothing inert was written, so a retry is still possible.
+      expect(await listAdoptions(stateDir)).toEqual([]);
+    });
+
+    it("reports exactly the sessions that then become visible", async () => {
+      // The headline symptom: "Imported 96 chats" while the chat count moves by
+      // 2. Every id in `adopted` must actually show up under the agent.
+      await writeTranscript(otherDir, "sess-free-a");
+      await writeTranscript(otherDir, "sess-free-b");
+      for (const id of ["sess-owned-a", "sess-owned-b", "sess-owned-c"]) {
+        await writeTranscript(otherDir, id);
+        await writeJobRecord(SIBLING, id, "chat");
+      }
+
+      const service = makeService();
+      const result = await service.adoptSessionsFrom(AGENT, agentDir, {
+        fromWorkingDir: otherDir,
+      });
+      const visible = await service.getAgentSessions(AGENT, agentDir, false);
+
+      expect(result.adopted.sort()).toEqual(["sess-free-a", "sess-free-b"]);
+      expect(visible.map((s) => s.sessionId).sort()).toEqual(result.adopted.sort());
+    });
+
+    it("refuses a candidate that becomes sibling-owned between the scan and the write", async () => {
+      // The scan and the write are separated by real I/O (a 1500-transcript
+      // import runs for minutes), so the scan's verdict can go stale. Simulate
+      // that by writing the sibling's job record from inside the first
+      // placement, with the attribution cache disabled so the write-site guard
+      // genuinely re-reads state.
+      // Explicit mtimes: candidates are scanned newest-first, so this pins
+      // `sess-a` as the first placement and `sess-b` as the one the sibling
+      // claims mid-batch.
+      await writeTranscript(otherDir, "sess-a", { mtime: new Date("2026-07-02T00:00:00Z") });
+      await writeTranscript(otherDir, "sess-b", { mtime: new Date("2026-07-01T00:00:00Z") });
+
+      type Placer = { placeTranscript: (...a: unknown[]) => Promise<void> };
+      const service = makeService({ cacheTtlMs: 0 });
+      const real = (service as unknown as Placer).placeTranscript;
+      const place = vi
+        .spyOn(service as unknown as Placer, "placeTranscript")
+        .mockImplementation(async (...args: unknown[]) => {
+          await writeJobRecord(SIBLING, "sess-b", "manual");
+          place.mockRestore();
+          return real.apply(service, args);
+        });
+
+      const result = await service.adoptSessionsFrom(AGENT, agentDir, {
+        fromWorkingDir: otherDir,
+      });
+
+      expect(result.adopted).toEqual(["sess-a"]);
+      expect(result.skipped).toEqual([
+        expect.objectContaining({
+          sessionId: "sess-b",
+          reason: "attributed-to-run",
+          ownedBy: SIBLING,
+        }),
+      ]);
+      expect(await getAdoption(stateDir, "sess-b")).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // The single-session adopt path
+  // ===========================================================================
+
+  describe("adoptSession", () => {
+    it("refuses a session that became sibling-owned between the scan and the adopt", async () => {
+      await writeTranscript(agentDir, "sess-race");
+
+      const service = makeService();
+      const listed = await service.listAdoptableSessions(AGENT, agentDir);
+      expect(listed.map((s) => s.sessionId)).toEqual(["sess-race"]);
+
+      // A sibling's run lands between the picker rendering and the user clicking.
+      await writeJobRecord(SIBLING, "sess-race", "chat");
+      // Drops the attribution index too, standing in for the TTL lapsing.
+      service.invalidateWorkingDirectory(agentDir);
+
+      await expect(
+        service.adoptSession(AGENT, "sess-race", { workingDirectory: agentDir }),
+      ).rejects.toBeInstanceOf(SessionAdoptionRefusedError);
+
+      // The refusal must leave no inert record behind, or the retry path is dead.
+      expect(await getAdoption(stateDir, "sess-race")).toBeNull();
+    });
+
+    it("carries the owning agent on the refusal", async () => {
+      await writeTranscript(agentDir, "sess-owned");
+      await writeJobRecord(SIBLING, "sess-owned", "fork");
+
+      const error = await makeService()
+        .adoptSession(AGENT, "sess-owned", { workingDirectory: agentDir })
+        .then(
+          () => null,
+          (e: unknown) => e as SessionAdoptionRefusedError,
+        );
+
+      expect(error).toBeInstanceOf(SessionAdoptionRefusedError);
+      expect(error?.sessionId).toBe("sess-owned");
+      expect(error?.ownedBy).toBe(SIBLING);
+      expect(error?.message).toContain(SIBLING);
+    });
+
+    it("still allows claiming a session this agent already owns (idempotent no-op)", async () => {
+      // Same-agent again: the record cannot win precedence either, but the
+      // session is already visible under the agent, so refusing would break a
+      // legitimate re-claim.
+      await writeTranscript(agentDir, "sess-mine");
+      await writeJobRecord(AGENT, "sess-mine", "chat");
+
+      const record = await makeService().adoptSession(AGENT, "sess-mine", {
+        workingDirectory: agentDir,
+      });
+
+      expect(record.agentName).toBe(AGENT);
+    });
+
+    it("still allows re-adopting a session another agent had merely adopted", async () => {
+      // Adoption records do NOT outrank a later adoption — `recordAdoption`
+      // overwrites — so this one really would take effect and must be allowed.
+      await writeTranscript(agentDir, "sess-handover");
+      await recordAdoption(stateDir, "sess-handover", { agentName: SIBLING });
+
+      const service = makeService();
+      const record = await service.adoptSession(AGENT, "sess-handover", {
+        workingDirectory: agentDir,
+      });
+
+      expect(record.agentName).toBe(AGENT);
+      const visible = await service.getAgentSessions(AGENT, agentDir, false);
+      expect(visible.map((s) => s.sessionId)).toEqual(["sess-handover"]);
+    });
+
+    it("still allows adopting a genuinely unattributed session", async () => {
+      await writeTranscript(agentDir, "sess-free");
+
+      const service = makeService();
+      const record = await service.adoptSession(AGENT, "sess-free", {
+        workingDirectory: agentDir,
+      });
+
+      expect(record.agentName).toBe(AGENT);
+      const visible = await service.getAgentSessions(AGENT, agentDir, false);
+      expect(visible.map((s) => s.sessionId)).toEqual(["sess-free"]);
+    });
+  });
+});

--- a/packages/core/src/state/__tests__/session-attribution.test.ts
+++ b/packages/core/src/state/__tests__/session-attribution.test.ts
@@ -5,7 +5,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import yaml from "yaml";
 import { recordAdoption } from "../adopted-sessions.js";
 import type { JobMetadata, JobStatus, TriggerType } from "../schemas/job-metadata.js";
-import { AttributionIndexBuilder, buildAttributionIndex } from "../session-attribution.js";
+import {
+  AttributionIndexBuilder,
+  attributionAfterAdoptionBy,
+  buildAttributionIndex,
+  canAgentAdopt,
+  isOwnedByAgent,
+  isUnattributed,
+  type SessionAttribution,
+} from "../session-attribution.js";
 
 // Mock listJobs
 vi.mock("../job-metadata.js", () => ({
@@ -1040,5 +1048,129 @@ describe("AttributionIndexBuilder (incremental)", () => {
     index = await builder.build(tempDir);
     expect(index.getAttribute("sess-1").agentName).toBeUndefined();
     expect(index.size).toBe(0);
+  });
+});
+
+// =============================================================================
+// Ownership predicates (herdctl#437)
+// =============================================================================
+
+describe("ownership predicates", () => {
+  const nativeUnowned: SessionAttribution = {
+    origin: "native",
+    agentName: undefined,
+    triggerType: undefined,
+  };
+  /** The shape that caused #437: a real job record whose trigger folds to native. */
+  const siblingJob: SessionAttribution = {
+    origin: "native",
+    agentName: "sweeper-x",
+    triggerType: "chat",
+  };
+  const ownJob: SessionAttribution = {
+    origin: "native",
+    agentName: "keeper-x",
+    triggerType: "chat",
+  };
+  const webRun: SessionAttribution = {
+    origin: "web",
+    agentName: "sweeper-x",
+    triggerType: "web",
+  };
+  const adoptedBySibling: SessionAttribution = {
+    origin: "adopted",
+    agentName: "sweeper-x",
+    triggerType: undefined,
+  };
+
+  describe("isUnattributed", () => {
+    it("is true only when nobody owns the session", () => {
+      expect(isUnattributed(nativeUnowned)).toBe(true);
+    });
+
+    it("is false for a sibling's job record even though its origin is native", () => {
+      // This is the whole bug: `origin === "native"` is NOT "unattributed".
+      expect(siblingJob.origin).toBe("native");
+      expect(isUnattributed(siblingJob)).toBe(false);
+    });
+
+    it.each([
+      ["own job record", ownJob],
+      ["web run", webRun],
+      ["prior adoption", adoptedBySibling],
+    ] as const)("is false for a %s", (_label, attribution) => {
+      expect(isUnattributed(attribution)).toBe(false);
+    });
+  });
+
+  describe("canAgentAdopt", () => {
+    it("refuses a session a sibling agent owns via a job record", () => {
+      expect(canAgentAdopt(siblingJob, "keeper-x")).toBe(false);
+    });
+
+    it("refuses a session a sibling agent owns via a platform binding", () => {
+      expect(canAgentAdopt(webRun, "keeper-x")).toBe(false);
+    });
+
+    it("allows an unattributed session", () => {
+      expect(canAgentAdopt(nativeUnowned, "keeper-x")).toBe(true);
+    });
+
+    it("allows re-claiming a session the agent already owns", () => {
+      expect(canAgentAdopt(ownJob, "keeper-x")).toBe(true);
+    });
+
+    it("allows taking over a session another agent had merely adopted", () => {
+      // `recordAdoption` overwrites, so adoption records do not outrank a later
+      // adoption the way job and platform records do.
+      expect(canAgentAdopt(adoptedBySibling, "keeper-x")).toBe(true);
+    });
+  });
+
+  describe("the two gates cannot disagree", () => {
+    const ALL: SessionAttribution[] = [
+      nativeUnowned,
+      siblingJob,
+      ownJob,
+      webRun,
+      adoptedBySibling,
+      { origin: "schedule", agentName: "sweeper-x", triggerType: "schedule" },
+      { origin: "discord", agentName: "sweeper-x", triggerType: undefined },
+      { origin: "native", agentName: "sweeper-x", triggerType: "manual" },
+      { origin: "native", agentName: "sweeper-x", triggerType: "webhook" },
+      { origin: "native", agentName: "sweeper-x", triggerType: "fork" },
+    ];
+
+    it("anything the scan offers, the adopt path accepts", () => {
+      // isUnattributed ⇒ canAgentAdopt. Violating this is exactly the #437
+      // failure mode: a candidate offered by the scan that the write path
+      // cannot honour.
+      for (const attribution of ALL) {
+        if (isUnattributed(attribution)) {
+          expect(canAgentAdopt(attribution, "keeper-x")).toBe(true);
+        }
+      }
+    });
+
+    it("anything the adopt path accepts is then visible to the adopting agent", () => {
+      // canAgentAdopt ⇒ the listing gate passes afterwards. This is what makes
+      // an accepted adoption non-inert by construction.
+      for (const attribution of ALL) {
+        if (canAgentAdopt(attribution, "keeper-x")) {
+          expect(
+            isOwnedByAgent(attributionAfterAdoptionBy(attribution, "keeper-x"), "keeper-x"),
+          ).toBe(true);
+        }
+      }
+    });
+
+    it("anything the adopt path refuses stays with its existing owner", () => {
+      for (const attribution of ALL) {
+        if (!canAgentAdopt(attribution, "keeper-x")) {
+          expect(attributionAfterAdoptionBy(attribution, "keeper-x")).toEqual(attribution);
+          expect(isOwnedByAgent(attribution, "keeper-x")).toBe(false);
+        }
+      }
+    });
   });
 });

--- a/packages/core/src/state/__tests__/session-discovery-combined-424-419.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery-combined-424-419.test.ts
@@ -43,9 +43,15 @@ vi.mock("../../runner/runtime/cli-session-path.js", async (importActual) => {
   };
 });
 
-vi.mock("../session-attribution.js", () => {
+vi.mock("../session-attribution.js", async (importActual) => {
+  const actual = await importActual<typeof import("../session-attribution.js")>();
   const fn = vi.fn();
   return {
+    // Spread the ACTUAL module so the pure ownership predicates
+    // (`isOwnedByAgent`, `isUnattributed`, `canAgentAdopt` — herdctl#437)
+    // survive the mock. Only the index *builder* is replaced; the predicates
+    // are the shared logic under test and must not be stubbed out.
+    ...actual,
     buildAttributionIndex: fn,
     AttributionIndexBuilder: class MockAttributionIndexBuilder {
       build = fn;

--- a/packages/core/src/state/__tests__/session-discovery-unreadable.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery-unreadable.test.ts
@@ -42,9 +42,15 @@ vi.mock("../../runner/runtime/cli-session-path.js", async (importActual) => {
   };
 });
 
-vi.mock("../session-attribution.js", () => {
+vi.mock("../session-attribution.js", async (importActual) => {
+  const actual = await importActual<typeof import("../session-attribution.js")>();
   const fn = vi.fn();
   return {
+    // Spread the ACTUAL module so the pure ownership predicates
+    // (`isOwnedByAgent`, `isUnattributed`, `canAgentAdopt` — herdctl#437)
+    // survive the mock. Only the index *builder* is replaced; the predicates
+    // are the shared logic under test and must not be stubbed out.
+    ...actual,
     buildAttributionIndex: fn,
     AttributionIndexBuilder: class MockAttributionIndexBuilder {
       build = fn;

--- a/packages/core/src/state/__tests__/session-discovery.test.ts
+++ b/packages/core/src/state/__tests__/session-discovery.test.ts
@@ -10,9 +10,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Mock session-attribution. The service now builds its index through
 // AttributionIndexBuilder#build; route that to the SAME fn exported as
 // buildAttributionIndex, so `vi.mocked(buildAttributionIndex)` drives both.
-vi.mock("../session-attribution.js", () => {
+vi.mock("../session-attribution.js", async (importActual) => {
+  const actual = await importActual<typeof import("../session-attribution.js")>();
   const fn = vi.fn();
   return {
+    // Spread the ACTUAL module so the pure ownership predicates
+    // (`isOwnedByAgent`, `isUnattributed`, `canAgentAdopt` — herdctl#437)
+    // survive the mock. Only the index *builder* is replaced; the predicates
+    // are the shared logic under test and must not be stubbed out.
+    ...actual,
     buildAttributionIndex: fn,
     AttributionIndexBuilder: class MockAttributionIndexBuilder {
       build = fn;

--- a/packages/core/src/state/errors.ts
+++ b/packages/core/src/state/errors.ts
@@ -65,6 +65,33 @@ export class StateFileError extends StateError {
 }
 
 /**
+ * Error thrown when an adoption claim is refused because it could not take
+ * effect (herdctl#437).
+ *
+ * Attribution resolves job records and platform bindings *ahead* of adoption
+ * records, so claiming a session that another agent already owns writes a record
+ * that is inert by construction: the caller is told the adoption succeeded, the
+ * session never appears under the adopting agent, and the burnt record excludes
+ * it from every later attempt. Refusing loudly is what keeps that recoverable.
+ */
+export class SessionAdoptionRefusedError extends StateError {
+  /** The session that could not be adopted */
+  public readonly sessionId: string;
+  /** The agent that already owns it, and would keep owning it */
+  public readonly ownedBy: string;
+
+  constructor(sessionId: string, ownedBy: string, detail: string) {
+    super(
+      `Cannot adopt session ${sessionId}: it is already attributed to agent "${ownedBy}" (${detail}). ` +
+        `Job and platform records outrank adoption, so the record would have no effect.`,
+    );
+    this.name = "SessionAdoptionRefusedError";
+    this.sessionId = sessionId;
+    this.ownedBy = ownedBy;
+  }
+}
+
+/**
  * Get a descriptive error message for common permission errors
  */
 export function getPermissionErrorMessage(code: string | undefined, path: string): string {

--- a/packages/core/src/state/session-attribution.ts
+++ b/packages/core/src/state/session-attribution.ts
@@ -299,6 +299,92 @@ function createAttributionIndex(
   };
 }
 
+// =============================================================================
+// Ownership predicates
+// =============================================================================
+//
+// One question — "who owns this session?" — was previously asked in two places
+// with two different answers (herdctl#437). The listing gate asked whether
+// `agentName` matched; the adoption gate asked whether `origin` was `"native"`.
+// Those are NOT the same question, because `triggerTypeToOrigin` folds `manual`,
+// `webhook`, `chat` and `fork` into `"native"`: a session with a real job record
+// under a *sibling* agent is `{ origin: "native", agentName: "sweeper-x" }`, so
+// it passed the adoption gate and then failed the listing gate. It was adopted,
+// reported as imported, and never appeared.
+//
+// The functions below are the single source of that answer. Crucially the
+// adoption gate is *defined in terms of* the listing gate — `canAgentAdopt` is
+// literally "would `isOwnedByAgent` be true afterwards" — so the two can no
+// longer drift apart: there is only one `isOwnedByAgent`, and everything else
+// derives from it.
+
+/**
+ * Does `agentName` own this session — i.e. will it appear in that agent's
+ * listing?
+ *
+ * This is THE listing gate. Every other predicate here is expressed through it.
+ *
+ * `agentName` is nullable to match the docker-directory call site, where the
+ * scanned directory may carry no agent name. An `undefined` name therefore
+ * matches exactly the unattributed sessions — the pre-existing behaviour of that
+ * gate, preserved deliberately.
+ */
+export function isOwnedByAgent(
+  attribution: SessionAttribution,
+  agentName: string | undefined,
+): boolean {
+  return attribution.agentName === agentName;
+}
+
+/**
+ * Is this session owned by nobody at all?
+ *
+ * The scan gate for adoption. Strictly stronger than `origin === "native"`,
+ * which is only the *absence of a platform/schedule/web run* and says nothing
+ * about whether an agent already has a claim.
+ */
+export function isUnattributed(attribution: SessionAttribution): boolean {
+  return attribution.origin === "native" && attribution.agentName === undefined;
+}
+
+/**
+ * The attribution a session would resolve to if `agentName` adopted it right
+ * now.
+ *
+ * Mirrors the precedence order encoded in {@link createAttributionIndex}: an
+ * adoption record is read *after* job records and platform bindings, so those
+ * keep their claim and the new record is inert. A prior *adoption* is different
+ * — `recordAdoption` overwrites it — so re-adoption really does take effect.
+ *
+ * Those two cases are distinguishable without knowing which index an attribution
+ * came from: only the adoption store yields `origin: "adopted"`, and only the
+ * unattributed fallback yields no `agentName`.
+ */
+export function attributionAfterAdoptionBy(
+  attribution: SessionAttribution,
+  agentName: string,
+): SessionAttribution {
+  const adoptionWouldWin = attribution.origin === "adopted" || attribution.agentName === undefined;
+
+  return adoptionWouldWin ? { origin: "adopted", agentName, triggerType: undefined } : attribution;
+}
+
+/**
+ * Would writing an adoption record for `agentName` actually make this session
+ * that agent's — either by winning the precedence contest, or because the agent
+ * already owns it?
+ *
+ * The adopt-time gate. Deliberately looser than {@link isUnattributed}: a
+ * session the agent already owns is not worth *offering* in a picker (it is
+ * already there), but re-claiming it is a harmless idempotent no-op rather than
+ * something to refuse. The relationship `isUnattributed(a) ⇒ canAgentAdopt(a,
+ * anyAgent)` is what guarantees the scan never proposes something the adopt path
+ * would reject.
+ */
+export function canAgentAdopt(attribution: SessionAttribution, agentName: string): boolean {
+  return isOwnedByAgent(attributionAfterAdoptionBy(attribution, agentName), agentName);
+}
+
 /** One job file's contribution to the index, memoized by the builder. */
 interface CachedJobFile {
   /** File mtime (epoch ms) when last parsed — the cache-invalidation key. */

--- a/packages/core/src/state/session-discovery.ts
+++ b/packages/core/src/state/session-discovery.ts
@@ -20,6 +20,7 @@ import {
 } from "../runner/runtime/cli-session-path.js";
 import { createLogger } from "../utils/logger.js";
 import { listAdoptions, recordAdoption, removeAdoption } from "./adopted-sessions.js";
+import { SessionAdoptionRefusedError } from "./errors.js";
 import {
   type ChatMessage,
   extractFirstMessagePreview,
@@ -35,6 +36,10 @@ import type { AdoptedSession } from "./schemas/adopted-session.js";
 import {
   type AttributionIndex,
   AttributionIndexBuilder,
+  canAgentAdopt,
+  isOwnedByAgent,
+  isUnattributed,
+  type SessionAttribution,
   type SessionOrigin,
 } from "./session-attribution.js";
 import {
@@ -163,6 +168,19 @@ export interface AdoptSkippedSession {
   reason: AdoptSkipReason;
   /** Extra context (e.g. the underlying errno message, the owning agent). */
   detail?: string;
+  /**
+   * The agent that already owns this session, when one does — set on
+   * `"attributed-to-run"` and `"already-adopted"` skips.
+   *
+   * This is deliberately a *field* rather than a second skip reason
+   * (herdctl#437): "owned by a sibling agent" and "produced by a web/schedule
+   * run" are the same refusal with different context, a UI that wants to say
+   * something different for each needs the owner's name either way, and adding
+   * a member to {@link AdoptSkipReason} would break consumers that switch on it
+   * exhaustively. Compare it against the adopting agent's own qualified name to
+   * tell "belongs to another agent" from "already yours".
+   */
+  ownedBy?: string;
 }
 
 /** Result of a batch adoption. */
@@ -255,6 +273,24 @@ function decodePathForDisplay(encodedPath: string): string {
 
   // Fallback: just replace all hyphens
   return encodedPath.replace(/-/g, "/");
+}
+
+/**
+ * Describe an attribution that blocks adoption, as a skip a UI can render.
+ *
+ * Shared by the scan gate and the two write-site guards so a candidate refused
+ * before any I/O and one refused after it read identically.
+ */
+function describeAttributionSkip(
+  attribution: SessionAttribution,
+): Pick<AdoptSkippedSession, "reason" | "detail" | "ownedBy"> {
+  return {
+    reason: "attributed-to-run",
+    detail: attribution.agentName
+      ? `origin "${attribution.origin}" (agent ${attribution.agentName})`
+      : `origin "${attribution.origin}"`,
+    ownedBy: attribution.agentName,
+  };
 }
 
 /**
@@ -959,7 +995,11 @@ export class SessionDiscoveryService {
     // When multiple agents share a working directory, this prevents the same
     // native CLI sessions from appearing under every agent. Unattributed sessions
     // are still visible in the global recent sessions list and All Chats view.
-    if (attribution.agentName !== agentName) {
+    //
+    // `isOwnedByAgent` is the shared predicate the adoption gate is defined
+    // against (herdctl#437) — keep this call rather than re-inlining the
+    // comparison, or the two can drift apart again.
+    if (!isOwnedByAgent(attribution, agentName)) {
       return { session: null, sidechainUpdate };
     }
 
@@ -1281,8 +1321,9 @@ export class SessionDiscoveryService {
           const attribution = attributionIndex.getAttribute(sessionId);
 
           // For docker directories, only include sessions attributed to this specific agent
-          // (since all docker agents share the same docker-sessions directory)
-          if (dir.dockerEnabled && attribution.agentName !== dir.agentName) {
+          // (since all docker agents share the same docker-sessions directory).
+          // Same shared ownership predicate as `enrichAgentSession` (herdctl#437).
+          if (dir.dockerEnabled && !isOwnedByAgent(attribution, dir.agentName)) {
             continue;
           }
 
@@ -1469,22 +1510,25 @@ export class SessionDiscoveryService {
             sessionId,
             reason: "already-adopted",
             detail: `adopted by ${existing.agentName} at ${existing.adoptedAt}`,
+            ownedBy: existing.agentName,
           });
           continue;
         }
 
-        // Anything the attribution index already resolves is not a *native*
-        // session: a job record or a live platform binding means a real run owns
-        // it, and adoption must not compete with that.
+        // Only *unattributed* sessions are adoptable. This deliberately asks
+        // `isUnattributed` rather than `origin === "native"` (herdctl#437):
+        // `triggerTypeToOrigin` folds `manual`/`webhook`/`chat`/`fork` into
+        // `"native"`, so a session with a genuine job record under a sibling
+        // agent has a native *origin* while being firmly someone else's. Offering
+        // it produced an adoption record that lost the precedence contest and was
+        // therefore inert — the session was reported as imported and never
+        // appeared, and the burnt marker excluded it from every retry.
+        //
+        // A session this agent already owns is excluded too: it is visible under
+        // the agent already, so there is nothing to import.
         const attribution = attributionIndex.getAttribute(sessionId);
-        if (attribution.origin !== "native") {
-          skipped.push({
-            sessionId,
-            reason: "attributed-to-run",
-            detail: attribution.agentName
-              ? `origin "${attribution.origin}" (agent ${attribution.agentName})`
-              : `origin "${attribution.origin}"`,
-          });
+        if (!isUnattributed(attribution)) {
+          skipped.push({ sessionId, ...describeAttributionSkip(attribution) });
           continue;
         }
 
@@ -1642,12 +1686,35 @@ export class SessionDiscoveryService {
    * @param options.sourceCwd - Working directory the transcript came from
    * @param options.workingDirectory - The agent's working directory, used only
    *   to invalidate the right listing cache
+   * @throws {SessionAdoptionRefusedError} If another agent already owns the
+   *   session, so the record could not take effect
    */
   async adoptSession(
     agentName: string,
     sessionId: string,
     options?: { sourceCwd?: string; workingDirectory?: string },
   ): Promise<AdoptedSession> {
+    // Refuse a claim that cannot win the precedence contest (herdctl#437).
+    // Attribution resolves job records and platform bindings ahead of adoptions,
+    // so claiming a session a *different* agent owns writes a record that is
+    // inert by construction: the caller is told it worked, the session never
+    // appears, and the burnt marker excludes it from every later attempt.
+    //
+    // This is a live check rather than a re-use of any scan's verdict — the
+    // picker that produced the session id and this call are separate round
+    // trips, and a sibling's run can land between them.
+    const attribution = (await this.getAttributionIndex()).getAttribute(sessionId);
+    if (!canAgentAdopt(attribution, agentName)) {
+      const { detail } = describeAttributionSkip(attribution);
+      throw new SessionAdoptionRefusedError(
+        sessionId,
+        // `canAgentAdopt` is false only when some *other* agent owns it, so
+        // `agentName` is necessarily set here.
+        attribution.agentName ?? "unknown",
+        detail ?? "",
+      );
+    }
+
     const record = await recordAdoption(this.stateDir, sessionId, {
       agentName,
       sourceCwd: options?.sourceCwd,
@@ -1831,6 +1898,22 @@ export class SessionDiscoveryService {
     for (const { sessionId } of candidates) {
       const sourceFile = path.join(sourceDir, `${sessionId}.jsonl`);
       const destFile = path.join(destDir, `${sessionId}.jsonl`);
+
+      // Re-check ownership at the write site, not just at the scan (herdctl#437).
+      // The scan and this loop are separated by real I/O — a 1500-transcript
+      // import runs for minutes, well past the attribution cache TTL — so a
+      // sibling agent's run can land in between and the scan's verdict go stale.
+      // `getAttributionIndex` is TTL-cached, so this is a map lookup per
+      // candidate in the common case and a rebuild only once the TTL lapses.
+      //
+      // Refusing here is the point: an adoption record that cannot win the
+      // precedence contest is inert *and* burns the marker, which is what made
+      // the original failure unrecoverable. A skip is recoverable.
+      const attribution = (await this.getAttributionIndex()).getAttribute(sessionId);
+      if (!canAgentAdopt(attribution, agentName)) {
+        skipped.push({ sessionId, ...describeAttributionSkip(attribution) });
+        continue;
+      }
 
       if (!inPlace) {
         // Never clobber: an existing transcript with this id in the destination


### PR DESCRIPTION
Fixes #437.

## The bug

`scanAdoptionCandidates` asked "is this session **native**?" when it needed to ask "is this session **unattributed**?".

`triggerTypeToOrigin` folds `manual`, `webhook`, `chat` and `fork` into `origin: "native"`. So a session with a genuine job record under a *sibling* agent resolves to `{ origin: "native", agentName: "sweeper-x" }` — natively originated, but firmly someone else's. It passed the adoption gate (`origin !== "native"`) and then failed the per-agent listing gate (`attribution.agentName !== agentName`).

The adoption record was written and lost the precedence contest (job → platform → adopted → native), so it was **inert by construction**. The import reported success, the session never appeared, and the burnt marker read as `already-adopted` on every retry — silent and unrecoverable. Measured on a real corpus: 1502 of 1531 candidates (98.1%) carried a sibling-agent job record.

## What changed

**1. The scan gate.** `isUnattributed` instead of `origin === "native"`. Sessions the *adopting* agent already owns are excluded too — they are already visible under it, so there is nothing to import.

**2. One shared predicate.** The two gates encoded the same question in two places and drifted; that drift *is* the bug. Both now derive from a single set of pure predicates in `session-attribution.ts` — the module that already owns the precedence order — and, crucially, the adoption gate is *defined in terms of* the listing gate:

```ts
canAgentAdopt(attr, agent) === isOwnedByAgent(attributionAfterAdoptionBy(attr, agent), agent)
```

There is one `isOwnedByAgent`, and everything else derives from it, so this class of bug is structurally impossible rather than fixed once. Two invariants follow, and both are asserted directly over the full space of attribution shapes:

- anything the scan offers, the adopt path accepts (`isUnattributed ⇒ canAgentAdopt`)
- anything the adopt path accepts is visible to the adopting agent afterwards

`canAgentAdopt` is deliberately *looser* than `isUnattributed`: re-claiming a session you already own is a harmless no-op, and a session another agent merely *adopted* is adoptable because `recordAdoption` overwrites — adoption records don't outrank a later adoption the way job and platform records do.

**3. Refusal at the write site, not just the scan.** `adoptSession` throws the new `SessionAdoptionRefusedError`; `adoptSessionsFrom` re-checks each candidate immediately before recording it and reports a skip. The scan and the write are separate calls — separated by minutes of file copying in a 1500-transcript import, well past the attribution cache TTL — so a sibling's run can land in between. Refusing is what turns an unrecoverable silent failure into a legible one.

**4. `AdoptSkippedSession.ownedBy`** (new, optional) names the owning agent on `attributed-to-run` and `already-adopted` skips.

### On the third suggestion — splitting `"attributed-to-run"`

I chose **not** to add a skip-reason member, and want to flag it for override.

Every non-native origin also carries an `agentName`, so a new `"attributed-to-other-agent"` member would fire on essentially every real case and leave `"attributed-to-run"` unreachable dead code. Meanwhile adding a union member is the one change here that could break a TS consumer switching exhaustively on the reason — including Paddock, the consumer this unblocks.

An optional `ownedBy` field gives a UI strictly more than a second enum member would (`skip.ownedBy === thisAgent ? "already yours" : \`belongs to ${skip.ownedBy}\``), costs no compatibility, and `detail` was already documented as carrying "the owning agent". If you'd rather have the enum split, it's a small follow-up.

## Tests — red first

Every existing test passed because the #423 fixtures had **no job records at all**. These use real transcripts, real `job-*.yaml` records, the real adoption store and the real attribution index.

Against the unfixed code (with only the additive scaffolding in place), **12 of 16 failed**:

```
listAdoptableSessions > does not offer a session owned by a sibling agent
  AssertionError: expected [ 'sess-sibling' ] to deeply equal []
listAdoptableSessions > ...with trigger_type manual (folds to origin native)
  AssertionError: expected [ 'sess-manual' ] to deeply equal []
listAdoptableSessions > ...with trigger_type webhook (folds to origin native)
  AssertionError: expected [ 'sess-webhook' ] to deeply equal []
listAdoptableSessions > ...with trigger_type chat (folds to origin native)
  AssertionError: expected [ 'sess-chat' ] to deeply equal []
listAdoptableSessions > ...with trigger_type fork (folds to origin native)
  AssertionError: expected [ 'sess-fork' ] to deeply equal []
listAdoptableSessions > still offers a genuinely unattributed transcript alongside an owned one
  AssertionError: expected [ 'sess-owned', 'sess-free' ] to deeply equal [ 'sess-free' ]
listAdoptableSessions > does not offer a session the adopting agent already owns via its own job record
  AssertionError: expected [ 'sess-mine' ] to deeply equal []
adoptSessionsFrom > skips a sibling-owned session and names the owner
  AssertionError: expected [ 'sess-sibling' ] to deeply equal []
adoptSessionsFrom > reports exactly the sessions that then become visible
  AssertionError: expected [ 'sess-free-a', 'sess-free-b', …(3) ] to deeply equal [ 'sess-free-a', 'sess-free-b' ]
adoptSessionsFrom > refuses a candidate that becomes sibling-owned between the scan and the write
  AssertionError: expected [ 'sess-b', 'sess-a' ] to deeply equal [ 'sess-a' ]
adoptSession > refuses a session that became sibling-owned between the scan and the adopt
  AssertionError: promise resolved "{ version: 1, …(4) }" instead of rejecting
adoptSession > carries the owning agent on the refusal
  AssertionError: expected null to be an instance of SessionAdoptionRefusedError
```

`reports exactly the sessions that then become visible` is the headline symptom in miniature: the unfixed code adopts 5 and shows 2.

The **4 that passed** against the unfixed code are the ones that matter for interpreting the rest:

- `control: a "web" job record was already excluded before the fix` — kept deliberately. `trigger_type: "web"` maps to origin `"web"`, so the old gate already caught it. A regression test built on that trigger type proves nothing; this one documents why the four native-folding types are the whole bug.
- the three `adoptSession` "still allows…" cases (unattributed, same-agent, handover-from-another-adopter) — pinning that the new refusal isn't over-broad.

The same-agent / sibling-agent distinction is pinned on both paths, since a same-agent record behaves differently and would pass a naive test.

## Verification

- `packages/core`: **1 failed | 3661 passed | 1 skipped (3663)**. The single failure is the known pre-existing `directory.test.ts > "throws StateDirectoryCreateError when parent directory is not writable"`, which fails only because this box runs tests as root. It is the only one.
- chat 298, cli 202 (+10 skipped), web 176, discord 342 (+97 skipped), slack 350 — all passing.
- `tsc --noEmit` clean across all packages; `biome check` clean on every touched file; `pnpm --filter @herdctl/core build` succeeds and the module loads.
- The new test file was run 3× to confirm it isn't order-dependent (candidate ordering is pinned with explicit mtimes).

## Notes for review

- **Behaviour change:** `adoptSession` now throws where it previously returned an inert record, and `listAdoptableSessions` no longer offers sessions the agent already owns via a job record. Adopting genuine terminal `claude` history — the case adoption exists for — is unaffected.
- The write-site re-check calls `getAttributionIndex()` per candidate. That's TTL-cached, so it's a map lookup in the common case and rebuilds only once the TTL lapses mid-batch, which is exactly the case it's there to catch.
- Three existing test files mocked `session-attribution.js` wholesale; they now spread the actual module (the pattern already used for the `session-metadata` mock) so the pure predicates aren't stubbed out.
- Changeset included as a `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session adoption now targets only truly unowned sessions.
  - Prevented conflicting adoptions when another agent already owns a session.
  - Added safeguards against ownership changes during adoption.
  - Sessions already owned by the current agent are excluded from adoption listings.
  - Batch adoption results now identify skipped sessions and their current owner.

- **Documentation**
  - Clarified session ownership, adoption eligibility, refusal behavior, and skip details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->