### PR TITLE
feat(core): stop a single background task in a live session (#449)

### DIFF
--- a/.changeset/stop-task-in-session.md
+++ b/.changeset/stop-task-in-session.md
@@ -1,0 +1,41 @@
+---
+"@herdctl/core": minor
+---
+
+feat(core): stop a single background task in a live session
+
+A consumer could not stop **one** background task in a session — two gaps, both
+of which had to close.
+
+**`RuntimeSession.stopTask(taskId)`** forwards the SDK's `stop_task` control
+request. The SDK `Query` was a `const` captured in `SDKRuntime.openSession`'s
+closure: never assigned to `this`, never returned, with no generic passthrough,
+so `stopTask` was unreachable from outside. (`session.messages` is the `Query`
+behind a cast, but any caller passing `onLifecycleSignal` — the interesting
+case — gets a wrapper generator that forwards nothing.)
+
+**`FleetManager.stopTaskInSession(sessionId, taskId)`** (and
+`SessionReaper.stopTaskInSession` beneath it) addresses that stop by session id
+instead of by handle. That is the half that actually bites: background shells,
+subagents and monitors routinely outlive the turn that started them, while a
+consumer holds its `RuntimeSession` only until the turn's result lands. A
+handle-scoped stop therefore works only while a turn happens to be in flight and
+goes inert over exactly the long tail where something is still running and the
+user is asking why. Consumers cannot hold the handle longer, because they do not
+own the session's lifetime — the reaper does, and already keeps the session past
+the turn. This is the door onto that state, mirroring `reapChatSession` /
+`forceReap`.
+
+Semantics carried over from the CLI's own handler: idempotent (`not_found` /
+`not_running` are successes, so stopping a task that just finished is fine — and
+no liveness pre-check is added that would reintroduce that race); not
+ownership-gated, so an out-of-band actor such as a UI stop button can stop any
+task in the session; and self-notifying, since the SDK emits the terminal
+`task_notification{status:"stopped"}` on the session's own stream.
+
+`stopTaskInSession` returns `false` only for a session that is not live, matching
+`reapChatSession`. A runtime refusal propagates rather than being translated into
+a silent success — notably `monitor_mcp` tasks, which the CLI has no kill
+strategy for and rejects with `unsupported_type`; a consumer needs to know the
+button did nothing. A live session whose handle carries no `stopTask` at all
+throws the new `SessionTaskControlUnsupportedError` for the same reason.

