### PR TITLE
feat(core): reapChatSession — close a managed session the reap policy never releases

### DIFF
--- a/.changeset/force-reap-session.md
+++ b/.changeset/force-reap-session.md
@@ -1,0 +1,49 @@
+---
+"@herdctl/core": minor
+---
+
+feat(core): `FleetManager.reapChatSession` — close a managed session that the reap policy will never release
+
+`decideReap` keeps a streaming session alive for exactly as long as it holds
+live background work, with — by its own header comment — "no idle timer, no
+max-lifetime backstop, no idle-concurrency cap". That is the right default:
+reaping a session with work in flight kills the work. But it left consumers with
+no way out when a session becomes permanently unreapable, and there are at least
+two ordinary ways that happens:
+
+- A background task never exits (a model-authored `until` loop whose sentinel
+  never arrives), so `backgroundTasks` never drains.
+- A re-invocation turn dies without firing a Stop hook — on a subscription usage
+  limit, say. `activity` has already cleared `awaitingTasks`, so every later
+  `background_tasks_changed` returns early at the guard, and only a `turn_end`
+  could re-arm it or reap. None comes. The session is stranded live with no
+  pending reap.
+
+In both cases the session's message stream never ends, so a consumer rendering
+that stream shows the chat as running until the process restarts. There was no
+API to end it.
+
+**`SessionReaper.forceReap(sessionId)`** closes a live managed session
+regardless of what it is holding, and **`FleetManager.reapChatSession(sessionId)`**
+exposes it (the lifecycle manager is private on the fleet). Both are idempotent
+and return `false` for an unknown, unmanaged or already-reaped id.
+
+This belongs on the reaper rather than being a `close()` the consumer calls on
+the `RuntimeSession` it already holds. Closing the query directly goes behind the
+reaper's bookkeeping: `liveById` keeps a stale entry, so `whenSessionReaped`
+never resolves — a later resume of that id stalls until its 5-minute ceiling
+(#403) — and `WakeRegistry` skips that session's wakes forever. `forceReap`
+routes through the same private `reap` the policy uses, so the id is
+unregistered, reap waiters drain, and the consumer observes an ordinary
+end-of-stream and unwinds through its ordinary path. No new teardown contract.
+
+The reap log line now carries a reason (`Reaping idle session …` is unchanged;
+a forced one reads `Reaping force-reaped on request session …`).
+
+Policy is untouched: nothing reaps on its own that didn't before. This only adds
+a door that can be opened deliberately, so a consumer can honour a user's "stop
+this now". Note that `interrupt()` is not that door — it targets an in-flight
+model turn, and a session held open purely for background work has none.
+
+Unblocks [paddock#528](https://github.com/edspencer/paddock/issues/528), where a
+chat wedges "running" with a Stop button that cannot do anything.

--- a/docs/src/content/docs/concepts/sessions.md
+++ b/docs/src/content/docs/concepts/sessions.md
@@ -238,6 +238,8 @@ A live streaming session keeps a warm `claude` process around (~300 MB each). Se
 - **Reap on idle** — the session is closed the instant its turn ends, *unless* it holds live background work (running shells, subagents, monitors). Resuming later recovers the full conversation, and Claude's prompt cache is server-side and survives the reap, so closing an idle session costs only ~0.5s of respawn time.
 - **Durable wakes** — timer-class wakeups the agent scheduled in-session (`ScheduleWakeup` one-shots, `CronCreate` recurring crons) would normally die with the `claude` process. Instead, herdctl captures them as durable wake entries in `state.yaml` (`session_wakes`) and re-fires them from its own scheduler loop, resuming the session with the wake's prompt.
 
+The keep-alive rule has no backstop — no idle timer, no max lifetime. That is deliberate (reaping a session with work in flight kills the work), but it means a session whose background work never finishes is never reaped on its own, and its message stream never ends. [`reapChatSession()`](/library-reference/fleet-manager/#reapchatsessionsessionid) closes such a session on demand, so a UI can offer a working "stop".
+
 Wake semantics:
 
 | Behavior | Rule |

--- a/docs/src/content/docs/library-reference/fleet-manager.mdx
+++ b/docs/src/content/docs/library-reference/fleet-manager.mdx
@@ -1447,6 +1447,45 @@ A `RuntimeSession` holds a live `claude` query for as long as it is open. Always
 
 ---
 
+### `reapChatSession(sessionId)`
+
+Closes a managed chat session immediately, whatever background work it is holding.
+
+```typescript
+manager.reapChatSession(sessionId: string): boolean
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sessionId` | `string` | **Yes** | Resolved session id of a session opened with `manageLifecycle: true` |
+
+#### Returns
+
+`true` if a live managed session with that id was found and closed; `false` for an unknown, unmanaged or already-reaped id. Idempotent, and synchronous — the underlying `close()` is deferred a tick, so the session's message stream ends shortly after this returns.
+
+#### Description
+
+The reap policy keeps a session alive for exactly as long as it holds live background work, with no idle timer and no max-lifetime backstop. That protects work in flight, but it means a session can become permanently unreapable — a background task whose sentinel never arrives, or a re-invocation turn that dies without a Stop hook (a subscription usage limit, say) and so never re-arms the state the policy needs. Its message stream then never ends, and a consumer rendering that stream shows the session as running until the process restarts.
+
+`reapChatSession()` is the deliberate way out. Use it to honour a user's "stop this now" in a chat UI.
+
+<Aside type="note">
+`interrupt()` is not a substitute. It targets an in-flight model turn, and a session held open purely for background work has none.
+</Aside>
+
+Reach for this rather than calling `close()` on the `RuntimeSession` you already hold. A direct `close()` goes behind the reaper's bookkeeping: the id stays registered as live, so a later resume of it stalls until its 5-minute ceiling and the wake registry skips that session's wakes indefinitely. `reapChatSession()` routes through the same path the policy uses, so the id is unregistered, deferred resumes are released, and consumers see an ordinary end-of-stream.
+
+```typescript
+// A chat wedged "running" — end the session on the user's behalf.
+if (!manager.reapChatSession(sessionId)) {
+  logger.warn(`No live managed session ${sessionId} to reap`);
+}
+```
+
+---
+
 ### `listAgentCommands(agentName, options?)`
 
 Lists the slash commands available to an agent — for populating a command palette or autocomplete — in a single call.

--- a/packages/core/src/fleet-manager/__tests__/reap-chat-session.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/reap-chat-session.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for FleetManager.reapChatSession — the escape hatch for a managed
+ * session the reap policy will never release on its own.
+ *
+ * These drive the REAL SessionLifecycleManager + SessionReaper the fleet builds
+ * in initialize(), so what's covered is the actual wiring (a private
+ * `sessionLifecycle` reached through a public method), not a stub of it. The
+ * policy behaviour itself is covered in session/__tests__/session-reaper.test.ts.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Claude SDK to prevent real API calls.
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+import type { RuntimeSession } from "../../runner/runtime/interface.js";
+import type { SessionLifecycleSignal } from "../../session/types.js";
+import { FleetManager } from "../fleet-manager.js";
+
+const silentLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+/** A background task, so the policy holds the session open and never reaps it. */
+const TASK = { id: "t1", type: "shell", status: "running", description: "server" };
+
+function fakeSession(): RuntimeSession & { close: ReturnType<typeof vi.fn> } {
+  async function* empty(): AsyncGenerator<never> {}
+  return {
+    messages: empty(),
+    send: vi.fn().mockResolvedValue(undefined),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    listCommands: vi.fn().mockResolvedValue([]),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function keepAliveSignal(sessionId: string): SessionLifecycleSignal {
+  return { kind: "turn_end", sessionId, sessionCrons: [], backgroundTasks: [TASK] };
+}
+
+describe("FleetManager.reapChatSession()", () => {
+  let tempDir: string;
+  let configPath: string;
+  let stateDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "fleet-reap-chat-session-"));
+    const configDir = join(tempDir, "config");
+    stateDir = join(tempDir, ".herdctl");
+    await mkdir(join(configDir, "agents"), { recursive: true });
+    await mkdir(join(tempDir, "workspace"), { recursive: true });
+
+    const yaml = await import("yaml");
+    await writeFile(
+      join(configDir, "agents", "keeper.yaml"),
+      yaml.stringify({ name: "keeper", working_directory: join(tempDir, "workspace") }),
+    );
+    configPath = join(configDir, "herdctl.yaml");
+    await writeFile(
+      configPath,
+      yaml.stringify({ version: 1, agents: [{ path: "./agents/keeper.yaml" }] }),
+    );
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  function createManager() {
+    return new FleetManager({ configPath, stateDir, checkInterval: 10000, logger: silentLogger() });
+  }
+
+  it("returns false before initialize(), when there is no lifecycle manager yet", () => {
+    expect(createManager().reapChatSession("sess-1")).toBe(false);
+  });
+
+  it("closes a session the policy is holding open for background work", async () => {
+    const manager = createManager();
+    await manager.initialize();
+    const lifecycle = manager.getSessionLifecycle();
+    if (!lifecycle) throw new Error("expected a session lifecycle manager after initialize()");
+
+    const session = fakeSession();
+    const managed = lifecycle.manage(session, "keeper");
+    await managed.handleSignal(keepAliveSignal("sess-1"));
+    expect(managed.isLive()).toBe(true); // kept alive: nothing will reap this
+
+    expect(manager.reapChatSession("sess-1")).toBe(true);
+    expect(managed.isLive()).toBe(false);
+    await new Promise((r) => setTimeout(r, 5)); // close() is deferred a tick
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false for an unknown session id, and for one already reaped", async () => {
+    const manager = createManager();
+    await manager.initialize();
+    const lifecycle = manager.getSessionLifecycle();
+    if (!lifecycle) throw new Error("expected a session lifecycle manager after initialize()");
+
+    const session = fakeSession();
+    const managed = lifecycle.manage(session, "keeper");
+    await managed.handleSignal(keepAliveSignal("sess-1"));
+
+    expect(manager.reapChatSession("who-dis")).toBe(false);
+    expect(manager.reapChatSession("sess-1")).toBe(true);
+    expect(manager.reapChatSession("sess-1")).toBe(false);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -1149,6 +1149,26 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
     return this.jobControl.openChatSession(agentName, options);
   }
   /**
+   * Close a managed chat session now, whatever background work it is holding.
+   *
+   * The reaper keeps a session alive for as long as it holds live background
+   * work and has no backstop, so a session whose background tasks never finish
+   * is never reaped and its message stream never ends. A consumer driving a UI
+   * off that stream needs a way to end it on the user's behalf — a "stop" that
+   * means *end this session*, not `interrupt()` (which targets an in-flight
+   * model turn, and during the background phase there is none).
+   *
+   * Closing the {@link RuntimeSession} directly is not equivalent: it bypasses
+   * the reaper's bookkeeping and strands the session id as live, stalling later
+   * resumes and suppressing its wakes. See {@link SessionReaper.forceReap}.
+   *
+   * Only applies to sessions opened with `manageLifecycle: true`. Idempotent;
+   * returns `false` for an unknown, unmanaged, or already-reaped session id.
+   */
+  reapChatSession(sessionId: string): boolean {
+    return this.sessionLifecycle?.reaper.forceReap(sessionId) ?? false;
+  }
+  /**
    * List the slash commands available to an agent in one shot.
    *
    * A convenience wrapper that opens a streaming session, reads its command list,

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -505,6 +505,98 @@ describe("SessionReaper", () => {
       expect(managed.isLive()).toBe(false);
     });
   });
+
+  // The policy has no backstop by design, so a session can end up permanently
+  // unreapable and its message stream never ends. forceReap is the escape hatch
+  // a consumer needs to honour a user's "stop this now" — and it has to unwind
+  // the reaper's own bookkeeping, not just close the query.
+  describe("forceReap", () => {
+    it("closes a session the policy is deliberately holding alive for background work", async () => {
+      const onReap = vi.fn();
+      const reaper = new SessionReaper({ registry: fakeRegistry(), onReap });
+      const session = fakeSession();
+      const managed = reaper.manage(session, "team/agent");
+
+      await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+      expect(managed.isLive()).toBe(true); // keepAlive: the policy will never reap this
+
+      expect(reaper.forceReap("sess-1")).toBe(true);
+      expect(onReap).toHaveBeenCalledWith({ agent: "team/agent", sessionId: "sess-1" });
+      expect(managed.isLive()).toBe(false);
+      await tick();
+      expect(session.close).toHaveBeenCalledTimes(1);
+    });
+
+    // The whole reason this lives on the reaper rather than being a `close()` the
+    // consumer calls itself: closing behind the reaper's back leaves the id
+    // registered live, so a later resume stalls on whenSessionReaped until its
+    // ceiling (#403) and the wake registry skips the session's wakes forever.
+    it("unregisters the id and releases resumes waiting on whenSessionReaped", async () => {
+      const reaper = new SessionReaper({ registry: fakeRegistry() });
+      const session = fakeSession();
+      const managed = reaper.manage(session, "team/agent");
+      await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+
+      expect(reaper.isSessionLive("sess-1")).toBe(true);
+      let resumed = false;
+      const waiting = reaper.whenSessionReaped("sess-1").then(() => {
+        resumed = true;
+      });
+      await tick();
+      expect(resumed).toBe(false); // still live → a resume is correctly deferred
+
+      reaper.forceReap("sess-1");
+      await waiting;
+      expect(resumed).toBe(true);
+      expect(reaper.isSessionLive("sess-1")).toBe(false);
+    });
+
+    it("is idempotent and returns false for an unknown or already-reaped id", async () => {
+      const reaper = new SessionReaper({ registry: fakeRegistry() });
+      const session = fakeSession();
+      const managed = reaper.manage(session, "team/agent");
+      await managed.handleSignal(signal({ backgroundTasks: [TASK] }));
+
+      expect(reaper.forceReap("nope")).toBe(false);
+      expect(reaper.forceReap("sess-1")).toBe(true);
+      expect(reaper.forceReap("sess-1")).toBe(false); // already reaped
+      await tick();
+      expect(session.close).toHaveBeenCalledTimes(1);
+    });
+
+    // The production wedge (paddock#528). A turn spawns background sub-agents, then
+    // the sub-agents die and the parent's re-invocation turn dies too — on a usage
+    // limit, say — without firing a Stop hook. `activity` has already cleared
+    // awaitingTasks, so every later background_tasks_changed returns early, and
+    // only a turn_end could re-arm it or reap. None comes. The session is stranded
+    // live with no pending reap, forever: the stream never ends, so a consumer
+    // rendering it shows "running" until the process restarts.
+    it("rescues a session stranded live by a re-invocation turn that never ends", async () => {
+      vi.useFakeTimers();
+      const onReap = vi.fn();
+      const reaper = new SessionReaper({ registry: fakeRegistry(), onReap });
+      const session = fakeSession();
+      const managed = reaper.manage(session, "team/agent");
+
+      await managed.handleSignal(signal({ backgroundTasks: [TASK] })); // turn_end → keepAlive
+      await managed.handleSignal(signal({ kind: "background_tasks_changed" })); // drained → grace armed
+      await managed.handleSignal(signal({ kind: "activity" })); // re-invocation starts → grace cancelled
+
+      // ...and that turn dies without a turn_end. Nothing left can reap this.
+      await vi.runAllTimersAsync();
+      await managed.handleSignal(signal({ kind: "background_tasks_changed" }));
+      await vi.runAllTimersAsync();
+      expect(onReap).not.toHaveBeenCalled();
+      expect(managed.isLive()).toBe(true);
+      expect(session.close).not.toHaveBeenCalled();
+
+      // The escape hatch: the stream ends, and the consumer unwinds normally.
+      expect(reaper.forceReap("sess-1")).toBe(true);
+      await vi.runAllTimersAsync();
+      expect(managed.isLive()).toBe(false);
+      expect(session.close).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 /** In-memory persistence returning independent copies (like a real read). */

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -162,6 +162,40 @@ export class SessionReaper {
     });
   }
 
+  /**
+   * Close a live managed session NOW, whatever it is holding.
+   *
+   * {@link decideReap} keeps a session alive for exactly as long as it holds
+   * live background work — deliberately, and with no timer, no max-lifetime
+   * backstop and no idle cap. That is the right *default*, but it must not be
+   * the only option: a session whose background work never finishes (or whose
+   * re-invocation turn dies without a `turn_end` to re-arm the awaiting-tasks
+   * state) is never reaped, its message stream never ends, and a consumer
+   * driving a UI off that stream has no way to honour a user's "stop this now".
+   *
+   * A consumer cannot do this for itself. It holds the {@link RuntimeSession}
+   * and could call `close()` directly, but that closes the query behind the
+   * reaper's back: {@link liveById} keeps a stale entry, so {@link
+   * whenSessionReaped} never resolves (a later resume of that id stalls until
+   * its ceiling, #403) and {@link WakeRegistry} skips the session's wakes
+   * forever. Reaping is the reaper's to do.
+   *
+   * So this routes through the same {@link reap} the policy uses: unregister
+   * the id, drain the reap waiters, then close. The consumer just observes an
+   * ordinary end-of-stream and unwinds through its ordinary path — no new
+   * teardown contract to get right.
+   *
+   * Idempotent, and safe to call for an unknown or already-reaped id.
+   *
+   * @returns `true` if a live session with this id was found and closed.
+   */
+  forceReap(sessionId: string): boolean {
+    const managed = this.liveById.get(sessionId);
+    if (!managed?.isLive()) return false;
+    this.reap(managed, sessionId, "force-reaped on request");
+    return true;
+  }
+
   // --- internal, called by ManagedSessionImpl ---
 
   registerLive(sessionId: string, managed: ManagedSessionImpl): void {
@@ -288,9 +322,9 @@ export class SessionReaper {
     this.reap(managed, signal.sessionId);
   }
 
-  private reap(managed: ManagedSessionImpl, sessionId: string): void {
+  private reap(managed: ManagedSessionImpl, sessionId: string, reason = "idle"): void {
     if (!managed.isLive()) return;
-    this.logger.info(`Reaping idle session ${sessionId} (${managed.agent})`);
+    this.logger.info(`Reaping ${reason} session ${sessionId} (${managed.agent})`);
     // Notify before closing, but never let a throwing consumer callback skip the
     // close() — that would leak the very session we decided to reap.
     this.notify(() => this.onReap?.({ agent: managed.agent, sessionId }));


### PR DESCRIPTION
## The gap

`decideReap` keeps a streaming session alive for exactly as long as it holds live background work, and says so plainly in its own header: *"No idle timer, no max-lifetime backstop, no idle-concurrency cap."*

That is the right default — reaping a session with work in flight kills the work. But it left consumers with **no way out** when a session becomes permanently unreapable, and there are at least two ordinary ways that happens:

1. **A background task never exits.** A model-authored `until` loop whose sentinel never arrives, so `backgroundTasks` never drains.
2. **A re-invocation turn dies without firing a Stop hook** — on a subscription usage limit, say. `activity` has already cleared `awaitingTasks`, so every later `background_tasks_changed` returns early at the `isAwaitingTasks()` guard, and only a `turn_end` could re-arm it or reap. None comes. The session is stranded live with no pending reap.

In both cases the session's message stream never ends, so a consumer rendering that stream shows the session as running until the process restarts. There was no API to end it.

## The change

- **`SessionReaper.forceReap(sessionId): boolean`** — close a live managed session regardless of what it is holding.
- **`FleetManager.reapChatSession(sessionId): boolean`** — public exposure, since `sessionLifecycle` is private on the fleet.

Both idempotent; both return `false` for an unknown, unmanaged or already-reaped id.

## Why on the reaper, and not just `close()`

A consumer holds the `RuntimeSession` and could call `close()` itself. That is **not** equivalent — it closes the query behind the reaper's bookkeeping:

- `liveById` keeps a stale entry, so `whenSessionReaped` never resolves and a later resume of that id stalls until its 5-minute ceiling (#403).
- `WakeRegistry` skips that session's wakes indefinitely.

`forceReap` routes through the same private `reap` the policy uses, so `markDone()` unregisters the id and drains the reap waiters before `close()`. The consumer observes an ordinary end-of-stream and unwinds through its ordinary path — no new teardown contract to get right.

Worth stating explicitly: **`interrupt()` is not a substitute.** It targets an in-flight model turn, and a session held open purely for background work has none.

## Scope

Policy is untouched — nothing reaps on its own that didn't before. This only adds a door that can be opened deliberately.

The reap log line now carries a reason; `Reaping idle session …` is unchanged, a forced one reads `Reaping force-reaped on request session …`.

## Tests

Four new reaper tests and three FleetManager tests. The one that matters is `rescues a session stranded live by a re-invocation turn that never ends` — it drives the real signal sequence (`turn_end` keepAlive → `background_tasks_changed` drained → `activity`, then nothing) and asserts the session is genuinely stuck (`onReap` never fires, `close()` never called) before showing `forceReap` releases it.

`pnpm typecheck` green across the monorepo; core suite passes (3675) and the docs site builds. One pre-existing failure locally, `directory.test.ts > throws StateDirectoryCreateError when parent directory is not writable`, is environmental — it fails on `main` too because this box runs as uid 0, so a chmod-unwritable parent is still writable.

## Docs

`library-reference/fleet-manager.mdx` gains a `reapChatSession()` section; `concepts/sessions.md` notes that the keep-alive rule has no backstop and points at it.

Unblocks edspencer/paddock#528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API to force-close live managed chat sessions on demand.
  - Returns whether a session was successfully closed and safely handles unknown or already-closed sessions.
  - Forced closures use standard cleanup and are recorded distinctly from automatic reaping.

- **Documentation**
  - Documented session behavior when background work remains unfinished.
  - Added reference documentation for the new session-reaping API.

- **Tests**
  - Added coverage for forced closure, idempotency, waiting callers, and sessions stranded during unfinished work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->