### PR TITLE
fix(core): hold execute()'s terminal message while background subagents are live

### DIFF
--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -11,9 +11,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 type FakeMessage = Record<string, unknown>;
 
 // A controllable async generator standing in for the SDK's query() stream.
-// The queue is fed by the test; `query()` returns an object whose
-// `[Symbol.asyncIterator]` walks it, and whose `return()` marks it closed
-// (mirrors the real SDK Query handle `execute()` calls on the way out).
+// The queue is fed by the test; `query()` returns the Query object itself
+// (`iterable` below), which `execute()` calls `q.return()` on directly — NOT
+// only the iterator `[Symbol.asyncIterator]()` returns. A mock exposing
+// `return()` solely on the iterator lets `q.return()` throw (silently caught
+// by execute()'s own try/catch), so `isClosed()` never flips even though the
+// test looks green — hence `return()` is defined on `iterable` itself here,
+// same as the real SDK's `Query` (an AsyncGenerator, callable directly).
 function makeControllableStream() {
   const pending: FakeMessage[] = [];
   const waiters: Array<(msg: FakeMessage | typeof DONE) => void> = [];
@@ -24,6 +28,12 @@ function makeControllableStream() {
     const waiter = waiters.shift();
     if (waiter) waiter(message);
     else pending.push(message);
+  }
+
+  async function doReturn() {
+    closed = true;
+    for (const w of waiters.splice(0)) w(DONE);
+    return { done: true as const, value: undefined };
   }
 
   const iterable = {
@@ -38,13 +48,10 @@ function makeControllableStream() {
           if (message === DONE) return { done: true, value: undefined };
           return { done: false, value: message };
         },
-        async return() {
-          closed = true;
-          for (const w of waiters.splice(0)) w(DONE);
-          return { done: true, value: undefined };
-        },
+        return: doReturn,
       };
     },
+    return: doReturn,
   };
 
   return { push, iterable, isClosed: () => closed };
@@ -110,6 +117,42 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
     // Both background_tasks_changed messages passed through as normal
     // content; the terminal result was released only once tasks drained.
     expect(seen.map((m) => m.type)).toEqual(["system", "system", "result"]);
+    expect(stream.isClosed()).toBe(true);
+  });
+
+  it("does not release the held terminal on an unrelated activity signal", async () => {
+    // Regression for a bug CodeRabbit caught on PR #459: onLifecycleSignal
+    // used to overwrite liveBackgroundTasks on EVERY signal, including
+    // `activity` (fired on the next assistant message, always backgroundTasks
+    // []) — wiping a real pending count and releasing the terminal early.
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // An assistant message is what tapLifecycleStream treats as `activity` —
+    // must NOT clear the held task count.
+    stream.push({ type: "assistant", message: { content: [] } });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
   });
 
   it("does not hold the terminal result when ceiling is 0", async () => {
@@ -133,6 +176,7 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
 
     await drain;
     expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+    expect(stream.isClosed()).toBe(true);
   });
 
   it("gives up and yields the terminal once the ceiling elapses", async () => {
@@ -158,5 +202,6 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
     await drain; // resolves once the 20ms ceiling fires
     const results = seen.filter((m) => m.type === "result");
     expect(results).toHaveLength(1);
+    expect(stream.isClosed()).toBe(true);
   });
 });

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -30,7 +30,7 @@ function makeControllableStream() {
     else pending.push(message);
   }
 
-  async function doReturn() {
+  async function doReturn(): Promise<{ done: true; value: undefined }> {
     closed = true;
     for (const w of waiters.splice(0)) w(DONE);
     return { done: true as const, value: undefined };

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -268,7 +268,7 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
   });
 
   it("releases the held terminal on a turn_end Stop hook that authoritatively reports empty background_tasks", async () => {
-    // Gegenprobe: a genuine empty snapshot (the field present, just empty)
+    // Counter-check: a genuine empty snapshot (the field present, just empty)
     // must still release as before — only an omitted field is a non-snapshot.
     const runtime = new SDKRuntime();
     const seen: FakeMessage[] = [];

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -69,9 +69,20 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   tool: vi.fn(() => ({})),
 }));
 
+import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { ResolvedAgent } from "../../../config/index.js";
 import type { RuntimeExecuteOptions } from "../interface.js";
 import { SDKRuntime } from "../sdk-runtime.js";
+
+/** Grab the Stop-hook callback `execute()` registered on its last `query()` call. */
+function stopCallbackFromLastQueryCall(): (input: unknown) => Promise<unknown> {
+  const lastCall = vi.mocked(query).mock.calls.at(-1)!;
+  const options = (lastCall[0] as { options: Record<string, unknown> }).options;
+  const hooks = options.hooks as {
+    Stop: Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>;
+  };
+  return hooks.Stop[0].hooks[0];
+}
 
 const agent = { name: "keeper", qualifiedName: "keeper" } as unknown as ResolvedAgent;
 
@@ -203,5 +214,97 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
     const results = seen.filter((m) => m.type === "result");
     expect(results).toHaveLength(1);
     expect(stream.isClosed()).toBe(true);