--- a/docs/src/content/docs/concepts/sessions.md
+++ b/docs/src/content/docs/concepts/sessions.md
@@ -240,6 +240,8 @@ A live streaming session keeps a warm `claude` process around (~300 MB each). Se
 
 The keep-alive rule has no backstop — no idle timer, no max lifetime. That is deliberate (reaping a session with work in flight kills the work), but it means a session whose background work never finishes is never reaped on its own, and its message stream never ends. [`reapChatSession()`](/library-reference/fleet-manager/#reapchatsessionsessionid) closes such a session on demand, so a UI can offer a working "stop".
 
+For the narrower case — one runaway background task, not the whole session — [`stopTaskInSession()`](/library-reference/fleet-manager/#stoptaskinsessionsessionid-taskid) stops a single shell, subagent or monitor by id and leaves the session running. Both are keyed by session id for the same reason: background work outlives the turn that started it, so the `RuntimeSession` handle a consumer holds is already gone by the time the stop is wanted.
+
 Wake semantics:
 
 | Behavior | Rule |

--- a/docs/src/content/docs/library-reference/fleet-manager.mdx
+++ b/docs/src/content/docs/library-reference/fleet-manager.mdx
@@ -1486,6 +1486,56 @@ if (!manager.reapChatSession(sessionId)) {
 
 ---
 
+### `stopTaskInSession(sessionId, taskId)`
+
+Stops one background task in a managed chat session, leaving the session running.
+
+```typescript
+await manager.stopTaskInSession(
+  sessionId: string,
+  taskId: string
+): Promise<boolean>
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sessionId` | `string` | **Yes** | Resolved session id of a session opened with `manageLifecycle: true` |
+| `taskId` | `string` | **Yes** | Id of the background task, as carried on the session's `task_notification` messages and on the `BackgroundTaskSummary` handed to `onKeepAlive` |
+
+#### Returns
+
+`true` once the stop request has been delivered; `false` for an unknown, unmanaged or already-reaped session id. Rejects if the runtime refuses the stop — see below.
+
+#### Description
+
+The finer-grained sibling of [`reapChatSession()`](#reapchatsessionsessionid): that ends the whole session, this ends a single background shell, sub-agent or monitor and leaves everything else running. The SDK emits the terminal `task_notification` with `status: "stopped"` on the session's own message stream, so a consumer driving a UI off that stream needs no separate confirmation and no bookkeeping.
+
+Why by session id rather than on the `RuntimeSession` you hold? Because background tasks routinely outlive the turn that started them, and your handle does not — you release it when the turn's result lands. A stop reachable only through the handle would work while a turn happened to be in flight and go inert over exactly the window where a task is still running and the user is asking why. Past the turn, the reaper is the only thing still holding the session, so that is where the door has to be.
+
+<Aside type="note">
+`interrupt()` is not a substitute here either. It targets the in-flight model turn; during the background phase there is none, and interrupting would not touch the task anyway.
+</Aside>
+
+Stopping is idempotent and not ownership-gated. A task that finished a moment ago stops cleanly — the CLI answers `not_found` / `not_running` with a success — so do not guard the call with your own liveness check; that only reintroduces the race. And because the control request carries no caller id, any task in the session can be stopped by an out-of-band actor, which is what makes a UI stop button work at all.
+
+One case rejects rather than resolving: `monitor_mcp` tasks, which have no kill strategy and answer `unsupported_type`. That is surfaced deliberately — reporting a still-running task as stopped is the one outcome a stop button must never produce.
+
+```typescript
+// Per-row stop button on a running-work bar.
+try {
+  if (!(await manager.stopTaskInSession(sessionId, taskId))) {
+    logger.warn(`No live managed session ${sessionId}`);
+  }
+} catch (error) {
+  // e.g. a monitor_mcp task the CLI cannot kill — tell the user, don't swallow.
+  logger.error(`Could not stop task ${taskId}: ${(error as Error).message}`);
+}
+```
+
+---
+
 ### `listAgentCommands(agentName, options?)`
 
 Lists the slash commands available to an agent — for populating a command palette or autocomplete — in a single call.

--- a/packages/core/src/fleet-manager/__tests__/open-chat-session-resume-collision.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/open-chat-session-resume-collision.test.ts
@@ -51,6 +51,7 @@ function fakeManagedSession(): RuntimeSession {
     interrupt: vi.fn().mockResolvedValue(undefined),
     listCommands: vi.fn().mockResolvedValue([]),
     setModel: vi.fn().mockResolvedValue(undefined),
+    stopTask: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/core/src/fleet-manager/__tests__/reap-chat-session.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/reap-chat-session.test.ts
@@ -32,7 +32,10 @@ const silentLogger = () => ({
 /** A background task, so the policy holds the session open and never reaps it. */
 const TASK = { id: "t1", type: "shell", status: "running", description: "server" };
 
-function fakeSession(): RuntimeSession & { close: ReturnType<typeof vi.fn> } {
+function fakeSession(): RuntimeSession & {
+  close: ReturnType<typeof vi.fn>;
+  stopTask: ReturnType<typeof vi.fn>;
+} {
   async function* empty(): AsyncGenerator<never> {}
   return {
     messages: empty(),
@@ -40,6 +43,7 @@ function fakeSession(): RuntimeSession & { close: ReturnType<typeof vi.fn> } {
     interrupt: vi.fn().mockResolvedValue(undefined),
     listCommands: vi.fn().mockResolvedValue([]),
     setModel: vi.fn().mockResolvedValue(undefined),
+    stopTask: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/core/src/fleet-manager/__tests__/stop-task-in-session.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/stop-task-in-session.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for FleetManager.stopTaskInSession — stopping ONE background task in a
+ * managed session, addressed by session id (edspencer/herdctl#449).
+ *
+ * These drive the REAL SessionLifecycleManager + SessionReaper the fleet builds
+ * in initialize(), so what's covered is the actual wiring (a private
+ * `sessionLifecycle` reached through a public method), not a stub of it. The
+ * reaper-level contract is covered in session/__tests__/stop-task-in-session.test.ts.
+ *
+ * The case that matters most is the post-turn one. A consumer holds its
+ * `RuntimeSession` for the duration of a turn and releases it when the result
+ * lands, but background shells, sub-agents and monitors outlive that turn — so a
+ * stop that is only reachable through the handle goes inert exactly over the
+ * window where the user is watching something run and wants it stopped. Only the
+ * reaper still holds the session there, which is why this is keyed by id.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Claude SDK to prevent real API calls.
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+import type { RuntimeSession } from "../../runner/runtime/interface.js";
+import type { SessionLifecycleSignal } from "../../session/types.js";
+import { SessionTaskControlUnsupportedError } from "../errors.js";
+import { FleetManager } from "../fleet-manager.js";
+
+const silentLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+/** A background task, so the policy holds the session open and never reaps it. */
+const TASK = { id: "t1", type: "shell", status: "running", description: "server" };
+
+function fakeSession(): RuntimeSession & {
+  close: ReturnType<typeof vi.fn>;
+  stopTask: ReturnType<typeof vi.fn>;
+} {
+  async function* empty(): AsyncGenerator<never> {}
+  return {
+    messages: empty(),
+    send: vi.fn().mockResolvedValue(undefined),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    listCommands: vi.fn().mockResolvedValue([]),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    stopTask: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** The turn is producing output — a turn is in flight. */
+function activitySignal(sessionId: string): SessionLifecycleSignal {
+  return { kind: "activity", sessionId, sessionCrons: [], backgroundTasks: [TASK] };
+}
+
+/** The turn ENDED, and left live background work behind: the #449 gap-2 state. */
+function turnEndKeepingAlive(sessionId: string): SessionLifecycleSignal {
+  return { kind: "turn_end", sessionId, sessionCrons: [], backgroundTasks: [TASK] };
+}
+
+describe("FleetManager.stopTaskInSession()", () => {
+  let tempDir: string;
+  let configPath: string;
+  let stateDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "fleet-stop-task-in-session-"));
+    const configDir = join(tempDir, "config");
+    stateDir = join(tempDir, ".herdctl");
+    await mkdir(join(configDir, "agents"), { recursive: true });
+    await mkdir(join(tempDir, "workspace"), { recursive: true });
+
+    const yaml = await import("yaml");
+    await writeFile(
+      join(configDir, "agents", "keeper.yaml"),
+      yaml.stringify({ name: "keeper", working_directory: join(tempDir, "workspace") }),
+    );
+    configPath = join(configDir, "herdctl.yaml");
+    await writeFile(
+      configPath,
+      yaml.stringify({ version: 1, agents: [{ path: "./agents/keeper.yaml" }] }),
+    );
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  function createManager() {
+    return new FleetManager({ configPath, stateDir, checkInterval: 10000, logger: silentLogger() });
+  }
+
+  async function initializedManager() {
+    const manager = createManager();
+    await manager.initialize();
+    const lifecycle = manager.getSessionLifecycle();
+    if (!lifecycle) throw new Error("expected a session lifecycle manager after initialize()");
+    return { manager, lifecycle };
+  }
+
+  it("returns false before initialize(), when there is no lifecycle manager yet", async () => {
+    await expect(createManager().stopTaskInSession("sess-1", "t1")).resolves.toBe(false);
+  });
+
+  it("stops a task in a session whose turn is still in flight", async () => {
+    const { manager, lifecycle } = await initializedManager();
+    const session = fakeSession();
+    const managed = lifecycle.manage(session, "keeper");
+    await managed.handleSignal(activitySignal("sess-1"));
+
+    await expect(manager.stopTaskInSession("sess-1", "t1")).resolves.toBe(true);
+    expect(session.stopTask).toHaveBeenCalledWith("t1");
+  });
+
+  it("stops a task AFTER the turn ended — the gap this exists to close", async () => {
+    const { manager, lifecycle } = await initializedManager();
+    const session = fakeSession();
+    const managed = lifecycle.manage(session, "keeper");
+
+    // A turn runs and then ends, leaving background work behind. This is where a
+    // consumer releases its RuntimeSession: its turn is over and the result has
+    // landed. Everything below reaches the task by session id ALONE — the handle
+    // above is only ever read as a spy, never called through.
+    await managed.handleSignal(activitySignal("sess-1"));
+    await managed.handleSignal(turnEndKeepingAlive("sess-1"));
+
+    // The policy is holding the session open solely for the background task, with
+    // no timer and no backstop: nothing will reap it while the task runs.
+    expect(managed.isLive()).toBe(true);
+    expect(session.close).not.toHaveBeenCalled();
+
+    await expect(manager.stopTaskInSession("sess-1", "t1")).resolves.toBe(true);
+    expect(session.stopTask).toHaveBeenCalledTimes(1);
+    expect(session.stopTask).toHaveBeenCalledWith("t1");
+
+    // Stopping the task is not closing the session: the session survives, and the
+    // SDK's own terminal task_notification is what ends the work.
+    expect(managed.isLive()).toBe(true);
+    expect(session.close).not.toHaveBeenCalled();
+    expect(session.interrupt).not.toHaveBeenCalled();
+  });
+
+  it("still stops a task across several post-turn signals (idempotent, repeatable)", async () => {
+    const { manager, lifecycle } = await initializedManager();
+    const session = fakeSession();
+    const managed = lifecycle.manage(session, "keeper");
+    await managed.handleSignal(turnEndKeepingAlive("sess-1"));
+    // A second background task appears while the session sits post-turn.
+    await managed.handleSignal({
+      kind: "background_tasks_changed",
+      sessionId: "sess-1",
+      sessionCrons: [],
+      backgroundTasks: [TASK, { ...TASK, id: "t2" }],
+    });
+
+    await expect(manager.stopTaskInSession("sess-1", "t2")).resolves.toBe(true);
+    // Stopping something that already finished is a success, not an error — the
+    // CLI answers not_found/not_running that way and we add no liveness gate.
+    await expect(manager.stopTaskInSession("sess-1", "t2")).resolves.toBe(true);
+    expect(session.stopTask.mock.calls).toEqual([["t2"], ["t2"]]);
+  });
+
+  it("returns false for an unknown session id, and for one already reaped", async () => {
+    const { manager, lifecycle } = await initializedManager();
+    const session = fakeSession();
+    await lifecycle.manage(session, "keeper").handleSignal(turnEndKeepingAlive("sess-1"));
+
+    await expect(manager.stopTaskInSession("who-dis", "t1")).resolves.toBe(false);
+
+    expect(manager.reapChatSession("sess-1")).toBe(true);
+    await expect(manager.stopTaskInSession("sess-1", "t1")).resolves.toBe(false);
+    expect(session.stopTask).not.toHaveBeenCalled();
+    await new Promise((r) => setTimeout(r, 5)); // close() is deferred a tick
+  });
+
+  it("rejects when the runtime refuses the stop (monitor_mcp: unsupported_type)", async () => {
+    const { manager, lifecycle } = await initializedManager();
+    const session = fakeSession();
+    const managed = lifecycle.manage(session, "keeper");
+    await managed.handleSignal(turnEndKeepingAlive("sess-1"));
+    session.stopTask.mockRejectedValue(new Error("unsupported_type"));
+
+    // A false success is worse than an error: the consumer would render the task
+    // as stopped while it keeps running.
+    await expect(manager.stopTaskInSession("sess-1", "monitor-1")).rejects.toThrow(
+      "unsupported_type",
+    );
+
+    // ...and the refusal leaves the fleet's reaper state untouched.
+    expect(managed.isLive()).toBe(true);
+    expect(manager.reapChatSession("sess-1")).toBe(true);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects with SessionTaskControlUnsupportedError for a handle without stopTask", async () => {
+    const { manager, lifecycle } = await initializedManager();
+    const legacy = { ...fakeSession(), stopTask: undefined } as unknown as RuntimeSession;
+    const managed = lifecycle.manage(legacy, "keeper");
+    await managed.handleSignal(turnEndKeepingAlive("sess-1"));
+
+    await expect(manager.stopTaskInSession("sess-1", "t1")).rejects.toBeInstanceOf(
+      SessionTaskControlUnsupportedError,
+    );
+    expect(managed.isLive()).toBe(true);
+  });
+});

--- a/packages/core/src/fleet-manager/errors.ts
+++ b/packages/core/src/fleet-manager/errors.ts
@@ -43,6 +43,7 @@ export const FleetManagerErrorCode = {
   JOB_FORK_ERROR: "JOB_FORK_ERROR",
   INVALID_WORKING_DIRECTORY_OVERRIDE: "INVALID_WORKING_DIRECTORY_OVERRIDE",
   STREAMING_SESSION_UNSUPPORTED: "STREAMING_SESSION_UNSUPPORTED",
+  SESSION_TASK_CONTROL_UNSUPPORTED: "SESSION_TASK_CONTROL_UNSUPPORTED",
 
   // Distribution errors
   SOURCE_PARSE_ERROR: "SOURCE_PARSE_ERROR",
@@ -732,6 +733,40 @@ export class StreamingSessionUnsupportedError extends FleetManagerError {
     );
     this.name = "StreamingSessionUnsupportedError";
     this.runtime = options?.runtime;
+  }
+}
+
+/**
+ * Thrown when a live session cannot service a per-task control request because
+ * its `RuntimeSession` handle carries no `stopTask`.
+ *
+ * `stopTask` is a required member of `RuntimeSession`, and the only runtime that
+ * opens sessions at all is the SDK runtime — so in-tree this is unreachable. It
+ * exists because the handle is a plain structural object supplied by whoever
+ * opened the session: an older build, a test double, or a third-party runtime
+ * can satisfy the type nominally and still not carry the method at runtime.
+ *
+ * The alternative — resolving quietly — would report a task as stopped that is
+ * still running, which is the one outcome a stop button must never produce. So
+ * this is thrown, and kept distinct from the `false` that
+ * {@link import("./fleet-manager.js").FleetManager.stopTaskInSession} returns
+ * for a session that is simply not live.
+ */
+export class SessionTaskControlUnsupportedError extends FleetManagerError {
+  /** The session whose runtime handle cannot stop tasks */
+  public readonly sessionId: string;
+
+  constructor(sessionId: string, options?: { cause?: Error }) {
+    super(
+      `Session "${sessionId}" cannot stop background tasks: its runtime session ` +
+        "handle does not implement stopTask. Per-task control requires the SDK runtime.",
+      {
+        cause: options?.cause,
+        code: FleetManagerErrorCode.SESSION_TASK_CONTROL_UNSUPPORTED,
+      },
+    );
+    this.name = "SessionTaskControlUnsupportedError";
+    this.sessionId = sessionId;
   }
 }
 

--- a/packages/core/src/fleet-manager/fleet-manager.ts
+++ b/packages/core/src/fleet-manager/fleet-manager.ts
@@ -1169,6 +1169,34 @@ export class FleetManager extends EventEmitter implements FleetManagerContext {
     return this.sessionLifecycle?.reaper.forceReap(sessionId) ?? false;
   }
   /**
+   * Stop ONE background task in a managed chat session, by session id.
+   *
+   * The finer-grained sibling of {@link reapChatSession}: that ends the whole
+   * session, this ends a single background shell / sub-agent / monitor and
+   * leaves the session running. The SDK emits the terminal
+   * `task_notification{status:"stopped"}` on the session's own message stream,
+   * so a consumer driving a UI off that stream needs no separate confirmation.
+   *
+   * Keyed by session id rather than taken on the {@link RuntimeSession} handle
+   * for the same reason `reapChatSession` is: background tasks outlive the turn
+   * that started them, and the consumer's handle does not. Only the reaper holds
+   * the session across that gap. See {@link SessionReaper.stopTaskInSession}.
+   *
+   * Idempotent — stopping a task that already finished resolves normally, since
+   * the CLI answers `not_found` / `not_running` with a success. Not
+   * ownership-gated: any task in the session can be stopped by an out-of-band
+   * caller.
+   *
+   * Only applies to sessions opened with `manageLifecycle: true`. Returns
+   * `false` for an unknown, unmanaged, or already-reaped session id. Rejects if
+   * the runtime refuses the stop — notably `monitor_mcp` tasks, which the CLI
+   * cannot kill and rejects with `unsupported_type`; that surfaces rather than
+   * being reported as a success.
+   */
+  async stopTaskInSession(sessionId: string, taskId: string): Promise<boolean> {
+    return (await this.sessionLifecycle?.reaper.stopTaskInSession(sessionId, taskId)) ?? false;
+  }
+  /**
    * List the slash commands available to an agent in one shot.
    *
    * A convenience wrapper that opens a streaming session, reads its command list,

--- a/packages/core/src/fleet-manager/index.ts
+++ b/packages/core/src/fleet-manager/index.ts
@@ -81,6 +81,7 @@ export {
   // Schedule mutation gate error (D2)
   ScheduleMutationDisabledError,
   ScheduleNotFoundError,
+  SessionTaskControlUnsupportedError,
   StreamingSessionUnsupportedError,
 } from "./errors.js";
 // Event emitters (US-4: Extract Event Emitters Module)

--- a/packages/core/src/runner/runtime/__tests__/session-stop-task.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/session-stop-task.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for `RuntimeSession.stopTask` — the SDK runtime forwarding the SDK's
+ * `stop_task` control request (gap 1 of edspencer/herdctl#449).
+ *
+ * The `Query` handle `openSession()` opens is a `const` in a closure: unreachable
+ * from outside except through the methods the returned literal exposes. So the
+ * thing worth testing is exactly that the new member reaches `Query.stopTask`
+ * with the caller's task id — and that a refusal (a `monitor_mcp` task, which the
+ * CLI has no kill strategy for) comes back as a rejection rather than a
+ * fabricated success.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+/** The Query test double every openSession() in this file is handed. */
+function fakeQuery() {
+  return {
+    [Symbol.asyncIterator]: async function* () {},
+    supportedCommands: vi.fn().mockResolvedValue([]),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    stopTask: vi.fn().mockResolvedValue(undefined),
+    return: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+let currentQuery = fakeQuery();
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(() => currentQuery),
+  createSdkMcpServer: vi.fn(() => ({})),
+  tool: vi.fn(() => ({})),
+}));
+
+import type { ResolvedAgent } from "../../../config/index.js";
+import { SDKRuntime } from "../sdk-runtime.js";
+
+const agent = { name: "keeper", qualifiedName: "keeper" } as unknown as ResolvedAgent;
+
+function openSession(onLifecycleSignal?: () => void) {
+  currentQuery = fakeQuery();
+  const session = new SDKRuntime().openSession({ prompt: "hi", agent, onLifecycleSignal });
+  return { session, q: currentQuery };
+}
+
+describe("RuntimeSession.stopTask", () => {
+  it("forwards the task id to the SDK Query's stopTask", async () => {
+    const { session, q } = openSession();
+
+    await session.stopTask("task-abc");
+
+    expect(q.stopTask).toHaveBeenCalledTimes(1);
+    expect(q.stopTask).toHaveBeenCalledWith("task-abc");
+  });
+
+  it("stops one task without interrupting the turn or closing the session", async () => {
+    const { session, q } = openSession();
+
+    await session.stopTask("task-abc");
+
+    // The whole point of a per-task stop: everything else is left running.
+    expect(q.interrupt).not.toHaveBeenCalled();
+    expect(q.return).not.toHaveBeenCalled();
+  });
+
+  it("stays reachable when a lifecycle tap wraps the message stream", async () => {
+    // The interesting case per #449: with `onLifecycleSignal` the caller gets a
+    // wrapper generator instead of the Query, so `session.messages` is no longer
+    // an escape hatch onto it. stopTask must still reach through.
+    const { session, q } = openSession(vi.fn());
+
+    await session.stopTask("task-abc");
+
+    expect(q.stopTask).toHaveBeenCalledWith("task-abc");
+  });
+
+  it("propagates a refusal (monitor_mcp: unsupported_type) instead of resolving", async () => {
+    const { session, q } = openSession();
+    q.stopTask.mockRejectedValue(new Error("unsupported_type"));
+
+    await expect(session.stopTask("monitor-1")).rejects.toThrow("unsupported_type");
+  });
+
+  it("resolves for an already-finished task — the CLI answers not_found with a success", async () => {
+    // Idempotency is the CLI's, not ours; assert we add no liveness pre-check
+    // that would reintroduce the race.
+    const { session, q } = openSession();
+
+    await expect(session.stopTask("already-done")).resolves.toBeUndefined();
+    expect(q.stopTask).toHaveBeenCalledWith("already-done");
+  });
+});

--- a/packages/core/src/runner/runtime/interface.ts
+++ b/packages/core/src/runner/runtime/interface.ts
@@ -178,6 +178,36 @@ export interface RuntimeSession {
   /** Change the model used for subsequent turns in this session. */
   setModel(model?: string): Promise<void>;
 
+  /**
+   * Stop ONE background task in this session by id — a background shell, a
+   * sub-agent, a monitor — without touching the rest of the session.
+   *
+   * Distinct from {@link interrupt} (which stops the in-flight model turn, and
+   * during the background phase there is none) and from closing the session
+   * (which stops everything). The SDK emits the terminal
+   * `task_notification{status:"stopped"}` on {@link messages} itself, so callers
+   * need no separate confirmation and no bookkeeping.
+   *
+   * Idempotent by construction: the CLI converts `not_found` / `not_running`
+   * into a success, so stopping a task that just finished on its own resolves
+   * normally. Do NOT wrap this in a liveness pre-check — that only reintroduces
+   * the race it is designed to absorb.
+   *
+   * Not ownership-gated: this control request carries no caller id, so it can
+   * stop any task in the session. That is the point — an out-of-band actor (a
+   * UI's stop button) is exactly who needs it.
+   *
+   * Rejects when the task cannot be stopped for a reason that is not a race —
+   * notably `monitor_mcp` tasks, for which the CLI has no kill strategy and
+   * answers `unsupported_type`. That rejection is surfaced rather than
+   * swallowed: a caller needs to know the button did nothing.
+   *
+   * @param taskId - The background task's id, as carried on the session's
+   *   `task_notification` messages and on
+   *   {@link import("../../session/types.js").BackgroundTaskSummary}.
+   */
+  stopTask(taskId: string): Promise<void>;
+
   /** Close the session, ending the input stream and shutting down the query. */
   close(): Promise<void>;
 }

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -203,8 +203,8 @@ export class SDKRuntime implements RuntimeInterface {
    * The initial `options.prompt` (if any) is sent as the first turn; further
    * turns are sent via {@link RuntimeSession.send}. Because the input iterable
    * stays open, the returned SDK `Query` handle is retained so its control
-   * requests (`interrupt`, `supportedCommands`, `setModel`) stay available for
-   * the life of the session.
+   * requests (`interrupt`, `supportedCommands`, `setModel`, `stopTask`) stay
+   * available for the life of the session.
    */
   openSession(options: RuntimeExecuteOptions): RuntimeSession {
     const sdkOptions = this.buildSdkOptions(options);
@@ -257,6 +257,7 @@ export class SDKRuntime implements RuntimeInterface {
       },
       listCommands: () => q.supportedCommands(),
       setModel: (model?: string) => q.setModel(model),
+      stopTask: (taskId: string) => q.stopTask(taskId),
       close: async () => {
         input.end();
         // Best-effort: tell the SDK generator we're done so it tears down the CLI.

--- a/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
+++ b/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
@@ -23,6 +23,7 @@ function fakeSession(): RuntimeSession {
     interrupt: vi.fn().mockResolvedValue(undefined),
     listCommands: vi.fn().mockResolvedValue([]),
     setModel: vi.fn().mockResolvedValue(undefined),
+    stopTask: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -19,7 +19,10 @@ async function* stream(messages: SDKMessage[]): AsyncGenerator<SDKMessage> {
   for (const m of messages) yield m;
 }
 
-function fakeSession(): RuntimeSession & { close: ReturnType<typeof vi.fn> } {
+function fakeSession(): RuntimeSession & {
+  close: ReturnType<typeof vi.fn>;
+  stopTask: ReturnType<typeof vi.fn>;
+} {
   async function* empty(): AsyncGenerator<never> {}
   return {
     messages: empty(),
@@ -27,6 +30,7 @@ function fakeSession(): RuntimeSession & { close: ReturnType<typeof vi.fn> } {
     interrupt: vi.fn().mockResolvedValue(undefined),
     listCommands: vi.fn().mockResolvedValue([]),
     setModel: vi.fn().mockResolvedValue(undefined),
+    stopTask: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/core/src/session/__tests__/stop-task-in-session.test.ts
+++ b/packages/core/src/session/__tests__/stop-task-in-session.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for SessionReaper.stopTaskInSession — the session-id-keyed door onto a
+ * live session's per-task control request (gap 2 of edspencer/herdctl#449).
+ *
+ * The reaper is the only thing that holds a session across the gap between "the
+ * turn ended" and "its background work finished", so it is the only place a stop
+ * can be addressed by session id. These cover the contract: `false` means
+ * exactly "no live session with this id", a refusal propagates, and neither a
+ * refusal nor an unsupported handle disturbs the reap decision.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { SessionTaskControlUnsupportedError } from "../../fleet-manager/errors.js";
+import type { RuntimeSession } from "../../runner/runtime/interface.js";
+import { SessionReaper } from "../session-reaper.js";
+import type { SessionLifecycleSignal } from "../types.js";
+import type { WakeRegistry } from "../wake-registry.js";
+
+const tick = () => new Promise((r) => setTimeout(r, 5));
+
+function fakeSession(): RuntimeSession & {
+  close: ReturnType<typeof vi.fn>;
+  stopTask: ReturnType<typeof vi.fn>;
+} {
+  async function* empty(): AsyncGenerator<never> {}
+  return {
+    messages: empty(),
+    send: vi.fn().mockResolvedValue(undefined),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    listCommands: vi.fn().mockResolvedValue([]),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    stopTask: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function fakeRegistry() {
+  return {
+    reconcile: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+  } as unknown as WakeRegistry;
+}
+
+const TASK = { id: "t1", type: "shell", status: "running", description: "server" };
+
+/** A `turn_end` carrying live background work: the turn is over, the tasks are not. */
+function turnEndKeepingAlive(sessionId = "sess-1"): SessionLifecycleSignal {
+  return { kind: "turn_end", sessionId, sessionCrons: [], backgroundTasks: [TASK] };
+}
+
+describe("SessionReaper.stopTaskInSession()", () => {
+  it("resolves the live session by id and forwards the task id", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/keeper");
+    await managed.handleSignal(turnEndKeepingAlive());
+
+    await expect(reaper.stopTaskInSession("sess-1", "t1")).resolves.toBe(true);
+    expect(session.stopTask).toHaveBeenCalledWith("t1");
+  });
+
+  it("returns false for an unknown session id, without touching any session", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    await reaper.manage(session, "team/keeper").handleSignal(turnEndKeepingAlive());
+
+    await expect(reaper.stopTaskInSession("who-dis", "t1")).resolves.toBe(false);
+    expect(session.stopTask).not.toHaveBeenCalled();
+  });
+
+  it("returns false once the session has been reaped", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/keeper");
+    await managed.handleSignal(turnEndKeepingAlive());
+
+    expect(reaper.forceReap("sess-1")).toBe(true);
+    expect(managed.isLive()).toBe(false);
+
+    await expect(reaper.stopTaskInSession("sess-1", "t1")).resolves.toBe(false);
+    expect(session.stopTask).not.toHaveBeenCalled();
+    await tick();
+  });
+
+  it("returns false for a detached session (the consumer took over the lifetime)", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/keeper");
+    await managed.handleSignal(turnEndKeepingAlive());
+    managed.detach();
+
+    await expect(reaper.stopTaskInSession("sess-1", "t1")).resolves.toBe(false);
+    expect(session.stopTask).not.toHaveBeenCalled();
+  });
+
+  it("addresses the right session when several are live at once", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const a = fakeSession();
+    const b = fakeSession();
+    await reaper.manage(a, "team/a").handleSignal(turnEndKeepingAlive("sess-a"));
+    await reaper.manage(b, "team/b").handleSignal(turnEndKeepingAlive("sess-b"));
+
+    await expect(reaper.stopTaskInSession("sess-b", "t1")).resolves.toBe(true);
+    expect(b.stopTask).toHaveBeenCalledWith("t1");
+    expect(a.stopTask).not.toHaveBeenCalled();
+  });
+
+  it("propagates a monitor_mcp refusal and leaves the session live and reapable", async () => {
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/keeper");
+    await managed.handleSignal(turnEndKeepingAlive());
+    session.stopTask.mockRejectedValue(new Error("unsupported_type"));
+
+    await expect(reaper.stopTaskInSession("sess-1", "monitor-1")).rejects.toThrow(
+      "unsupported_type",
+    );
+
+    // A refusal is the runtime's answer, not a reaper state transition: the
+    // session must survive it intact, and the ordinary reap must still work.
+    expect(managed.isLive()).toBe(true);
+    expect(session.close).not.toHaveBeenCalled();
+    expect(reaper.isSessionLive("sess-1")).toBe(true);
+    expect(reaper.forceReap("sess-1")).toBe(true);
+    await tick();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws SessionTaskControlUnsupportedError when the handle has no stopTask", async () => {
+    // Unreachable in-tree — `stopTask` is required on RuntimeSession and only the
+    // SDK runtime opens sessions — but the handle is a structural object from an
+    // arbitrary caller, so an older or foreign one can still turn up. Fail loudly:
+    // resolving would report a still-running task as stopped.
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    const legacy = { ...session, stopTask: undefined } as unknown as RuntimeSession;
+    const managed = reaper.manage(legacy, "team/keeper");
+    await managed.handleSignal(turnEndKeepingAlive());
+
+    await expect(reaper.stopTaskInSession("sess-1", "t1")).rejects.toBeInstanceOf(
+      SessionTaskControlUnsupportedError,
+    );
+    expect(managed.isLive()).toBe(true);
+    expect(reaper.isSessionLive("sess-1")).toBe(true);
+  });
+
+  it("does not pre-check task liveness — an unknown task id is still forwarded", async () => {
+    // The CLI converts not_found/not_running into a success, so a task that
+    // finished a millisecond ago stops cleanly. A liveness gate here would only
+    // reintroduce that race.
+    const reaper = new SessionReaper({ registry: fakeRegistry() });
+    const session = fakeSession();
+    await reaper.manage(session, "team/keeper").handleSignal(turnEndKeepingAlive());
+
+    await expect(reaper.stopTaskInSession("sess-1", "a-task-nobody-reported")).resolves.toBe(true);
+    expect(session.stopTask).toHaveBeenCalledWith("a-task-nobody-reported");
+  });
+});

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -17,6 +17,7 @@
  * See edspencer/herdctl#307.
  */
 
+import { SessionTaskControlUnsupportedError } from "../fleet-manager/errors.js";
 import type { RuntimeSession } from "../runner/runtime/interface.js";
 import { createLogger } from "../utils/logger.js";
 import { decideReap } from "./reaper-policy.js";
@@ -193,6 +194,47 @@ export class SessionReaper {
     const managed = this.liveById.get(sessionId);
     if (!managed?.isLive()) return false;
     this.reap(managed, sessionId, "force-reaped on request");
+    return true;
+  }
+
+  /**
+   * Stop ONE background task in a live managed session, by session id.
+   *
+   * `RuntimeSession.stopTask` exists, but a consumer cannot reach it when it
+   * matters. It holds the handle only for the duration of a turn and releases it
+   * when the turn's result lands — while background shells, sub-agents and
+   * monitors routinely outlive that turn. So a handle-scoped stop works only
+   * while a turn happens to be in flight, and goes inert over exactly the long
+   * tail where something is still running and the user is asking why.
+   *
+   * Consumers cannot fix that by holding the handle longer, because they do not
+   * own the session's lifetime — this reaper does, and {@link liveById} already
+   * keeps the session past the turn precisely so its background work can finish.
+   * This is the door onto that state: same shape as {@link forceReap}, one step
+   * short of it — stop this *task*, not the whole session.
+   *
+   * Deliberately does NOT pre-check that the task is live. The CLI answers
+   * `not_found` / `not_running` with a success, so stopping a task that just
+   * completed on its own resolves normally; a liveness gate here would only
+   * reintroduce that race. Nor is it ownership-gated — the control request
+   * carries no caller id, which is what makes an out-of-band stop button work.
+   *
+   * Rejections from the runtime propagate. Notably `monitor_mcp` tasks, which
+   * the CLI has no kill strategy for and rejects with `unsupported_type`: a
+   * consumer needs to see that the stop did nothing rather than render a
+   * success. A rejection leaves reaper state untouched — the session stays live
+   * and reapable, and nothing about the reap decision is disturbed.
+   *
+   * @returns `true` once the stop request has been delivered — matching
+   *   {@link forceReap}, `false` means only "no live session with this id".
+   * @throws {@link import("../fleet-manager/errors.js").SessionTaskControlUnsupportedError}
+   *   if the live session's handle carries no `stopTask`.
+   */
+  async stopTaskInSession(sessionId: string, taskId: string): Promise<boolean> {
+    const managed = this.liveById.get(sessionId);
+    if (!managed?.isLive()) return false;
+    this.logger.debug(`Stopping task ${taskId} in session ${sessionId} (${managed.agent})`);
+    await managed.stopTask(taskId);
     return true;
   }
 
@@ -438,6 +480,21 @@ class ManagedSessionImpl implements ManagedSession {
 
   detach(): void {
     this.markDone();
+  }
+
+  /**
+   * Forward a stop-task control request to the underlying session handle.
+   *
+   * The handle is a plain structural object supplied by whoever opened the
+   * session, so `stopTask` may be missing at runtime even though the type
+   * requires it (an older build, a foreign runtime). Throw rather than resolve:
+   * a silent success here reports a still-running task as stopped.
+   */
+  stopTask(taskId: string): Promise<void> {
+    if (typeof this.session.stopTask !== "function") {
+      throw new SessionTaskControlUnsupportedError(this.resolvedSessionId ?? "unknown");
+    }
+    return this.session.stopTask(taskId);
   }
 
   /** Reap: mark not-live and close the session after the current hook unwinds. */


### PR DESCRIPTION
Closes #449.

Two gaps stood between a consumer and stopping **one** background task in a live session. Both are closed here.

## Gap 1 — `RuntimeSession.stopTask(taskId)`

`SDKRuntime.openSession` captured the SDK `Query` as a `const` in a closure: never assigned to `this`, never returned, no generic control-request passthrough. `session.messages` *is* the `Query` behind a cast, but any caller passing `onLifecycleSignal` — the interesting case, and the one the reaper uses — gets the `tapLifecycleStream` wrapper generator instead, which forwards nothing. So the method is added to the interface and forwarded in the returned literal beside `setModel`. No dependency bump: `stopTask` is already in the installed SDK (`0.3.215`).

## Gap 2 — `FleetManager.stopTaskInSession(sessionId, taskId)`

The half that actually bites. Background shells, sub-agents and monitors routinely outlive the turn that started them, while a consumer holds its `RuntimeSession` only until the turn's result lands. A handle-scoped stop therefore works while a turn happens to be in flight and goes inert exactly over the long tail where something is still running and the user is asking why. Consumers can't fix that by holding the handle longer — they don't own the session's lifetime, the reaper does, and `SessionReaper.liveById` already keeps the session across that gap. This is the door onto that state, mirroring the existing `reapChatSession` / `forceReap` pair: `SessionReaper.stopTaskInSession` under `FleetManager.stopTaskInSession`.

Semantics carried over from the CLI's own handler: **idempotent** (`not_found` / `not_running` are successes, and no liveness pre-check is added that would reintroduce that race), **not ownership-gated** (the control request carries no caller id — that's what makes an out-of-band stop button work), and **self-notifying** (the SDK emits the terminal `task_notification{status:"stopped"}` on the session's own stream).

## The three decisions

**1. A live session whose runtime cannot stop tasks → throw, don't return `false`.**

Moot today — `stopTask` is a *required* member of `RuntimeSession`, and `openSession` is optional on `RuntimeInterface` with only `SDKRuntime` implementing it — but the handle is a plain structural object supplied by whoever opened the session, so an older build, a foreign runtime or a stale test double can satisfy the type nominally and still not carry the method. Resolving quietly there would report a still-running task as stopped, which is the one outcome a stop button must never produce. So it throws a new `SessionTaskControlUnsupportedError` (extends `FleetManagerError`, code `SESSION_TASK_CONTROL_UNSUPPORTED`, exported from the barrel). The payoff is that `false` keeps a single unambiguous meaning: *no live session with this id*.

**2. `monitor_mcp`'s `unsupported_type` rejection propagates.** Agreed with your recommendation. A `monitor_mcp` task has no kill strategy in the CLI, and translating its rejection into a success would render a stopped-looking row for a task that is still running. Same reasoning as decision 1, so the two are consistent: every "the stop did not happen" outcome surfaces as a rejection, and `false` never means failure. A rejection is also inert with respect to reaper state — the session stays live, registered, and reapable — which the tests pin.

**3. `false` (not throw) for a session that is not live.** Matches `reapChatSession`. "The session is already gone" is a race a consumer will hit routinely — a reap landing between render and click — and it isn't exceptional: the tasks went with it, so the user's intent is already satisfied. `Promise<boolean>` rather than `boolean` since the underlying control request is async.

## Tests

- `runner/runtime/__tests__/session-stop-task.test.ts` — the delegation reaches `Query.stopTask` with the right id; still reaches it when a lifecycle tap has replaced the message stream (the case that closes the `messages`-as-escape-hatch loophole); stops nothing else (no `interrupt`, no `return`); a refusal propagates.
- `session/__tests__/stop-task-in-session.test.ts` — resolves a live session by id; `false` for unknown / reaped / detached; addresses the right session when several are live; a refusal leaves the session live, registered and still reapable; the unsupported-handle throw; and no liveness pre-check on the task id.
- `fleet-manager/__tests__/stop-task-in-session.test.ts` — drives the **real** `SessionLifecycleManager` + `SessionReaper` the fleet builds in `initialize()`, as `reap-chat-session.test.ts` does. Includes the Gap-2 case explicitly: a turn runs, ends leaving live background work, and the task is then stopped by session id alone — the `RuntimeSession` handle is only ever read as a spy from that point, never called through. It asserts the session survives the stop (not closed, not interrupted), so it can't pass against a change that only fixes Gap 1.

The four existing fakes named in the issue gained the new member.

## Verification

`pnpm typecheck` green across all 7 packages, `pnpm build` green (including docs), biome clean on the changed files. Full suite: 3727 passed, 1 pre-existing failure unrelated to this change — `state/__tests__/directory.test.ts > throws StateDirectoryCreateError when parent directory is not writable`, which fails identically on a clean `main` on this box because it runs as uid 0 and `chmod 0o555` doesn't stop root. Core coverage 85.25% lines / 77.41% branches, above the package's 74/65 gates.

Changeset: minor on `@herdctl/core`. Docs: a `stopTaskInSession` section in the FleetManager reference plus a pointer from the sessions concept page.

## Consumer

Unblocks edspencer/paddock#848 — a per-row stop button on its running-work bar, which needs Gap 2 specifically for the background phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to stop individual background tasks in active sessions without ending the session or interrupting other tasks.
  * Added session-level task stopping by session ID, including idempotent handling of completed tasks.
  * Added clear errors when task control is unavailable and surfaced runtime refusal errors.
  * Added notifications when tasks are stopped.

* **Documentation**
  * Documented task stopping and its behavior for active, unavailable, and already-closed sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->