### PR TITLE
fix(web): chat load timeouts/retry, Show all sessions, deterministic All Chats search (#170, #150, #145, #275)

### DIFF
--- a/.changeset/lucky-pugs-attack.md
+++ b/.changeset/lucky-pugs-attack.md
@@ -1,0 +1,11 @@
+---
+"@herdctl/web": patch
+---
+
+Fix a cluster of dashboard bugs in chat and All Chats.
+
+- **Chat messages now time out and can be retried (#170).** `fetchChatMessages` (and the ad hoc equivalent) had no timeout, so a hung API call left the feed on "Loading messages..." forever. Requests are now aborted after 15s with a clear error, and both the error banner and the empty state offer a Retry.
+- **Existing sessions no longer show a misleading empty state (#170).** A session that loaded zero messages said "Send a message to start the conversation"; it now reports "No messages found for this session" with a retry, while genuinely new chats keep the original prompt.
+- **"Show all" in a directory group actually expands it (#150).** The render slice was pinned to the first 10 sessions no matter how many were loaded. Clicking now reveals every loaded session and keeps paging from the server while more remain.
+- **Search no longer leaves empty directory groups behind (#275).** A group that matched only by its path or agent name filtered all of its own sessions away and rendered a confusing per-group "no sessions" message. Such a group now shows all of its sessions, and groups that match nothing are dropped entirely so the single top-level "No matching sessions" state is used consistently.
+- **WebSocket messages sent immediately on connect are no longer dropped (#275).** The server attached its `message` listener only after awaiting the initial fleet-status snapshot, so a frame sent the instant the socket opened could be lost on a cold or loaded server. Listeners are now attached synchronously.

--- a/packages/web/src/client/src/components/all-chats/AllChatsPage.tsx
+++ b/packages/web/src/client/src/components/all-chats/AllChatsPage.tsx
@@ -7,8 +7,7 @@
 
 import { FolderSearch } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { sessionMatchesQuery } from "../../lib/session-utils";
-import type { DirectoryGroup as DirectoryGroupType } from "../../lib/types";
+import { groupMatchesQuery } from "../../lib/session-utils";
 import {
   useAllChatsActions,
   useAllChatsError,
@@ -20,23 +19,6 @@ import {
 } from "../../store";
 import { AllChatsSearch } from "./AllChatsSearch";
 import { DirectoryGroup } from "./DirectoryGroup";
-
-/**
- * Check if a directory group matches the search query.
- * A group matches if the working directory, agent name, or any session matches.
- */
-function groupMatchesQuery(group: DirectoryGroupType, query: string): boolean {
-  const lowerQuery = query.toLowerCase();
-
-  // Check working directory
-  if (group.workingDirectory.toLowerCase().includes(lowerQuery)) return true;
-
-  // Check agent name
-  if (group.agentName?.toLowerCase().includes(lowerQuery)) return true;
-
-  // Check sessions
-  return group.sessions.some((session) => sessionMatchesQuery(session, query));
-}
 
 // =============================================================================
 // Sub-Components

--- a/packages/web/src/client/src/components/all-chats/DirectoryGroup.tsx
+++ b/packages/web/src/client/src/components/all-chats/DirectoryGroup.tsx
@@ -6,7 +6,7 @@
  */
 
 import { ChevronRight, Info } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { agentPath } from "../../lib/paths";
 import { sessionMatchesQuery } from "../../lib/session-utils";
@@ -42,6 +42,11 @@ const INITIAL_SESSIONS_SHOWN = 10;
 
 export function DirectoryGroup({ group, expanded, onToggle, searchQuery }: DirectoryGroupProps) {
   const { loadMoreGroupSessions } = useAllChatsActions();
+  // Whether the user has asked to see every locally-loaded session in this
+  // group. Without this the render slice was pinned to INITIAL_SESSIONS_SHOWN
+  // forever, so "Show all" fetched more sessions that were never displayed.
+  const [showAll, setShowAll] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   // Filter sessions client-side when searching
   const filteredSessions = useMemo(() => {
@@ -50,13 +55,25 @@ export function DirectoryGroup({ group, expanded, onToggle, searchQuery }: Direc
   }, [group.sessions, searchQuery]);
 
   // Determine how many sessions to show
-  const sessionsToShow = filteredSessions.slice(0, INITIAL_SESSIONS_SHOWN);
-  const hasMoreLoaded = filteredSessions.length > INITIAL_SESSIONS_SHOWN;
+  const sessionsToShow = showAll
+    ? filteredSessions
+    : filteredSessions.slice(0, INITIAL_SESSIONS_SHOWN);
+  const hasMoreLoaded = !showAll && filteredSessions.length > INITIAL_SESSIONS_SHOWN;
   const hasMoreOnServer = group.sessionCount > group.sessions.length;
+  const remainingOnServer = group.sessionCount - group.sessions.length;
 
-  // Handle "Show all" click
-  const handleShowAll = () => {
-    loadMoreGroupSessions(group.encodedPath);
+  // Handle "Show all" click: reveal everything already loaded, and pull the
+  // next page from the server when the group is only partially loaded. The
+  // button stays visible while the server still has more.
+  const handleShowAll = async () => {
+    setShowAll(true);
+    if (!hasMoreOnServer || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      await loadMoreGroupSessions(group.encodedPath);
+    } finally {
+      setLoadingMore(false);
+    }
   };
 
   return (
@@ -130,9 +147,14 @@ export function DirectoryGroup({ group, expanded, onToggle, searchQuery }: Direc
                   <button
                     type="button"
                     onClick={handleShowAll}
-                    className="text-xs text-herd-primary hover:text-herd-primary-hover transition-colors font-medium"
+                    disabled={loadingMore}
+                    className="text-xs text-herd-primary hover:text-herd-primary-hover transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    Show all {group.sessionCount} sessions
+                    {loadingMore
+                      ? "Loading..."
+                      : showAll
+                        ? `Load more (${remainingOnServer} remaining)`
+                        : `Show all ${group.sessionCount} sessions`}
                   </button>
                 </div>
               )}

--- a/packages/web/src/client/src/components/all-chats/DirectoryGroup.tsx
+++ b/packages/web/src/client/src/components/all-chats/DirectoryGroup.tsx
@@ -9,7 +9,7 @@ import { ChevronRight, Info } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { agentPath } from "../../lib/paths";
-import { sessionMatchesQuery } from "../../lib/session-utils";
+import { groupHeaderMatchesQuery, sessionMatchesQuery } from "../../lib/session-utils";
 import type { DirectoryGroup as DirectoryGroupType } from "../../lib/types";
 import { useAllChatsActions } from "../../store";
 import { SessionRow } from "./SessionRow";
@@ -48,11 +48,14 @@ export function DirectoryGroup({ group, expanded, onToggle, searchQuery }: Direc
   const [showAll, setShowAll] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
 
-  // Filter sessions client-side when searching
+  // Filter sessions client-side when searching. When the group itself matches
+  // the query (directory path or agent name), every session in it is relevant —
+  // see the same rule in AllChatsPage.groupMatchesQuery.
   const filteredSessions = useMemo(() => {
     if (!searchQuery) return group.sessions;
+    if (groupHeaderMatchesQuery(group, searchQuery)) return group.sessions;
     return group.sessions.filter((session) => sessionMatchesQuery(session, searchQuery));
-  }, [group.sessions, searchQuery]);
+  }, [group, searchQuery]);
 
   // Determine how many sessions to show
   const sessionsToShow = showAll
@@ -129,7 +132,7 @@ export function DirectoryGroup({ group, expanded, onToggle, searchQuery }: Direc
       {expanded && (
         <div className="divide-y divide-herd-border">
           {sessionsToShow.length === 0 ? (
-            <div className="px-4 py-3 text-sm text-herd-muted">No sessions match your search</div>
+            <div className="px-4 py-3 text-sm text-herd-muted">No sessions in this directory</div>
           ) : (
             <>
               {sessionsToShow.map((session) => (

--- a/packages/web/src/client/src/components/all-chats/__tests__/AllChatsPage.test.tsx
+++ b/packages/web/src/client/src/components/all-chats/__tests__/AllChatsPage.test.tsx
@@ -1,10 +1,12 @@
 /**
  * AllChatsPage component tests
  *
- * Regression coverage for herdctl#145: collapsing a group during an active
- * search immediately re-expanded it, because `expandedGroups` was in the
- * auto-expand effect's dependency array and the store always produces a fresh
- * Set on toggle.
+ * Regression coverage for:
+ * - herdctl#145: collapsing a group during an active search immediately
+ *   re-expanded it, because `expandedGroups` was in the auto-expand effect's
+ *   dependency array and the store always produces a fresh Set on toggle.
+ * - herdctl#275: the no-results state must be the single top-level message,
+ *   not a per-group one, regardless of how many groups the host machine has.
  */
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -98,5 +100,31 @@ describe("AllChatsPage", () => {
     // And it stays collapsed — the effect must not re-expand it on the next render.
     await vi.advanceTimersByTimeAsync(500);
     expect(screen.queryByText("Alpha chat")).not.toBeInTheDocument();
+  });
+
+  it("renders the top-level no-results state for an unmatched query (herdctl#275)", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText("/tmp/alpha")).toBeInTheDocument());
+
+    await search("zzz-no-such-session-qqq");
+
+    await waitFor(() => {
+      expect(screen.getByText("No matching sessions")).toBeInTheDocument();
+    });
+    // Non-matching groups are dropped entirely rather than rendered empty, so
+    // there is never a competing per-group message.
+    expect(screen.queryByText("/tmp/alpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("/tmp/beta")).not.toBeInTheDocument();
+  });
+
+  it("keeps a group whose directory path matches, showing all of its sessions", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText("/tmp/alpha")).toBeInTheDocument());
+
+    await search("alpha");
+
+    await waitFor(() => expect(screen.queryByText("/tmp/beta")).not.toBeInTheDocument());
+    expect(screen.getByText("/tmp/alpha")).toBeInTheDocument();
+    expect(screen.getByText("Alpha chat")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/client/src/components/all-chats/__tests__/AllChatsPage.test.tsx
+++ b/packages/web/src/client/src/components/all-chats/__tests__/AllChatsPage.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * AllChatsPage component tests
+ *
+ * Regression coverage for herdctl#145: collapsing a group during an active
+ * search immediately re-expanded it, because `expandedGroups` was in the
+ * auto-expand effect's dependency array and the store always produces a fresh
+ * Set on toggle.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "../../../lib/api";
+import type { DirectoryGroup } from "../../../lib/types";
+import { useStore } from "../../../store";
+import { AllChatsPage } from "../AllChatsPage";
+
+vi.mock("../../../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/api")>();
+  return { ...actual, fetchAllSessions: vi.fn() };
+});
+
+function makeGroup(name: string, sessionName: string): DirectoryGroup {
+  return {
+    workingDirectory: `/tmp/${name}`,
+    encodedPath: `-tmp-${name}`,
+    agentName: name,
+    sessionCount: 1,
+    sessions: [
+      {
+        sessionId: `${name}-session`,
+        workingDirectory: `/tmp/${name}`,
+        mtime: new Date("2025-01-01T00:00:00Z").toISOString(),
+        origin: "native",
+        agentName: name,
+        resumable: true,
+        customName: sessionName,
+        autoName: undefined,
+        preview: undefined,
+      },
+    ],
+  } as DirectoryGroup;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AllChatsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("AllChatsPage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(api.fetchAllSessions).mockResolvedValue({
+      groups: [makeGroup("alpha", "Alpha chat"), makeGroup("beta", "Beta chat")],
+      totalGroups: 2,
+    });
+    useStore.setState({
+      allChatsGroups: [],
+      allChatsTotalGroups: 0,
+      allChatsLoading: false,
+      allChatsError: null,
+      allChatsSearchQuery: "",
+      allChatsExpandedGroups: new Set(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  /** Type into the search box and let the 300ms debounce fire. */
+  async function search(query: string) {
+    fireEvent.change(screen.getByPlaceholderText(/Search sessions/), { target: { value: query } });
+    await vi.advanceTimersByTimeAsync(400);
+  }
+
+  it("keeps a group collapsed after the user collapses it during a search (herdctl#145)", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText("/tmp/alpha")).toBeInTheDocument());
+
+    await search("chat");
+    // Searching auto-expands every group.
+    await waitFor(() => expect(screen.getByText("Alpha chat")).toBeInTheDocument());
+
+    // Collapse the alpha group by clicking its header.
+    fireEvent.click(screen.getByText("/tmp/alpha"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha chat")).not.toBeInTheDocument();
+    });
+    // The other group is untouched.
+    expect(screen.getByText("Beta chat")).toBeInTheDocument();
+
+    // And it stays collapsed — the effect must not re-expand it on the next render.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(screen.queryByText("Alpha chat")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/client/src/components/all-chats/__tests__/DirectoryGroup.test.tsx
+++ b/packages/web/src/client/src/components/all-chats/__tests__/DirectoryGroup.test.tsx
@@ -93,4 +93,25 @@ describe("DirectoryGroup", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("shows all sessions of a group whose directory path matches the query", () => {
+    renderGroup(makeGroup(3), "project");
+
+    expect(screen.getByText("Session 1")).toBeInTheDocument();
+    expect(screen.getByText("Session 3")).toBeInTheDocument();
+  });
+
+  it("shows only matching sessions when the group header does not match", () => {
+    const group = makeGroup(0);
+    group.sessions = [
+      makeSession(1, { customName: "alpha" }),
+      makeSession(2, { customName: "beta" }),
+    ];
+    group.sessionCount = 2;
+
+    renderGroup(group, "alpha");
+
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.queryByText("beta")).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/client/src/components/all-chats/__tests__/DirectoryGroup.test.tsx
+++ b/packages/web/src/client/src/components/all-chats/__tests__/DirectoryGroup.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * DirectoryGroup component tests
+ *
+ * Regression coverage for herdctl#150: the "Show all" button fetched more
+ * sessions from the server but the render slice stayed pinned to
+ * INITIAL_SESSIONS_SHOWN, so a directory group could never display more than
+ * 10 sessions.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DirectoryGroup as DirectoryGroupType, DiscoveredSession } from "../../../lib/types";
+import { useStore } from "../../../store";
+import { DirectoryGroup } from "../DirectoryGroup";
+
+const loadMoreGroupSessions = vi.fn();
+
+function makeSession(index: number, overrides: Partial<DiscoveredSession> = {}): DiscoveredSession {
+  return {
+    sessionId: `session-${index}`,
+    workingDirectory: "/tmp/project",
+    mtime: new Date("2025-01-01T00:00:00Z").toISOString(),
+    origin: "native",
+    agentName: "coder",
+    resumable: true,
+    customName: `Session ${index}`,
+    autoName: undefined,
+    preview: `preview ${index}`,
+    ...overrides,
+  } as DiscoveredSession;
+}
+
+function makeGroup(sessionsLoaded: number, sessionCount = sessionsLoaded): DirectoryGroupType {
+  return {
+    workingDirectory: "/tmp/project",
+    encodedPath: "-tmp-project",
+    agentName: "coder",
+    sessionCount,
+    sessions: Array.from({ length: sessionsLoaded }, (_, i) => makeSession(i + 1)),
+  };
+}
+
+function renderGroup(group: DirectoryGroupType, searchQuery = "") {
+  return render(
+    <MemoryRouter>
+      <DirectoryGroup group={group} expanded onToggle={() => {}} searchQuery={searchQuery} />
+    </MemoryRouter>,
+  );
+}
+
+describe("DirectoryGroup", () => {
+  beforeEach(() => {
+    loadMoreGroupSessions.mockReset().mockResolvedValue(undefined);
+    useStore.setState({ loadMoreGroupSessions });
+  });
+
+  it("shows only the first 10 sessions before 'Show all' is clicked", () => {
+    renderGroup(makeGroup(25));
+
+    expect(screen.getByText("Session 10")).toBeInTheDocument();
+    expect(screen.queryByText("Session 11")).not.toBeInTheDocument();
+  });
+
+  it("renders every locally-loaded session after clicking 'Show all' (herdctl#150)", async () => {
+    renderGroup(makeGroup(25));
+
+    fireEvent.click(screen.getByRole("button", { name: /Show all 25 sessions/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Session 25")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Session 11")).toBeInTheDocument();
+    // Everything is loaded and shown, so there is nothing left to fetch.
+    expect(loadMoreGroupSessions).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /Show all/ })).not.toBeInTheDocument();
+  });
+
+  it("fetches the next page from the server when the group is only partly loaded", async () => {
+    renderGroup(makeGroup(12, 40));
+
+    fireEvent.click(screen.getByRole("button", { name: /Show all 40 sessions/ }));
+
+    await waitFor(() => {
+      expect(loadMoreGroupSessions).toHaveBeenCalledWith("-tmp-project");
+    });
+    // Locally-loaded sessions beyond the initial cap are revealed immediately.
+    expect(screen.getByText("Session 12")).toBeInTheDocument();
+    // The button stays available because the server still has more.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Load more \(28 remaining\)/ }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/client/src/components/chat/AdhocChatView.tsx
+++ b/packages/web/src/client/src/components/chat/AdhocChatView.tsx
@@ -6,7 +6,7 @@
  * Uses the CLI runtime to execute `claude --resume <sessionId>` in the session's working directory.
  */
 
-import { ArrowLeft, FolderOpen } from "lucide-react";
+import { ArrowLeft, FolderOpen, RefreshCw } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { useNavigate, useParams } from "react-router";
 import { allChatsPath } from "../../lib/paths";
@@ -64,6 +64,13 @@ export function AdhocChatView() {
     navigate(allChatsPath());
   }, [navigate]);
 
+  // Re-run the fetch after a timeout/failure without a full page reload
+  const handleRetry = useCallback(() => {
+    if (encodedPath && sessionId) {
+      fetchAdhocChatMessages(encodedPath, sessionId);
+    }
+  }, [encodedPath, sessionId, fetchAdhocChatMessages]);
+
   // Decode path for display
   const displayPath = encodedPath ? decodePathForDisplay(encodedPath) : "";
   const shortSessionId = sessionId?.slice(0, 8) ?? "";
@@ -118,15 +125,23 @@ export function AdhocChatView() {
       {chatError && (
         <div className="px-4 pt-4">
           <div className="max-w-2xl mx-auto">
-            <div className="bg-herd-status-error/10 border border-herd-status-error/20 text-herd-status-error rounded-lg px-3 py-2 text-xs">
-              {chatError}
+            <div className="bg-herd-status-error/10 border border-herd-status-error/20 text-herd-status-error rounded-lg px-3 py-2 text-xs flex items-center justify-between gap-4">
+              <span>{chatError}</span>
+              <button
+                type="button"
+                onClick={handleRetry}
+                className="shrink-0 inline-flex items-center gap-1 font-medium hover:underline"
+              >
+                <RefreshCw className="w-3 h-3" />
+                Retry
+              </button>
             </div>
           </div>
         </div>
       )}
 
       {/* Message feed */}
-      <MessageFeed agentName="__adhoc__" />
+      <MessageFeed agentName="__adhoc__" sessionId={sessionId} onRetry={handleRetry} />
 
       {/* Composer with ad hoc props */}
       <Composer

--- a/packages/web/src/client/src/components/chat/ChatView.tsx
+++ b/packages/web/src/client/src/components/chat/ChatView.tsx
@@ -6,8 +6,8 @@
  * Supports both existing sessions (with sessionId in URL) and new chats (no sessionId).
  */
 
-import { Container, Info, MessageCircle, SplitSquareHorizontal } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { Container, Info, MessageCircle, RefreshCw, SplitSquareHorizontal } from "lucide-react";
+import { useCallback, useEffect, useRef } from "react";
 import { useNavigate, useParams } from "react-router";
 import { agentChatPath } from "../../lib/paths";
 import {
@@ -62,6 +62,15 @@ export function ChatView() {
     };
   }, [qualifiedName, clearActiveChatState]);
 
+  // Re-run the message fetch for the session currently in the URL. Wired to the
+  // error banner and the "no messages found" empty state so a transient failure
+  // (timeout, 5xx, transcript not yet flushed) doesn't require a page reload.
+  const handleRetry = useCallback(() => {
+    if (sessionId && qualifiedName) {
+      fetchChatMessages(qualifiedName, sessionId);
+    }
+  }, [sessionId, qualifiedName, fetchChatMessages]);
+
   // Fetch messages when session ID changes
   useEffect(() => {
     if (sessionId && qualifiedName) {
@@ -103,8 +112,18 @@ export function ChatView() {
         {chatError && (
           <div className="px-4 pt-4">
             <div className="max-w-2xl mx-auto">
-              <div className="bg-herd-status-error/10 border border-herd-status-error/20 text-herd-status-error rounded-lg px-3 py-2 text-xs">
-                {chatError}
+              <div className="bg-herd-status-error/10 border border-herd-status-error/20 text-herd-status-error rounded-lg px-3 py-2 text-xs flex items-center justify-between gap-4">
+                <span>{chatError}</span>
+                {sessionId && (
+                  <button
+                    type="button"
+                    onClick={handleRetry}
+                    className="shrink-0 inline-flex items-center gap-1 font-medium hover:underline"
+                  >
+                    <RefreshCw className="w-3 h-3" />
+                    Retry
+                  </button>
+                )}
               </div>
             </div>
           </div>
@@ -179,7 +198,7 @@ export function ChatView() {
           </div>
         ) : (
           /* Message feed for existing sessions or new chats with messages */
-          <MessageFeed agentName={qualifiedName} />
+          <MessageFeed agentName={qualifiedName} sessionId={sessionId} onRetry={handleRetry} />
         )}
 
         {/* Composer - shown for resumable sessions or new chats */}

--- a/packages/web/src/client/src/components/chat/MessageFeed.tsx
+++ b/packages/web/src/client/src/components/chat/MessageFeed.tsx
@@ -5,7 +5,7 @@
  * Shows streaming indicator when agent is responding.
  */
 
-import { MessageCircle } from "lucide-react";
+import { MessageCircle, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChatMessage } from "../../lib/types";
 import { useChatMessages } from "../../store";
@@ -18,13 +18,21 @@ import { MessageBubble } from "./MessageBubble";
 interface MessageFeedProps {
   /** Agent name for display in empty state */
   agentName: string;
+  /**
+   * Session being viewed, when this is an *existing* session rather than a new
+   * chat. Drives the empty state: an existing session with zero messages means
+   * something went wrong, not "say hello".
+   */
+  sessionId?: string;
+  /** Re-run the message fetch for the current session */
+  onRetry?: () => void;
 }
 
 // =============================================================================
 // Component
 // =============================================================================
 
-export function MessageFeed(_props: MessageFeedProps) {
+export function MessageFeed({ sessionId, onRetry }: MessageFeedProps) {
   const {
     chatMessages,
     chatMessagesLoading,
@@ -97,8 +105,36 @@ export function MessageFeed(_props: MessageFeedProps) {
     );
   }
 
-  // Empty state
+  // Empty state. An existing session that loaded zero messages is a problem
+  // (transcript missing, still being written, or the fetch failed) — say so and
+  // offer a retry, rather than the misleading "start the conversation" prompt.
   if (displayMessages.length === 0 && !chatStreaming) {
+    if (sessionId) {
+      return (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-3 text-herd-muted text-center px-4">
+            <MessageCircle className="w-12 h-12 opacity-50" />
+            <div>
+              <p className="text-sm text-herd-fg">No messages found for this session</p>
+              <p className="text-xs mt-1 max-w-xs">
+                The transcript may still be writing, or it could not be read from disk.
+              </p>
+            </div>
+            {onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="inline-flex items-center gap-1.5 text-xs text-herd-primary hover:text-herd-primary-hover transition-colors font-medium"
+              >
+                <RefreshCw className="w-3.5 h-3.5" />
+                Retry
+              </button>
+            )}
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="flex flex-col items-center gap-3 text-herd-muted">

--- a/packages/web/src/client/src/components/chat/__tests__/MessageFeed.test.tsx
+++ b/packages/web/src/client/src/components/chat/__tests__/MessageFeed.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * MessageFeed empty-state tests
+ *
+ * Regression coverage for herdctl#170: an EXISTING session that loaded zero
+ * messages showed "Send a message to start the conversation", which reads as
+ * "this chat is new" when in fact the transcript could not be read.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useStore } from "../../../store";
+import { MessageFeed } from "../MessageFeed";
+
+describe("MessageFeed empty states", () => {
+  beforeEach(() => {
+    useStore.setState({
+      chatMessages: [],
+      chatMessagesLoading: false,
+      chatStreaming: false,
+      chatStreamingContent: "",
+      messageGrouping: "separate",
+    });
+  });
+
+  it("prompts the user to start the conversation for a new chat", () => {
+    render(<MessageFeed agentName="coder" />);
+
+    expect(screen.getByText("Send a message to start the conversation")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+  });
+
+  it("reports a missing transcript for an existing session (herdctl#170)", () => {
+    render(<MessageFeed agentName="coder" sessionId="session-1" />);
+
+    expect(screen.getByText("No messages found for this session")).toBeInTheDocument();
+    expect(screen.queryByText("Send a message to start the conversation")).not.toBeInTheDocument();
+  });
+
+  it("offers a retry for an existing session with no messages", () => {
+    const onRetry = vi.fn();
+    render(<MessageFeed agentName="coder" sessionId="session-1" onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Retry/ }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the loading state while messages are being fetched", () => {
+    useStore.setState({ chatMessagesLoading: true });
+
+    render(<MessageFeed agentName="coder" sessionId="session-1" />);
+
+    expect(screen.getByText("Loading messages...")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/client/src/lib/api.ts
+++ b/packages/web/src/client/src/lib/api.ts
@@ -95,6 +95,7 @@ async function handleResponse<T>(response: Response): Promise<T> {
 async function get<T>(
   path: string,
   params?: Record<string, string | number | undefined>,
+  options?: { signal?: AbortSignal },
 ): Promise<T> {
   const url = new URL(`${baseUrl}${path}`);
 
@@ -111,6 +112,7 @@ async function get<T>(
     headers: {
       Accept: "application/json",
     },
+    signal: options?.signal,
   });
 
   return handleResponse<T>(response);
@@ -356,9 +358,12 @@ export async function fetchChatSessions(
 export async function fetchChatSession(
   agentName: string,
   sessionId: string,
+  options?: { signal?: AbortSignal },
 ): Promise<ChatSessionDetailResponse> {
   return get<ChatSessionDetailResponse>(
     `/api/chat/${encodeURIComponent(agentName)}/sessions/${encodeURIComponent(sessionId)}`,
+    undefined,
+    options,
   );
 }
 
@@ -446,8 +451,11 @@ export async function fetchDirectoryGroupSessions(
 export async function fetchSessionByPath(
   encodedPath: string,
   sessionId: string,
+  options?: { signal?: AbortSignal },
 ): Promise<ChatSessionDetailResponse> {
   return get<ChatSessionDetailResponse>(
     `/api/chat/sessions/by-path/${encodeURIComponent(encodedPath)}/${encodeURIComponent(sessionId)}`,
+    undefined,
+    options,
   );
 }

--- a/packages/web/src/client/src/lib/session-utils.ts
+++ b/packages/web/src/client/src/lib/session-utils.ts
@@ -1,4 +1,4 @@
-import type { DiscoveredSession } from "./types.js";
+import type { DirectoryGroup, DiscoveredSession } from "./types.js";
 
 /**
  * Check if a session matches the search query.
@@ -17,4 +17,33 @@ export function sessionMatchesQuery(session: DiscoveredSession, query: string): 
     preview.includes(lowerQuery) ||
     agentName.includes(lowerQuery)
   );
+}
+
+/**
+ * Check if a directory group's own header matches the search query — i.e. its
+ * working directory path or the agent it is attributed to.
+ *
+ * Kept separate from {@link groupMatchesQuery} so callers can distinguish
+ * "this group matched because of what it *is*" (show all of its sessions) from
+ * "this group matched because one of its sessions did" (show only the matches).
+ */
+export function groupHeaderMatchesQuery(group: DirectoryGroup, query: string): boolean {
+  const lowerQuery = query.toLowerCase();
+  return (
+    group.workingDirectory.toLowerCase().includes(lowerQuery) ||
+    (group.agentName?.toLowerCase().includes(lowerQuery) ?? false)
+  );
+}
+
+/**
+ * Check if a directory group should survive the search filter.
+ *
+ * A group matches when its header matches (directory path / agent name) or when
+ * at least one of its loaded sessions matches. Groups that match neither are
+ * removed entirely, so the page renders a single top-level "no matching
+ * sessions" state rather than a list of empty groups.
+ */
+export function groupMatchesQuery(group: DirectoryGroup, query: string): boolean {
+  if (groupHeaderMatchesQuery(group, query)) return true;
+  return group.sessions.some((session) => sessionMatchesQuery(session, query));
 }

--- a/packages/web/src/client/src/store/__tests__/chat-slice.test.ts
+++ b/packages/web/src/client/src/store/__tests__/chat-slice.test.ts
@@ -1,0 +1,110 @@
+/**
+ * chat-slice tests
+ *
+ * Regression coverage for herdctl#170: fetchChatMessages had no timeout, so a
+ * hung API call left the message feed on "Loading messages..." indefinitely.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "../../lib/api";
+import { CHAT_MESSAGES_TIMEOUT_MS } from "../chat-slice";
+import { useStore } from "../index";
+
+vi.mock("../../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/api")>();
+  return {
+    ...actual,
+    fetchChatSession: vi.fn(),
+    fetchSessionByPath: vi.fn(),
+  };
+});
+
+/** Resolve only when the supplied AbortSignal fires — mimics a hung request. */
+function hangUntilAborted(_agent: string, _session: string, options?: { signal?: AbortSignal }) {
+  return new Promise<never>((_resolve, reject) => {
+    options?.signal?.addEventListener("abort", () => {
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+    });
+  });
+}
+
+describe("fetchChatMessages", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useStore.setState({
+      chatMessages: [],
+      chatMessagesLoading: false,
+      chatError: null,
+      activeChatSessionId: null,
+      activeChatAgent: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("loads messages for a session", async () => {
+    vi.mocked(api.fetchChatSession).mockResolvedValue({
+      messages: [{ role: "user", content: "hi", timestamp: "2025-01-01T00:00:00Z" }],
+    } as Awaited<ReturnType<typeof api.fetchChatSession>>);
+
+    await useStore.getState().fetchChatMessages("coder", "session-1");
+
+    const state = useStore.getState();
+    expect(state.chatMessages).toHaveLength(1);
+    expect(state.chatMessagesLoading).toBe(false);
+    expect(state.chatError).toBeNull();
+    expect(state.activeChatSessionId).toBe("session-1");
+  });
+
+  it("aborts and surfaces a timeout error when the request hangs (herdctl#170)", async () => {
+    vi.mocked(api.fetchChatSession).mockImplementation(hangUntilAborted as never);
+
+    const pending = useStore.getState().fetchChatMessages("coder", "session-1");
+    expect(useStore.getState().chatMessagesLoading).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(CHAT_MESSAGES_TIMEOUT_MS + 10);
+    await pending;
+
+    const state = useStore.getState();
+    expect(state.chatMessagesLoading).toBe(false);
+    expect(state.chatError).toMatch(/Timed out loading messages/);
+    // The session stays active so the Retry control knows what to re-fetch.
+    expect(state.activeChatSessionId).toBe("session-1");
+    expect(state.activeChatAgent).toBe("coder");
+  });
+
+  it("surfaces the underlying error message when the request fails outright", async () => {
+    vi.mocked(api.fetchChatSession).mockRejectedValue(new Error("HTTP 500: boom"));
+
+    await useStore.getState().fetchChatMessages("coder", "session-1");
+
+    expect(useStore.getState().chatError).toBe("HTTP 500: boom");
+    expect(useStore.getState().chatMessagesLoading).toBe(false);
+  });
+});
+
+describe("fetchAdhocChatMessages", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useStore.setState({ chatMessagesLoading: false, chatError: null });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("times out a hung ad hoc session fetch too", async () => {
+    vi.mocked(api.fetchSessionByPath).mockImplementation(hangUntilAborted as never);
+
+    const pending = useStore.getState().fetchAdhocChatMessages("-tmp-project", "session-1");
+    await vi.advanceTimersByTimeAsync(CHAT_MESSAGES_TIMEOUT_MS + 10);
+    await pending;
+
+    expect(useStore.getState().chatMessagesLoading).toBe(false);
+    expect(useStore.getState().chatError).toMatch(/Timed out loading messages/);
+  });
+});

--- a/packages/web/src/client/src/store/chat-slice.ts
+++ b/packages/web/src/client/src/store/chat-slice.ts
@@ -21,6 +21,45 @@ import type { ChatMessage, ChatSession, ChatToolCall, RecentChatSession } from "
 /** Maximum number of sessions shown per agent in the sidebar */
 const SIDEBAR_SESSION_LIMIT = 5;
 
+/** How long to wait for a session's messages before giving up and offering a retry */
+export const CHAT_MESSAGES_TIMEOUT_MS = 15_000;
+
+/**
+ * Run a message fetch under a hard timeout.
+ *
+ * Without this a hung API call (proxy timeout, huge transcript, dead server)
+ * left the message feed stuck on "Loading messages..." forever, with a page
+ * reload as the only escape.
+ */
+async function fetchMessagesWithTimeout<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  fallbackMessage: string,
+): Promise<{ ok: true; value: T } | { ok: false; message: string }> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, CHAT_MESSAGES_TIMEOUT_MS);
+
+  try {
+    return { ok: true, value: await run(controller.signal) };
+  } catch (error) {
+    if (timedOut) {
+      return {
+        ok: false,
+        message: `Timed out loading messages after ${Math.round(CHAT_MESSAGES_TIMEOUT_MS / 1000)}s`,
+      };
+    }
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : fallbackMessage,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export interface ChatState {
   /** List of chat sessions for the current agent */
   chatSessions: ChatSession[];
@@ -174,21 +213,29 @@ export const createChatSlice: StateCreator<ChatSlice, [], [], ChatSlice> = (set,
       chatStreamingContent: "",
     });
 
-    try {
-      const response = await fetchChatSession(agentName, sessionId);
+    const result = await fetchMessagesWithTimeout(
+      (signal) => fetchChatSession(agentName, sessionId, { signal }),
+      "Failed to fetch chat messages",
+    );
+
+    if (result.ok) {
       set({
-        chatMessages: response.messages,
+        chatMessages: result.value.messages,
         chatMessagesLoading: false,
         activeChatSessionId: sessionId,
         activeChatAgent: agentName,
       });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to fetch chat messages";
-      set({
-        chatMessagesLoading: false,
-        chatError: message,
-      });
+      return;
     }
+
+    set({
+      chatMessagesLoading: false,
+      chatError: result.message,
+      // Keep the session active so a retry knows what to re-fetch and the
+      // header/sidebar don't flicker back to "new chat".
+      activeChatSessionId: sessionId,
+      activeChatAgent: agentName,
+    });
   },
 
   renameChatSession: async (agentName: string, sessionId: string, customName: string) => {
@@ -442,21 +489,26 @@ export const createChatSlice: StateCreator<ChatSlice, [], [], ChatSlice> = (set,
       chatStreamingContent: "",
     });
 
-    try {
-      const response = await fetchSessionByPath(encodedPath, sessionId);
+    const result = await fetchMessagesWithTimeout(
+      (signal) => fetchSessionByPath(encodedPath, sessionId, { signal }),
+      "Failed to fetch ad hoc chat messages",
+    );
+
+    if (result.ok) {
       set({
-        chatMessages: response.messages,
+        chatMessages: result.value.messages,
         chatMessagesLoading: false,
         activeChatSessionId: sessionId,
         activeChatAgent: null, // Ad hoc sessions don't have an associated agent
       });
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Failed to fetch ad hoc chat messages";
-      set({
-        chatMessagesLoading: false,
-        chatError: message,
-      });
+      return;
     }
+
+    set({
+      chatMessagesLoading: false,
+      chatError: result.message,
+      activeChatSessionId: sessionId,
+      activeChatAgent: null,
+    });
   },
 });

--- a/packages/web/src/server/__tests__/ws-handler.test.ts
+++ b/packages/web/src/server/__tests__/ws-handler.test.ts
@@ -243,6 +243,49 @@ describe("WebSocketHandler", () => {
       );
     });
 
+    // Regression: the "message" listener used to be attached AFTER awaiting
+    // getFleetStatus(), so a client that sent a frame the instant its socket
+    // opened had it delivered to a listener-less socket and silently dropped.
+    // On a cold/loaded server that window is wide enough to be hit for real
+    // (herdctl#275: the raw ws ping/pong probe timing out in CI).
+    it("handles a message that arrives before the fleet status snapshot resolves", async () => {
+      let releaseStatus: (() => void) | undefined;
+      mockFleetManager.getFleetStatus = vi.fn(
+        () =>
+          new Promise((resolve) => {
+            releaseStatus = () => resolve({ state: "running", counts: { totalAgents: 1 } });
+          }),
+      );
+
+      const handler = new WebSocketHandler(mockFleetManager);
+
+      let messageHandler: ((data: any) => void) | undefined;
+      const mockSocket = {
+        on: vi.fn((event: string, cb: any) => {
+          if (event === "message") messageHandler = cb;
+        }),
+        readyState: 1,
+        OPEN: 1,
+        send: vi.fn(),
+        close: vi.fn(),
+      };
+
+      // Don't await: the snapshot promise is still pending on purpose.
+      const connected = handler.handleConnection(mockSocket as any);
+
+      // The listener must already be attached at this point.
+      expect(messageHandler).toBeDefined();
+
+      messageHandler!(Buffer.from(JSON.stringify({ type: "ping" })));
+      expect(mockSocket.send).toHaveBeenCalledWith(expect.stringContaining('"type":"pong"'));
+
+      releaseStatus?.();
+      await connected;
+      expect(mockSocket.send).toHaveBeenCalledWith(
+        expect.stringContaining('"type":"fleet:status"'),
+      );
+    });
+
     it("handles disconnect", async () => {
       const handler = new WebSocketHandler(mockFleetManager);
 

--- a/packages/web/src/server/ws/handler.ts
+++ b/packages/web/src/server/ws/handler.ts
@@ -71,17 +71,12 @@ export class WebSocketHandler {
     this.clients.add(client);
     logger.info(`WebSocket client connected: ${clientId} (total: ${this.clients.size})`);
 
-    // Send initial fleet status snapshot
-    try {
-      const status = await this.fleetManager.getFleetStatus();
-      this.sendToClient(client, { type: "fleet:status", payload: status });
-    } catch (error) {
-      logger.warn(
-        `Failed to send initial fleet status to ${clientId}: ${(error as Error).message}`,
-      );
-    }
-
-    // Handle incoming messages
+    // Attach listeners SYNCHRONOUSLY, before any await. A client that sends a
+    // frame immediately on `open` (the dashboard's keepalive ping, subscribe,
+    // or chat:send) would otherwise have it delivered to a socket with no
+    // "message" listener and silently dropped, because the fleet-status
+    // snapshot below yields to the event loop first. On a cold/busy server
+    // getFleetStatus() is slow enough for that window to be real.
     socket.on("message", (data: RawData) => {
       this.handleMessage(client, data);
     });
@@ -95,6 +90,16 @@ export class WebSocketHandler {
     socket.on("error", (error: Error) => {
       logger.warn(`WebSocket error for ${clientId}: ${error.message}`);
     });
+
+    // Send initial fleet status snapshot
+    try {
+      const status = await this.fleetManager.getFleetStatus();
+      this.sendToClient(client, { type: "fleet:status", payload: status });
+    } catch (error) {
+      logger.warn(
+        `Failed to send initial fleet status to ${clientId}: ${(error as Error).message}`,
+      );
+    }
   }
 
   /**

--- a/packages/web/test-ui/harness.ts
+++ b/packages/web/test-ui/harness.ts
@@ -15,8 +15,8 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FleetManager } from "@herdctl/core";
@@ -53,12 +53,16 @@ export interface Harness {
   fleet: FleetManager;
   /** The web server bundle (server, wsHandler, fleetBridge, chatManager). */
   web: WebServerResult;
-  /** Temp directory holding the fleet config + workspaces + state. */
+  /** Temp directory holding the fleet config + state (NOT the workspaces). */
   tmpRoot: string;
   /** The encoded ~/.claude/projects dir each agent writes its transcripts to. */
   agentSessionDir: (agentName: string) => string;
-  /** Working directory for an agent. */
+  /** Real on-disk working directory for an agent. */
   agentWorkdir: (agentName: string) => string;
+  /** The agent working directory encoded the way core keys directory groups. */
+  agentEncodedPath: (agentName: string) => string;
+  /** The working directory as the All Chats UI displays it (lossy decode). */
+  agentDisplayWorkdir: (agentName: string) => string;
   /** Tear everything down and remove temp files / transcripts. */
   stop: () => Promise<void>;
 }
@@ -66,6 +70,19 @@ export interface Harness {
 /** Mirror @herdctl/core encodePathForCli: every non-alphanumeric → "-". */
 function encodePathForCli(absolutePath: string): string {
   return absolutePath.replace(/[^A-Za-z0-9]/g, "-");
+}
+
+/**
+ * Mirror @herdctl/core decodePathForDisplay: the inverse of the encoder above,
+ * and lossy — every "-" becomes "/". This is the string the All Chats listing
+ * shows as a group's working directory, so assertions must compare against it
+ * rather than the real on-disk path.
+ */
+function decodePathForDisplay(encodedPath: string): string {
+  if (encodedPath.startsWith("-")) {
+    return `/${encodedPath.slice(1).replace(/-/g, "/")}`;
+  }
+  return encodedPath.replace(/-/g, "/");
 }
 
 function buildAgentYaml(agent: AgentSpec, workdir: string): string {
@@ -99,6 +116,28 @@ export async function startHarness(options: HarnessOptions = {}): Promise<Harnes
   const tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "herd-web-ui-")));
   const stateDir = join(tmpRoot, ".herdctl");
 
+  // Agent WORKING DIRECTORIES must live outside os.tmpdir(). Core's session
+  // discovery deliberately skips temp paths (isTempDirectory in
+  // state/session-discovery.ts filters /tmp/, /private/tmp/, /var/folders/ and
+  // os.tmpdir()), so a fleet whose agents work under the temp root can NEVER
+  // appear in the machine-wide All Chats listing. That made the All Chats specs
+  // untestable in a clean environment and let one of them pass only by matching
+  // the agent name in the layout sidebar (herdctl#275). Config, state and
+  // scratch all stay under tmpRoot; only the workspaces move here.
+  //
+  // The directory names are deliberately alphanumeric-only: encodePathForCli
+  // maps every non-alphanumeric character to "-", and the listing decodes that
+  // back by turning every "-" into "/", so anything else round-trips lossily.
+  const workRootRaw = join(
+    homedir(),
+    "herdctlwebuitests",
+    `run${Math.random().toString(36).slice(2, 10)}`,
+  );
+  mkdirSync(workRootRaw, { recursive: true });
+  // realpath for the same reason tmpRoot does it: the spawned binary reports a
+  // fully-resolved cwd, and core must watch the matching encoded directory.
+  const workRoot = realpathSync(workRootRaw);
+
   // 1) Write a fake-claude script file the binary reads via HERD_FAKE_SCRIPT.
   const scriptPath = join(tmpRoot, "fake-script.json");
   writeFileSync(scriptPath, JSON.stringify(fakeScript), "utf8");
@@ -114,7 +153,7 @@ export async function startHarness(options: HarnessOptions = {}): Promise<Harnes
   spawnSync("mkdir", ["-p", agentDir]);
   const agentRefs: string[] = [];
   for (const agent of agents) {
-    const workdir = join(tmpRoot, "work", agent.name);
+    const workdir = join(workRoot, agent.name);
     spawnSync("mkdir", ["-p", workdir]);
     const agentPath = join(agentDir, `${agent.name}.yaml`);
     writeFileSync(agentPath, buildAgentYaml(agent, workdir), "utf8");
@@ -159,9 +198,12 @@ export async function startHarness(options: HarnessOptions = {}): Promise<Harnes
   }
   const baseUrl = `http://127.0.0.1:${address.port}`;
 
-  const agentWorkdir = (agentName: string) => join(tmpRoot, "work", agentName);
+  const agentWorkdir = (agentName: string) => join(workRoot, agentName);
+  const agentEncodedPath = (agentName: string) => encodePathForCli(agentWorkdir(agentName));
+  const agentDisplayWorkdir = (agentName: string) =>
+    decodePathForDisplay(agentEncodedPath(agentName));
   const agentSessionDir = (agentName: string) =>
-    join(process.env.HOME ?? "", ".claude", "projects", encodePathForCli(agentWorkdir(agentName)));
+    join(process.env.HOME ?? "", ".claude", "projects", agentEncodedPath(agentName));
 
   const stop = async (): Promise<void> => {
     try {
@@ -191,12 +233,24 @@ export async function startHarness(options: HarnessOptions = {}): Promise<Harnes
         /* ignore */
       }
     }
-    try {
-      rmSync(tmpRoot, { recursive: true, force: true });
-    } catch {
-      /* ignore */
+    for (const dir of [tmpRoot, workRoot]) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
     }
   };
 
-  return { baseUrl, fleet, web, tmpRoot, agentSessionDir, agentWorkdir, stop };
+  return {
+    baseUrl,
+    fleet,
+    web,
+    tmpRoot,
+    agentSessionDir,
+    agentWorkdir,
+    agentEncodedPath,
+    agentDisplayWorkdir,
+    stop,
+  };
 }

--- a/packages/web/test-ui/tests/00-ws-probe.spec.ts
+++ b/packages/web/test-ui/tests/00-ws-probe.spec.ts
@@ -9,36 +9,65 @@ test("server replies to a ping with a pong over a real browser WebSocket", async
   page,
   harness,
 }) => {
-  // The raw probe times out consistently on a freshly-booted server in CI (a
-  // cold-start race), while every higher-level WS test (chat stream/resume) is
-  // green — so real WS coverage is retained. Skipped in CI pending herdctl#275.
-  test.skip(!!process.env.CI, "raw ws-probe cold-start flake in CI — herdctl#275");
   // The probe only needs a document context + page origin to open its own
   // WebSocket; don't block on the full SPA bundle "load" (avoids cold-start
   // flake when several fleets boot in parallel).
   await page.goto(harness.baseUrl, { waitUntil: "domcontentloaded" });
 
+  // This probe used to time out consistently in CI (herdctl#275). The cause was
+  // a server bug, not the test: WebSocketHandler.handleConnection attached its
+  // "message" listener only AFTER awaiting getFleetStatus(), so a ping sent the
+  // instant the socket opened was dropped on a cold/loaded server. The listener
+  // is now attached synchronously. As a consequence `pong` may now arrive
+  // BEFORE the initial `fleet:status` snapshot, so wait for both rather than
+  // assuming an ordering. The connection itself is retried so a genuinely
+  // slow-to-accept server doesn't fail the probe.
   const result = await page.evaluate(async (baseUrl) => {
     const wsUrl = `${baseUrl.replace("http", "ws")}/ws`;
-    const ws = new WebSocket(wsUrl);
-    return await new Promise<{ pong: boolean; gotStatus: boolean }>((resolve, reject) => {
-      let gotStatus = false;
-      const timer = setTimeout(() => reject(new Error("ws probe timeout")), 30_000);
-      ws.addEventListener("open", () => ws.send(JSON.stringify({ type: "ping" })));
-      ws.addEventListener("message", (ev) => {
-        const msg = JSON.parse(ev.data as string);
-        if (msg.type === "fleet:status") gotStatus = true;
-        if (msg.type === "pong") {
-          clearTimeout(timer);
-          ws.close();
-          resolve({ pong: true, gotStatus });
-        }
-      });
-      ws.addEventListener("error", () => {
-        clearTimeout(timer);
-        reject(new Error("ws probe error"));
-      });
-    });
+
+    async function probeOnce(timeoutMs: number) {
+      const ws = new WebSocket(wsUrl);
+      try {
+        return await new Promise<{ pong: boolean; gotStatus: boolean }>((resolve, reject) => {
+          let gotStatus = false;
+          let gotPong = false;
+          const settle = () => {
+            if (gotStatus && gotPong) {
+              clearTimeout(timer);
+              resolve({ pong: true, gotStatus: true });
+            }
+          };
+          const timer = setTimeout(
+            () => reject(new Error(`ws probe timeout (pong=${gotPong} status=${gotStatus})`)),
+            timeoutMs,
+          );
+          ws.addEventListener("open", () => ws.send(JSON.stringify({ type: "ping" })));
+          ws.addEventListener("message", (ev) => {
+            const msg = JSON.parse(ev.data as string);
+            if (msg.type === "fleet:status") gotStatus = true;
+            if (msg.type === "pong") gotPong = true;
+            settle();
+          });
+          ws.addEventListener("error", () => {
+            clearTimeout(timer);
+            reject(new Error("ws probe error"));
+          });
+        });
+      } finally {
+        ws.close();
+      }
+    }
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await probeOnce(10_000);
+      } catch (error) {
+        lastError = error;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+    throw lastError;
   }, harness.baseUrl);
 
   expect(result.gotStatus).toBe(true);

--- a/packages/web/test-ui/tests/07-sessions-and-errors.spec.ts
+++ b/packages/web/test-ui/tests/07-sessions-and-errors.spec.ts
@@ -37,9 +37,10 @@ async function seedCompletedSession(page: Page, harness: Harness): Promise<void>
       async () => {
         const res = await page.request.get(`${harness.baseUrl}/api/chat/all?limit=200`);
         const all = await res.json();
+        // Compare on encodedPath: it is the exact key core groups by, whereas
+        // workingDirectory is a lossy decode of it.
         return (all.groups ?? []).some(
-          (g: { workingDirectory: string }) =>
-            g.workingDirectory === harness.agentWorkdir("talker"),
+          (g: { encodedPath: string }) => g.encodedPath === harness.agentEncodedPath("talker"),
         );
       },
       { timeout: 30_000, intervals: [500] },
@@ -63,7 +64,9 @@ test.describe("All Chats session list", () => {
     // Assert on the group's working directory, not the agent name: "talker"
     // also renders in the layout sidebar, so matching it proves nothing about
     // the All Chats list. The temp workdir is unique to this harness.
-    await expect(page.getByText(harness.agentWorkdir("talker"))).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(harness.agentDisplayWorkdir("talker"))).toBeVisible({
+      timeout: 20_000,
+    });
   });
 
   // /chats is machine-wide (it discovers every Claude Code session under
@@ -86,7 +89,9 @@ test.describe("All Chats session list", () => {
 
     await expect(page.getByRole("heading", { name: "All Chats" })).toBeVisible();
     await expect(page.getByText("Every Claude Code session on this machine")).toBeVisible();
-    await expect(page.getByText(harness.agentWorkdir("talker"))).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(harness.agentDisplayWorkdir("talker"))).toBeVisible({
+      timeout: 20_000,
+    });
 
     await page
       .getByPlaceholder(/Search sessions/)

--- a/packages/web/test-ui/tests/07-sessions-and-errors.spec.ts
+++ b/packages/web/test-ui/tests/07-sessions-and-errors.spec.ts
@@ -1,8 +1,51 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../fixtures.js";
+import type { Harness } from "../harness.js";
 
 /**
  * Session-list (All Chats) journeys and error/empty states across the app.
  */
+
+/**
+ * Run one agent turn via REST, wait for it to finish, and wait for the server's
+ * session discovery to surface the resulting transcript in /api/chat/all.
+ *
+ * Both waits matter. The All Chats page fetches once on mount, so a test that
+ * navigates before discovery has caught up renders the base empty state and
+ * never recovers. The old spec instead waited on the text "talker", which also
+ * appears in the layout sidebar — a match that proves nothing about the session
+ * list and let the test proceed too early (herdctl#275).
+ */
+async function seedCompletedSession(page: Page, harness: Harness): Promise<void> {
+  const res = await page.request.post(`${harness.baseUrl}/api/agents/talker/trigger`, {
+    data: { prompt: "First message", triggerType: "web" },
+  });
+  expect(res.ok()).toBeTruthy();
+
+  await expect
+    .poll(
+      async () => {
+        const jobs = await (await page.request.get(`${harness.baseUrl}/api/jobs`)).json();
+        return jobs.jobs?.[0]?.status;
+      },
+      { timeout: 80_000, intervals: [1000] },
+    )
+    .toBe("completed");
+
+  await expect
+    .poll(
+      async () => {
+        const res = await page.request.get(`${harness.baseUrl}/api/chat/all?limit=200`);
+        const all = await res.json();
+        return (all.groups ?? []).some(
+          (g: { workingDirectory: string }) =>
+            g.workingDirectory === harness.agentWorkdir("talker"),
+        );
+      },
+      { timeout: 30_000, intervals: [500] },
+    )
+    .toBe(true);
+}
 
 test.describe("All Chats session list", () => {
   test.use({
@@ -13,28 +56,14 @@ test.describe("All Chats session list", () => {
   });
 
   test("a completed chat appears in the All Chats directory listing", async ({ page, harness }) => {
-    // Run one chat turn via REST so a transcript exists on disk.
-    const res = await page.request.post(`${harness.baseUrl}/api/agents/talker/trigger`, {
-      data: { prompt: "First message", triggerType: "web" },
-    });
-    expect(res.ok()).toBeTruthy();
-
-    // Wait for the job to complete.
-    await expect
-      .poll(
-        async () => {
-          const jobs = await (await page.request.get(`${harness.baseUrl}/api/jobs`)).json();
-          return jobs.jobs?.[0]?.status;
-        },
-        { timeout: 80_000, intervals: [1000] },
-      )
-      .toBe("completed");
+    await seedCompletedSession(page, harness);
 
     await page.goto(`${harness.baseUrl}/chats`);
     await expect(page.getByRole("heading", { name: "All Chats" })).toBeVisible();
-    // The agent's working directory group should be listed (it contains the
-    // session we just created). The agent name surfaces in the group header.
-    await expect(page.getByText("talker").first()).toBeVisible({ timeout: 20_000 });
+    // Assert on the group's working directory, not the agent name: "talker"
+    // also renders in the layout sidebar, so matching it proves nothing about
+    // the All Chats list. The temp workdir is unique to this harness.
+    await expect(page.getByText(harness.agentWorkdir("talker"))).toBeVisible({ timeout: 20_000 });
   });
 
   // /chats is machine-wide (it discovers every Claude Code session under
@@ -47,44 +76,22 @@ test.describe("All Chats session list", () => {
     page,
     harness,
   }) => {
-    // The no-results state only renders when ALL session groups filter out (true
-    // on a dev machine with many groups); in CI with a single seeded group the
-    // group is kept-but-empty and no top-level message shows. Skipped in CI
-    // pending a render fix — see herdctl#275. The directory listing itself is
-    // still covered (the "a completed chat appears" test above).
-    test.skip(!!process.env.CI, "machine-state-dependent no-results render — herdctl#275");
-    const trigger = await page.request.post(`${harness.baseUrl}/api/agents/talker/trigger`, {
-      data: { prompt: "First message", triggerType: "web" },
-    });
-    expect(trigger.ok()).toBeTruthy();
-    await expect
-      .poll(
-        async () => {
-          const jobs = await (await page.request.get(`${harness.baseUrl}/api/jobs`)).json();
-          return jobs.jobs?.[0]?.status;
-        },
-        { timeout: 80_000, intervals: [1000] },
-      )
-      .toBe("completed");
+    // One seeded group is enough for a deterministic result: a group matching
+    // neither its path/agent nor any of its sessions is now dropped entirely,
+    // so the single top-level state renders regardless of how many other
+    // session groups the host machine happens to have (herdctl#275).
+    await seedCompletedSession(page, harness);
 
     await page.goto(`${harness.baseUrl}/chats`);
 
     await expect(page.getByRole("heading", { name: "All Chats" })).toBeVisible();
     await expect(page.getByText("Every Claude Code session on this machine")).toBeVisible();
-    // Wait for the seeded session's group to LOAD before searching — otherwise the
-    // filter applies to a still-empty list (groups.length === 0 → base EmptyState,
-    // not the search "No matching sessions" state). The agent name heads its group.
-    await expect(page.getByText("talker").first()).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(harness.agentWorkdir("talker"))).toBeVisible({ timeout: 20_000 });
 
     await page
       .getByPlaceholder(/Search sessions/)
       .fill("zzz-no-such-session-qqq-impossible-match-xyz");
-    // Accept either no-results form: the top-level "No matching sessions" (when
-    // all groups filter out) or a group's "No sessions match your search" (when a
-    // single group remains with no matching sessions). See herdctl#275.
-    await expect(
-      page.getByText(/No matching sessions|No sessions match your search/).first(),
-    ).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("No matching sessions")).toBeVisible({ timeout: 20_000 });
   });
 });
 


### PR DESCRIPTION
Fixes a cluster of long-open `@herdctl/web` bugs. One commit per issue, each independently reviewable.

| Commit | Issue |
|---|---|
| `fix(web): time out, retry, and correctly empty-state chat loads` | #170 |
| `fix(web): expand a directory group beyond the first 10 sessions` | #150 |
| `test(web): lock in the collapse-during-search fix` | #145 |
| `fix(web): make the All Chats no-results state deterministic` | #275 |
| `fix(web): attach WebSocket listeners before awaiting fleet status` | #275 |
| `fix(web): give UI-test agents a non-temp working directory` | #275 |

---

### #170 — ChatView had no timeout, no retry, and a misleading empty state

All three gaps in the issue were still present. Fixed as proposed, plus the ad hoc session path which had the same problems:

- `fetchChatMessages` and `fetchAdhocChatMessages` now run under a **15s `AbortController`** and report `Timed out loading messages after 15s`. Previously a hung call left the feed on "Loading messages..." forever.
- `MessageFeed` takes a `sessionId`. An **existing** session with zero messages now shows "No messages found for this session" instead of "Send a message to start the conversation"; genuinely new chats are unchanged.
- **Retry** in the error banner and in the empty state, in both `ChatView` and `AdhocChatView`. On failure the active session is kept so retry knows what to re-fetch.

### #150 — "Show all" never expanded past 10 sessions

Still a live bug on `main`. Adds the `showAll` flag from **#161**, with two corrections that PR needed:

- #161 hid the button as soon as `showAll` was set, which caps a group at the first server page (a 100-session group would stop at 60). The button now stays as `Load more (N remaining)` while the server has more.
- `loadMoreGroupSessions` is awaited with a disabled/loading button, so the click isn't a no-op-looking dead control.

#161 can't be applied as-is (the file moved its search helper to `lib/session-utils` in #160), so its approach is reimplemented and credited in the commit message. **Recommend closing #161 as superseded.**

### #145 — groups re-expanded on toggle during search

**Already fixed on `main`** — `expandedGroups` was removed from the effect deps and a `biome-ignore` added. Nothing locked it in, so this adds a component test that searches, collapses a group, and asserts it stays collapsed. Verified it fails (infinite effect loop) when the dep is restored.

### #275 — two CI-fragile test-ui specs

Both turned out to have real causes. Neither is fixed by loosening assertions; **both specs are un-skipped and now pass in CI (28/28, no skips).**

**1. Raw ws probe — a server bug, not a flaky test.** `WebSocketHandler.handleConnection` awaited `getFleetStatus()` before calling `socket.on("message", ...)`, so any frame a client sent the instant its socket opened arrived at a listener-less socket and was **silently dropped** (`ws` does not buffer). On a cold or loaded server the window is wide enough to hit for real, and it affects any early client frame — the dashboard keepalive ping, `subscribe`, `chat:send` — not just the probe. Listeners are now attached synchronously before the first `await`. `pong` may consequently arrive before `fleet:status`, so the probe waits for both rather than assuming an ordering. It now passes in CI in ~525ms (previously timed out at 30s).

**2. All Chats no-results — two layered causes.**

*Product:* `groupMatchesQuery` kept a group whose *directory path or agent name* matched, but `DirectoryGroup` then filtered its sessions by session fields only — so the group survived with zero rows and rendered its own "No sessions match your search". Searching a directory name produced a list of empty groups instead of results. Unified in `lib/session-utils`: a group whose header matches shows **all** its sessions; a group matching only via sessions shows just those; a group matching neither is **dropped entirely**, so the single top-level "No matching sessions" is the only no-results message.

*Test harness (found by pushing this PR and reading the CI failure):* core's session discovery deliberately skips temp paths — `isTempDirectory` in `state/session-discovery.ts` filters `/tmp/`, `/private/tmp/`, `/var/folders/` and `os.tmpdir()` — and the harness put every agent working directory under `mkdtemp(tmpdir())`. **A harness-seeded session could therefore never appear in the All Chats listing, on any machine.** That is the real source of the environment divergence:

- `a completed chat appears in the All Chats directory listing` asserted on the text `talker`, which also renders in the layout sidebar. It passed everywhere while proving nothing.
- The no-results spec passed on a dev machine only because the developer's own `~/.claude` groups were present and all filtered out by the impossible query. On a clean CI runner there were no groups at all, so the page sat on its base empty state.

Only the agent workspaces move out of the temp root (to an alphanumeric-only dir under `$HOME`, removed on teardown); config and state stay in `tmpRoot`. The harness now exposes `agentEncodedPath` (core's exact grouping key) and `agentDisplayWorkdir` (the lossy decode the UI renders) so specs assert on a group precisely instead of on an ambiguous agent name.

---

### Verification

- `pnpm typecheck` ✅ · `pnpm build` ✅ · Lint & Format ✅ · Unit Tests ✅ · Build + Smoke ✅ · **Web UI Tests ✅ (28 passed, 0 skipped)**
- New regression tests: `DirectoryGroup.test.tsx`, `AllChatsPage.test.tsx`, `MessageFeed.test.tsx`, `chat-slice.test.ts`, plus a `ws-handler` test that sends a message while the fleet-status promise is still pending. `@herdctl/web` is at 195 passing unit tests (was 141).
- Two CI reruns were needed for unrelated pre-existing flakes in `@herdctl/core` / `herdctl` (5s-timeout tests in `hooks/__tests__/hook-executor.test.ts`, `scheduler/__tests__/scheduler.test.ts`, `cli/src/__tests__/smoke.test.ts` — different tests each run). Nothing in this PR touches those packages; worth a separate look at test timeouts on the CI runner.

Changeset: `@herdctl/web` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)