+  });
+
+  it("does not release the held terminal on a turn_end Stop hook fired without a background_tasks snapshot", async () => {
+    // Regression for the prod #459 follow-up (job-2026-08-26-6opnmq): the
+    // CLI's Stop-hook payload builder is conditional and can omit
+    // `background_tasks`/`session_crons` entirely for a turn, independent of
+    // the SDK's own per-field `?`-optionality. `input.background_tasks ?? []`
+    // used to read that omission as an authoritative "nothing pending",
+    // clobbering the live count tracked from `background_tasks_changed` and
+    // releasing the held terminal — killing the still-running background
+    // subagent.
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    // Simulate the CLI firing Stop without the background_tasks/session_crons
+    // envelope at all (not even `background_tasks: undefined`).
+    const stopCallback = stopCallbackFromLastQueryCall();
+    await stopCallback({
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+    });
+    // Force the execute() loop to re-check its release condition (it only
+    // re-evaluates on the next stream message, not on the out-of-band hook
+    // call itself) with a message that carries no task snapshot of its own.
+    stream.push({ type: "assistant", message: { content: [] } });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+  });
+
+  it("releases the held terminal on a turn_end Stop hook that authoritatively reports empty background_tasks", async () => {
+    // Gegenprobe: a genuine empty snapshot (the field present, just empty)
+    // must still release as before — only an omitted field is a non-snapshot.
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    const stopCallback = stopCallbackFromLastQueryCall();
+    await stopCallback({
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+      background_tasks: [],
+      session_crons: [],
+    });
+    // Force the execute() loop to re-check its release condition — see the
+    // no-snapshot test above for why this is needed.
+    stream.push({ type: "assistant", message: { content: [] } });
+
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
   });
 });

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -1,0 +1,162 @@
+/**
+ * issue #458: a one-shot `execute()` run must not hand JobExecutor the
+ * terminal message (letting it tear the query down) while a
+ * `run_in_background` Agent-tool subagent it spawned is still live — it
+ * should hold the terminal message until `background_tasks_changed` reports
+ * an empty set, capped by `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type FakeMessage = Record<string, unknown>;
+
+// A controllable async generator standing in for the SDK's query() stream.
+// The queue is fed by the test; `query()` returns an object whose
+// `[Symbol.asyncIterator]` walks it, and whose `return()` marks it closed
+// (mirrors the real SDK Query handle `execute()` calls on the way out).
+function makeControllableStream() {
+  const pending: FakeMessage[] = [];
+  const waiters: Array<(msg: FakeMessage | typeof DONE) => void> = [];
+  const DONE = Symbol("done");
+  let closed = false;
+
+  function push(message: FakeMessage) {
+    const waiter = waiters.shift();
+    if (waiter) waiter(message);
+    else pending.push(message);
+  }
+
+  const iterable = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          if (closed) return { done: true, value: undefined };
+          if (pending.length > 0) return { done: false, value: pending.shift() };
+          const message = await new Promise<FakeMessage | typeof DONE>((resolve) => {
+            waiters.push(resolve);
+          });
+          if (message === DONE) return { done: true, value: undefined };
+          return { done: false, value: message };
+        },
+        async return() {
+          closed = true;
+          for (const w of waiters.splice(0)) w(DONE);
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+
+  return { push, iterable, isClosed: () => closed };
+}
+
+let activeStream: ReturnType<typeof makeControllableStream> | undefined;
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(() => {
+    const stream = makeControllableStream();
+    activeStream = stream;
+    return stream.iterable;
+  }),
+  createSdkMcpServer: vi.fn(() => ({})),
+  tool: vi.fn(() => ({})),
+}));
+
+import type { ResolvedAgent } from "../../../config/index.js";
+import type { RuntimeExecuteOptions } from "../interface.js";
+import { SDKRuntime } from "../sdk-runtime.js";
+
+const agent = { name: "keeper", qualifiedName: "keeper" } as unknown as ResolvedAgent;
+
+function baseOptions(overrides: Partial<RuntimeExecuteOptions> = {}): RuntimeExecuteOptions {
+  return { prompt: "hi", agent, ...overrides };
+}
+
+afterEach(() => {
+  activeStream = undefined;
+  delete process.env.CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS;
+});
+
+describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
+  it("holds the terminal result until background_tasks_changed reports empty", async () => {
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    // Let execute() start and register its iterator.
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+
+    // Give the loop a couple of ticks to process both messages.
+    await new Promise((r) => setTimeout(r, 10));
+    // Non-terminal messages (like the background_tasks_changed system message
+    // itself) still pass straight through — only the terminal `result` is held.
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await drain;
+
+    // Both background_tasks_changed messages passed through as normal
+    // content; the terminal result was released only once tasks drained.
+    expect(seen.map((m) => m.type)).toEqual(["system", "system", "result"]);
+  });
+
+  it("does not hold the terminal result when ceiling is 0", async () => {
+    process.env.CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS = "0";
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+  });
+
+  it("gives up and yields the terminal once the ceiling elapses", async () => {
+    process.env.CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS = "20";
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    // Background task never drains — no further push.
+
+    await drain; // resolves once the 20ms ceiling fires
+    const results = seen.filter((m) => m.type === "result");
+    expect(results).toHaveLength(1);
+  });
+});

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -123,10 +123,16 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
     expect(seen.some((m) => m.type === "result")).toBe(false);
 
     stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    // The drain message alone is non-terminal and no longer ends the wait
+    // (see the "keeps waiting past a non-terminal drain message" test below)
+    // — the background task's own re-invocation turn still needs to produce
+    // its real terminal, here simulated as arriving right after the drain.
+    stream.push({ type: "result", subtype: "success" });
     await drain;
 
     // Both background_tasks_changed messages passed through as normal
-    // content; the terminal result was released only once tasks drained.
+    // content; the terminal result was released only once a fresh terminal
+    // arrived after tasks drained.
     expect(seen.map((m) => m.type)).toEqual(["system", "system", "result"]);
     expect(stream.isClosed()).toBe(true);
   });
@@ -162,6 +168,9 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
     expect(seen.some((m) => m.type === "result")).toBe(false);
 
     stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    // Drain alone is non-terminal — the loop still waits for a fresh
+    // terminal (the re-invocation's own result) before releasing.
+    stream.push({ type: "result", subtype: "success" });
     await drain;
     expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
   });
@@ -255,14 +264,15 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
       cwd: "/tmp",
       stop_hook_active: false,
     });
-    // Force the execute() loop to re-check its release condition (it only
-    // re-evaluates on the next stream message, not on the out-of-band hook
-    // call itself) with a message that carries no task snapshot of its own.
+    // A message that carries no task snapshot of its own must not clobber
+    // the tracked live count either.
     stream.push({ type: "assistant", message: { content: [] } });
     await new Promise((r) => setTimeout(r, 10));
     expect(seen.some((m) => m.type === "result")).toBe(false);
 
     stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    // Drain alone is non-terminal — wait for the re-invocation's own result.
+    stream.push({ type: "result", subtype: "success" });
     await drain;
     expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
   });
@@ -300,11 +310,55 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
       background_tasks: [],
       session_crons: [],
     });
-    // Force the execute() loop to re-check its release condition — see the
-    // no-snapshot test above for why this is needed.
     stream.push({ type: "assistant", message: { content: [] } });
+    // The Stop hook's authoritative empty snapshot is non-terminal — wait
+    // for the re-invocation's own result before releasing.
+    stream.push({ type: "result", subtype: "success" });
 
     await drain;
     expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+  });
+
+  it("keeps waiting past a non-terminal drain message and yields the fresh terminal, not the stale held one", async () => {
+    // Regression: the release check used to run after every message once a
+    // terminal was pending, not only on a fresh terminal. A
+    // `background_tasks_changed` drain message (tasks: []) is non-terminal —
+    // it gets yielded and passes straight through — but it also flips
+    // liveBackgroundTasks to empty in the same tick. The old code then broke
+    // right there, before the background task's own re-invocation turn
+    // (further assistant content + its real terminal) ever streamed, so the
+    // consumer only ever saw the stale first result.
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success", stale: true });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    // Drain event: non-terminal, but reports the task list as empty.
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await new Promise((r) => setTimeout(r, 10));
+    // The background subagent's own re-invocation turn, arriving late.
+    stream.push({ type: "assistant", message: { content: [] } });
+    stream.push({ type: "result", subtype: "success", stale: false });
+
+    await drain;
+
+    const results = seen.filter((m) => m.type === "result");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ stale: false });
   });
 });

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -220,7 +220,15 @@ export class SDKRuntime implements RuntimeInterface {
     // loop is waiting on that same tick).
     let liveBackgroundTasks: BackgroundTaskSummary[] = [];
     const onLifecycleSignal = (signal: SessionLifecycleSignal) => {
-      liveBackgroundTasks = signal.backgroundTasks;
+      // `activity` and `cron_deleted` carry no task snapshot (always `[]`,
+      // see SessionLifecycleSignal's own doc) — only `turn_end` and
+      // `background_tasks_changed` are authoritative. Taking every signal
+      // here would let an `activity` signal (fired on the next assistant
+      // message) wipe a real pending-task count to `[]` and release a held
+      // terminal early.
+      if (signal.kind === "turn_end" || signal.kind === "background_tasks_changed") {
+        liveBackgroundTasks = signal.backgroundTasks;
+      }
     };
     sdkOptions.hooks = {
       ...(sdkOptions.hooks ?? {}),
@@ -305,17 +313,21 @@ export class SDKRuntime implements RuntimeInterface {
           // else: keep looping, still holding.
         }
       }
+
+      // Inside the same try/finally as the loop above (not after it): a
+      // `yield` suspends the generator, and if the consumer aborts iteration
+      // right here (breaks its `for await`, calls `.return()`) without this
+      // being in the try, the `finally` below — and therefore input.end()/
+      // q.return() — would never run, leaking the query.
+      if (pendingTerminal) yield pendingTerminal;
     } finally {
       if (ceilingTimer) clearTimeout(ceilingTimer);
-    }
-
-    if (pendingTerminal) yield pendingTerminal;
-
-    input.end();
-    try {
-      await q.return(undefined);
-    } catch {
-      // Already closed / never started — nothing to clean up.
+      input.end();
+      try {
+        await q.return(undefined);
+      } catch {
+        // Already closed / never started — nothing to clean up.
+      }
     }
   }
 

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -226,7 +226,16 @@ export class SDKRuntime implements RuntimeInterface {
       // here would let an `activity` signal (fired on the next assistant
       // message) wipe a real pending-task count to `[]` and release a held
       // terminal early.
-      if (signal.kind === "turn_end" || signal.kind === "background_tasks_changed") {
+      // `hasSnapshot === false` means a `turn_end` fired without the CLI's
+      // background_tasks envelope (see SessionLifecycleSignal.hasSnapshot) —
+      // `signal.backgroundTasks` is then just an empty stand-in, not "drained
+      // to empty". Keep whatever we already tracked instead of clobbering it,
+      // which previously released a held terminal (and its live background
+      // subagent got killed) mid-wait. See edspencer/herdctl#459 follow-up.
+      if (
+        (signal.kind === "turn_end" || signal.kind === "background_tasks_changed") &&
+        signal.hasSnapshot !== false
+      ) {
         liveBackgroundTasks = signal.backgroundTasks;
       }
     };

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  type BackgroundTaskSummary,
   createSdkMcpServer,
   query,
   type SDKUserMessage,
@@ -16,12 +17,32 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import { buildLifecycleHooks, tapLifecycleStream } from "../../session/session-hooks.js";
+import type { SessionLifecycleSignal } from "../../session/types.js";
+import { isTerminalMessage } from "../message-processor.js";
 import { toSDKOptions } from "../sdk-adapter.js";
 import type { InjectedMcpServerDef, SDKMessage } from "../types.js";
 import { withClaudeConfigDir } from "./claude-config-dir.js";
 import { defaultClaudeHome } from "./cli-session-path.js";
 import type { RuntimeExecuteOptions, RuntimeInterface, RuntimeSession } from "./interface.js";
 import { MessageQueue } from "./message-queue.js";
+
+/**
+ * Ceiling for holding a one-shot `execute()` run's terminal message while a
+ * `run_in_background` Agent-tool subagent it spawned is still live (issue #458).
+ * Mirrors `claude -p`'s own `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` (default
+ * 10 min since Claude Code 2.1.182; `0` disables the wait) — the SDK runtime
+ * gets the same background-subagent grace the CLI runtime already gets.
+ */
+const DEFAULT_BG_WAIT_CEILING_MS = 10 * 60_000;
+function bgWaitCeilingMs(): number {
+  const raw = process.env.CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS;
+  if (raw === undefined || raw === "") return DEFAULT_BG_WAIT_CEILING_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_BG_WAIT_CEILING_MS;
+}
+
+/** Sentinel distinguishing "the ceiling timer won the race" from a real message. */
+const BG_WAIT_TIMED_OUT = Symbol("bg-wait-timed-out");
 
 /**
  * Build a streaming-input user message from plain text.
@@ -179,21 +200,122 @@ export class SDKRuntime implements RuntimeInterface {
   async *execute(options: RuntimeExecuteOptions): AsyncIterable<SDKMessage> {
     const sdkOptions = this.buildSdkOptions(options);
 
-    // Execute via SDK query(). Thread through the AbortController so the run is
-    // cancellable: the SDK `query()` options accept an `abortController` and stop
-    // the query when it aborts. This is what makes cancelJob able to interrupt an
-    // in-flight SDK turn (the CLI runtime aborts its subprocess separately).
-    const messages = query({
-      prompt: options.prompt,
+    // issue #458: a one-shot string-prompt `query()` ends its own generator the
+    // moment the top-level turn's terminal message arrives — abandoning any
+    // `run_in_background` Agent-tool subagent that hasn't finished yet, because
+    // JobExecutor's `for await` loop breaks on that same terminal message
+    // (nothing left to consult it wants to keep the query alive for). Fixed by
+    // borrowing openSession()'s streaming-input + lifecycle-hook wiring: a
+    // queue-backed prompt keeps the underlying query open, the Stop/
+    // background_tasks_changed hooks report whether background work is still
+    // live, and the terminal message is held back (up to bgWaitCeilingMs, the
+    // same grace `claude -p` gives via `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`)
+    // until it drains — instead of tearing the session down out from under it.
+    // Updated two ways: synchronously in this loop below (from the same
+    // `background_tasks_changed` stream message `tapLifecycleStream` reacts
+    // to — inspected directly here, not via its `sink`, which fires on a
+    // deferred microtask and would race the very message that triggered it),
+    // and from the Stop hook's authoritative end-of-turn snapshot via
+    // `onLifecycleSignal` below (fine to be async there — nothing in this
+    // loop is waiting on that same tick).
+    let liveBackgroundTasks: BackgroundTaskSummary[] = [];
+    const onLifecycleSignal = (signal: SessionLifecycleSignal) => {
+      liveBackgroundTasks = signal.backgroundTasks;
+    };
+    sdkOptions.hooks = {
+      ...(sdkOptions.hooks ?? {}),
+      ...buildLifecycleHooks(onLifecycleSignal),
+    };
+
+    const input = new MessageQueue<SDKUserMessage>();
+    if (options.prompt) {
+      input.push(toUserMessage(options.prompt));
+    }
+
+    // Thread the AbortController through so teardown has a lever beyond the
+    // generator's own `return()` (mirrors the original one-shot call).
+    const abortController = options.abortController ?? new AbortController();
+    const q = query({
+      prompt: input as AsyncIterable<SDKUserMessage>,
       options: {
         ...(sdkOptions as Record<string, unknown>),
-        abortController: options.abortController,
+        abortController,
       },
     });
+    const messages = tapLifecycleStream(
+      q as unknown as AsyncIterable<SDKMessage>,
+      onLifecycleSignal,
+    );
+    const iterator = messages[Symbol.asyncIterator]();
 
-    // Stream messages from SDK
-    for await (const message of messages) {
-      yield message as SDKMessage;
+    const ceilingMs = bgWaitCeilingMs();
+    let pendingTerminal: SDKMessage | undefined;
+    // Armed once, on the first message we hold back — a single deadline for
+    // the whole wait, not reset per message.
+    let ceilingTimer: ReturnType<typeof setTimeout> | undefined;
+    let ceilingPromise: Promise<typeof BG_WAIT_TIMED_OUT> | undefined;
+    const armCeiling = (): Promise<typeof BG_WAIT_TIMED_OUT> => {
+      if (!ceilingPromise) {
+        ceilingPromise = new Promise((resolve) => {
+          ceilingTimer = setTimeout(() => resolve(BG_WAIT_TIMED_OUT), ceilingMs);
+          ceilingTimer.unref?.();
+        });
+      }
+      return ceilingPromise;
+    };
+
+    try {
+      while (true) {
+        const nextResult = pendingTerminal
+          ? await Promise.race([iterator.next(), armCeiling()])
+          : await iterator.next();
+
+        if (nextResult === BG_WAIT_TIMED_OUT) break; // ceiling hit; yield the held terminal below
+        if (nextResult.done) break;
+
+        const message = nextResult.value;
+        // Read synchronously off the raw message, ahead of (and independent
+        // from) tapLifecycleStream's own deferred `sink` call for the same
+        // message — see the comment on `liveBackgroundTasks` above.
+        if (
+          message &&
+          (message as { type?: string }).type === "system" &&
+          (message as { subtype?: string }).subtype === "background_tasks_changed"
+        ) {
+          liveBackgroundTasks =
+            ((message as { tasks?: BackgroundTaskSummary[] }).tasks as BackgroundTaskSummary[]) ??
+            [];
+        }
+
+        if (isTerminalMessage(message)) {
+          // Supersedes any terminal already held — e.g. a re-invocation turn
+          // (the background task's own completion) produces a newer one.
+          pendingTerminal = message;
+        } else {
+          // Always forwarded, including while a terminal is held: a
+          // re-invocation's own content (assistant/tool messages) must reach
+          // the consumer, not just its eventual terminal.
+          yield message;
+        }
+
+        if (pendingTerminal) {
+          // ceilingMs === 0 mirrors `-p`'s "0 = don't wait" — stop holding
+          // immediately rather than arming a zero-length timer.
+          if (liveBackgroundTasks.length === 0 || ceilingMs === 0) break;
+          // else: keep looping, still holding.
+        }
+      }
+    } finally {
+      if (ceilingTimer) clearTimeout(ceilingTimer);
+    }
+
+    if (pendingTerminal) yield pendingTerminal;
+
+    input.end();
+    try {
+      await q.return(undefined);
+    } catch {
+      // Already closed / never started — nothing to clean up.
     }
   }
 

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -308,18 +308,22 @@ export class SDKRuntime implements RuntimeInterface {
           // Supersedes any terminal already held — e.g. a re-invocation turn
           // (the background task's own completion) produces a newer one.
           pendingTerminal = message;
+          // Only a *fresh* terminal message may end the wait. Checking this
+          // outside the branch (on every message once a terminal was pending)
+          // let a non-terminal `background_tasks_changed` drain event — which
+          // reaches this loop synchronously above and can flip
+          // liveBackgroundTasks to `[]` in the same iteration — break the
+          // loop right after the drain, before the background task's own
+          // re-invocation turn (further assistant messages + its real
+          // terminal) ever streamed. The consumer then saw the stale first
+          // terminal as the final answer.
+          if (liveBackgroundTasks.length === 0 || ceilingMs === 0) break;
+          // else: keep looping, still holding.
         } else {
           // Always forwarded, including while a terminal is held: a
           // re-invocation's own content (assistant/tool messages) must reach
           // the consumer, not just its eventual terminal.
           yield message;
-        }
-
-        if (pendingTerminal) {
-          // ceilingMs === 0 mirrors `-p`'s "0 = don't wait" — stop holding
-          // immediately rather than arming a zero-length timer.
-          if (liveBackgroundTasks.length === 0 || ceilingMs === 0) break;
-          // else: keep looping, still holding.
         }
       }
 

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -93,6 +93,51 @@ describe("buildLifecycleHooks", () => {
     expect(signal.backgroundTasks).toEqual([]);
   });
 
+  it("marks hasSnapshot false when the CLI omits the background_tasks envelope entirely", async () => {
+    // The CLI's Stop-hook payload builder wraps background_tasks/
+    // session_crons in one conditional envelope and can omit the key
+    // outright — distinct from the field being present with value
+    // `undefined` (the previous test). See #459 follow-up.
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    const inputWithoutEnvelope = {
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+      // no background_tasks / session_crons keys at all
+    } as unknown as HookInput;
+
+    await cb(inputWithoutEnvelope, undefined, { signal: new AbortController().signal });
+
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.hasSnapshot).toBe(false);
+    expect(signal.backgroundTasks).toEqual([]);
+    expect(signal.sessionCrons).toEqual([]);
+  });
+
+  it("marks hasSnapshot true (via a present key) even when the value is explicitly undefined", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    await cb(stopInput({ session_crons: undefined, background_tasks: undefined }), undefined, {
+      signal: new AbortController().signal,
+    });
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.hasSnapshot).toBe(true);
+  });
+
+  it("marks hasSnapshot true on a normal turn_end carrying a real snapshot", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    await cb(stopInput(), undefined, { signal: new AbortController().signal });
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.hasSnapshot).toBe(true);
+  });
+
   it("does nothing for non-stop hook inputs", async () => {
     const sink = vi.fn();
     const hooks = buildLifecycleHooks(sink);

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -138,6 +138,34 @@ describe("buildLifecycleHooks", () => {
     expect(signal.hasSnapshot).toBe(true);
   });
 
+  it("marks hasSnapshot false and ignores the snapshot when background_tasks is present but malformed", async () => {
+    // `?? []` only normalizes nullish — a non-array/invalid SDK payload must
+    // not sneak through as SessionCronSummary[]/BackgroundTaskSummary[].
+    // Field present + invalid shape is treated like field absent: logged and
+    // dropped, not crashed on.
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    const malformedInput = {
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+      background_tasks: "not-an-array",
+      session_crons: [{ id: "c1", schedule: "35 13 * * *", recurring: false, prompt: "go" }],
+    } as unknown as HookInput;
+
+    await expect(
+      cb(malformedInput, undefined, { signal: new AbortController().signal }),
+    ).resolves.toEqual({ continue: true });
+
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.hasSnapshot).toBe(false);
+    expect(signal.backgroundTasks).toEqual([]);
+    expect(signal.sessionCrons).toEqual([]);
+  });
+
   it("does nothing for non-stop hook inputs", async () => {
     const sink = vi.fn();
     const hooks = buildLifecycleHooks(sink);

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -118,7 +118,12 @@ describe("buildLifecycleHooks", () => {
     expect(signal.sessionCrons).toEqual([]);
   });
 
-  it("marks hasSnapshot true (via a present key) even when the value is explicitly undefined", async () => {
+  it("marks hasSnapshot false when the key is present but explicitly undefined", async () => {
+    // Array.isArray(undefined) is false, so a present-but-undefined key reads
+    // the same as an absent key — the stricter of the two readings. `in`
+    // would have called this "present" (true even for
+    // `{ background_tasks: undefined }`), reintroducing the old `?? []`
+    // clobber for this shape.
     const sink = vi.fn();
     const hooks = buildLifecycleHooks(sink);
     const cb = hooks!.Stop![0].hooks[0];
@@ -126,7 +131,9 @@ describe("buildLifecycleHooks", () => {
       signal: new AbortController().signal,
     });
     const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
-    expect(signal.hasSnapshot).toBe(true);
+    expect(signal.hasSnapshot).toBe(false);
+    expect(signal.sessionCrons).toEqual([]);
+    expect(signal.backgroundTasks).toEqual([]);
   });
 
   it("marks hasSnapshot true on a normal turn_end carrying a real snapshot", async () => {

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -460,7 +460,7 @@ describe("SessionReaper", () => {
   });
 
   it("still reaps a genuinely idle session on a turn_end that authoritatively reports empty background_tasks", async () => {
-    // Gegenprobe: a real empty snapshot (field present, genuinely empty) must
+    // Counter-check: a real empty snapshot (field present, genuinely empty) must
     // still reap as before — only an omitted field is a non-snapshot.
     const registry = fakeRegistry();
     const onReap = vi.fn();

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -436,6 +436,44 @@ describe("SessionReaper", () => {
     expect(session.close).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a background-task session alive on a turn_end without a background_tasks snapshot (#459 follow-up)", async () => {
+    // The CLI's Stop-hook payload builder can omit background_tasks/
+    // session_crons entirely for a turn_end, independent of the SDK's own
+    // per-field optionality — session-hooks.ts then reports hasSnapshot:
+    // false. Reading its empty backgroundTasks as authoritative would reap a
+    // session with real live background work. See job-2026-08-26-6opnmq.
+    const registry = fakeRegistry();
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry, onReap });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] })); // turn_end → keepAlive
+    await managed.handleSignal(
+      signal({ backgroundTasks: [], hasSnapshot: false }), // no-snapshot turn_end
+    );
+
+    expect(managed.isLive()).toBe(true);
+    expect(onReap).not.toHaveBeenCalled();
+    expect(registry.reconcile).toHaveBeenCalledTimes(1); // not called for the no-snapshot signal
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("still reaps a genuinely idle session on a turn_end that authoritatively reports empty background_tasks", async () => {
+    // Gegenprobe: a real empty snapshot (field present, genuinely empty) must
+    // still reap as before — only an omitted field is a non-snapshot.
+    const registry = fakeRegistry();
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry, onReap });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ backgroundTasks: [] }));
+
+    expect(managed.isLive()).toBe(false);
+    expect(onReap).toHaveBeenCalledWith({ agent: "team/agent", sessionId: "sess-1" });
+  });
+
   // A resume that may replay a stale async-input backlog runs the replayed backlog
   // as its OWN turn ahead of the caller's queued prompt turn. Reaping on the
   // backlog turn's turn_end would close the session out from under the queued turn

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -95,11 +95,24 @@ function deletedCronId(input: PostToolUseHookInput): string | null {
 export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"] {
   const stopCallback = async (input: HookInput) => {
     if (isMainAgentStop(input)) {
+      // The CLI builds `background_tasks`/`session_crons` as one conditional
+      // envelope and can omit BOTH fields for a given Stop, independent of the
+      // SDK's own per-field `?`-optionality. Detect via `in` — not `??` on the
+      // value — so "key absent" (no snapshot reported) isn't conflated with
+      // "key present, empty array" (authoritative: nothing pending). See
+      // {@link SessionLifecycleSignal.hasSnapshot}.
+      const hasSnapshot = "background_tasks" in input;
       const sessionCrons: SessionCronSummary[] = input.session_crons ?? [];
       const backgroundTasks: BackgroundTaskSummary[] = input.background_tasks ?? [];
       // Never let a sink failure reject the hook (which would disrupt turn flow);
       // log and continue. `emit` observes the async rejection off the hot path.
-      emit(sink, { kind: "turn_end", sessionId: input.session_id, sessionCrons, backgroundTasks });
+      emit(sink, {
+        kind: "turn_end",
+        sessionId: input.session_id,
+        sessionCrons,
+        backgroundTasks,
+        hasSnapshot,
+      });
     }
     return { continue: true };
   };

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -20,11 +20,28 @@ import type {
   SessionCronSummary,
   StopHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 import type { SDKMessage } from "../runner/types.js";
 import { createLogger } from "../utils/logger.js";
 import type { SessionLifecycleSignal } from "./types.js";
 
 const logger = createLogger("session-hooks");
+
+// Loose shape checks for the Stop hook's `background_tasks`/`session_crons`
+// snapshot — an external SDK payload, so validated rather than trusted
+// outright. Only the fields herdctl actually reads are required;
+// `.passthrough()` keeps the rest (e.g. `command`, `agent_type`) intact for
+// downstream consumers instead of stripping them.
+const backgroundTaskSummarySchema = z
+  .object({ id: z.string(), type: z.string(), status: z.string(), description: z.string() })
+  .passthrough();
+const sessionCronSummarySchema = z
+  .object({ id: z.string(), schedule: z.string(), recurring: z.boolean(), prompt: z.string() })
+  .passthrough();
+const stopSnapshotSchema = z.object({
+  background_tasks: z.array(backgroundTaskSummarySchema).optional(),
+  session_crons: z.array(sessionCronSummarySchema).optional(),
+});
 
 /** Receiver for lifecycle signals (the session-reaper's `handleSignal`). */
 export type LifecycleSignalSink = (signal: SessionLifecycleSignal) => void | Promise<void>;
@@ -101,9 +118,23 @@ export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"]
       // value — so "key absent" (no snapshot reported) isn't conflated with
       // "key present, empty array" (authoritative: nothing pending). See
       // {@link SessionLifecycleSignal.hasSnapshot}.
-      const hasSnapshot = "background_tasks" in input;
-      const sessionCrons: SessionCronSummary[] = input.session_crons ?? [];
-      const backgroundTasks: BackgroundTaskSummary[] = input.background_tasks ?? [];
+      const fieldPresent = "background_tasks" in input;
+      // `?? []` only normalizes nullish — it can't catch a non-array or
+      // malformed SDK payload sneaking through as SessionCronSummary[]/
+      // BackgroundTaskSummary[] (the reaper would then reconcile/decide off
+      // invalid state). Validate the shape too; an invalid payload is logged
+      // and treated the same as an absent field (hasSnapshot: false).
+      const parsed = stopSnapshotSchema.safeParse(input);
+      const hasSnapshot = fieldPresent && parsed.success;
+      if (fieldPresent && !parsed.success) {
+        logger.warn(
+          `Stop hook for session ${input.session_id} carried a malformed background_tasks/session_crons snapshot; ignoring it: ${parsed.error.message}`,
+        );
+      }
+      const sessionCrons: SessionCronSummary[] =
+        (parsed.success ? parsed.data.session_crons : undefined) ?? [];
+      const backgroundTasks: BackgroundTaskSummary[] =
+        (parsed.success ? parsed.data.background_tasks : undefined) ?? [];
       // Never let a sink failure reject the hook (which would disrupt turn flow);
       // log and continue. `emit` observes the async rejection off the hot path.
       emit(sink, {

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -114,11 +114,12 @@ export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"]
     if (isMainAgentStop(input)) {
       // The CLI builds `background_tasks`/`session_crons` as one conditional
       // envelope and can omit BOTH fields for a given Stop, independent of the
-      // SDK's own per-field `?`-optionality. Detect via `in` — not `??` on the
-      // value — so "key absent" (no snapshot reported) isn't conflated with
-      // "key present, empty array" (authoritative: nothing pending). See
+      // SDK's own per-field `?`-optionality. Detect via `Array.isArray` — not
+      // `in` (true even for `{ background_tasks: undefined }`, reintroducing
+      // the old `?? []` clobber) and not `??` on the value — so "no snapshot
+      // reported" isn't conflated with "authoritative empty snapshot". See
       // {@link SessionLifecycleSignal.hasSnapshot}.
-      const fieldPresent = "background_tasks" in input;
+      const fieldPresent = Array.isArray(input.background_tasks);
       // `?? []` only normalizes nullish — it can't catch a non-array or
       // malformed SDK payload sneaking through as SessionCronSummary[]/
       // BackgroundTaskSummary[] (the reaper would then reconcile/decide off

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -311,6 +311,17 @@ export class SessionReaper {
       return;
     }
 
+    // The CLI's Stop-hook payload builder can omit the background_tasks/
+    // session_crons envelope entirely for a given turn_end (independent of the
+    // SDK's own per-field optionality) — `signal.hasSnapshot === false` then
+    // means the arrays below are just empty stand-ins, not an authoritative
+    // "nothing pending". Reading them as authoritative would reap a session
+    // with real live background work out from under it. Do nothing and keep
+    // whatever state this session already has; the next signal that does carry
+    // a snapshot (background_tasks_changed or a later turn_end) re-decides.
+    // See edspencer/herdctl#459 follow-up.
+    if (signal.hasSnapshot === false) return;
+
     // turn_end: the authoritative snapshot supersedes any pending grace reap.
     managed.cancelPendingReap();
 

--- a/packages/core/src/session/types.ts
+++ b/packages/core/src/session/types.ts
@@ -54,6 +54,20 @@ export interface SessionLifecycleSignal {
    * {@link WakeRegistry.remove} so a herdctl-owned recurring wake stops firing.
    */
   deletedCronIds?: string[];
+  /**
+   * `turn_end` only: `false` when the CLI's Stop-hook payload builder omitted
+   * the `background_tasks`/`session_crons` envelope entirely for this turn
+   * (it's built conditionally, independent of the SDK's own per-field
+   * `?`-optionality) — `sessionCrons`/`backgroundTasks` are then just `?? []`
+   * stand-ins, not an authoritative "nothing pending" snapshot. A consumer
+   * must keep its last-known state instead of reading the stand-in as "drained
+   * to empty" (that clobber killed a live background subagent by releasing
+   * `SDKRuntime.execute()`'s held terminal and let `SessionReaper` reap a
+   * session with real background work — see edspencer/herdctl#459 follow-up).
+   * Omitted (`undefined`) means "authoritative", matching every other kind,
+   * whose arrays are always authoritative per their own doc above.
+   */
+  hasSnapshot?: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes #458

**Problem:** A one-shot string-prompt `query()` in `SDKRuntime.execute()` ends its own generator the moment the top-level turn's terminal message arrives. Any `run_in_background` Agent-tool subagent that hasn't finished yet is abandoned — JobExecutor's `for await` loop breaks on that same message with nothing left keeping the query alive. Under `claude -p` the harness waits for background subagents (capped by `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`); under the SDK runtime the session was torn down immediately, while the job still reported `status: completed`.

**Fix:** Mirrors `openSession()`'s streaming-input + lifecycle-hook wiring inside `execute()` itself: a queue-backed prompt keeps the query open, and the terminal message is held back while `backgroundTasks` is non-empty — capped by `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` (default 10 min, mirroring `claude -p`'s grace window; `0` disables the wait). Released early once tasks drain, or once the ceiling elapses.

**Verified:** 490 pre-existing tests unaffected; 3 new tests cover hold/release, ceiling=0, and ceiling-elapsed. Empirically verified end-to-end against a lab fleet with a real `run_in_background` subagent: its background-written marker file appeared for the first time across many prior attempts without this fix.

**Question — SessionReaper:** while digging I noticed `session/reaper-policy.ts` ships a `SessionReaper`/`decideReap` policy that looks designed to make exactly this kind of keep-alive decision, but nothing in the trigger/job path ever instantiates it. Was the intended design to wire the reaper into `closeSession()`/the job path instead of a local wait like this one? Happy to rework the PR in that direction if you'd prefer — this version deliberately stays minimal and local to `execute()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-shot SDK execution now waits for active background tasks before returning terminal results.
  * Results are released when background tasks finish or the configured wait period expires.
  * A zero-millisecond wait setting enables immediate completion.
* **Bug Fixes**
  * Prevented stale results from being returned before background-task updates complete.
  * Improved cancellation and stream cleanup during execution.
  * Incomplete or malformed task snapshots no longer prematurely release results or end sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->