### PR TITLE
fix(core): wire session-wake capture into the job path (#458 pt. 2)

### DIFF
--- a/packages/core/src/fleet-manager/__tests__/job-session-wake-capture.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/job-session-wake-capture.test.ts
@@ -1,0 +1,314 @@
+/**
+ * vulpes-pack#148 — wiring session wakes into the job path.
+ *
+ * Before this, `RuntimeExecuteOptions.onLifecycleSignal` was documented
+ * "ignored" by `execute()` and neither `JobControl.trigger()` nor
+ * `ScheduleExecutor.executeSchedule()` fed it anywhere: a job that called
+ * `ScheduleWakeup` completed and its wake evaporated. These exercise the
+ * capture wiring end-to-end through a real `FleetManager` (so a real
+ * `SessionLifecycleManager`/`WakeRegistry`/`FleetStateWakePersistence` is in
+ * play) with a stubbed `RuntimeFactory.create()` that yields scripted
+ * `SessionLifecycleSignal`s instead of talking to a real `claude` process.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RuntimeFactory } from "../../runner/index.js";
+import type {
+  RuntimeExecuteOptions,
+  RuntimeInterface,
+  RuntimeSession,
+} from "../../runner/runtime/interface.js";
+import { SDKRuntime } from "../../runner/runtime/sdk-runtime.js";
+import type { SDKMessage } from "../../runner/types.js";
+import type { TriggerInfo } from "../../scheduler/index.js";
+import { FleetStateWakePersistence } from "../../session/fleet-state-wake-persistence.js";
+import type { SessionWakeEntry } from "../../session/types.js";
+import { getJob } from "../../state/index.js";
+import { FleetManager } from "../fleet-manager.js";
+import { ScheduleExecutor } from "../schedule-executor.js";
+
+/** A stub runtime whose `execute()` is fully scripted by the test. */
+function stubRuntime(
+  handler: (options: RuntimeExecuteOptions) => AsyncGenerator<SDKMessage>,
+): RuntimeInterface {
+  return { execute: handler } as unknown as RuntimeInterface;
+}
+
+/** A minimal RuntimeSession, for `SDKRuntime.prototype.openSession` (the wake-fire path). */
+function fakeSession(): RuntimeSession {
+  async function* empty(): AsyncGenerator<never> {}
+  return {
+    messages: empty(),
+    send: vi.fn().mockResolvedValue(undefined),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    listCommands: vi.fn().mockResolvedValue([]),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    stopTask: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function dueWake(overrides: Partial<SessionWakeEntry> = {}): SessionWakeEntry {
+  return {
+    id: "w1",
+    agent: "keeper",
+    sessionId: "sess-1",
+    schedule: "*/5 * * * *",
+    recurring: false,
+    prompt: "WAKE-CONTINUE",
+    nextRunAt: new Date(Date.now() - 1000).toISOString(),
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("job-path session wake capture (vulpes-pack#148)", () => {
+  let tempDir: string;
+  let configDir: string;
+  let stateDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "herdctl-job-wake-"));
+    configDir = join(tempDir, "config");
+    stateDir = join(tempDir, ".herdctl");
+    await mkdir(configDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function createConfig(config: object) {
+    const configPath = join(configDir, "herdctl.yaml");
+    const yaml = await import("yaml");
+    await writeFile(configPath, yaml.stringify(config));
+    return configPath;
+  }
+
+  async function createAgentConfig(name: string, config: object) {
+    const agentDir = join(configDir, "agents");
+    await mkdir(agentDir, { recursive: true });
+    const agentPath = join(agentDir, `${name}.yaml`);
+    const yaml = await import("yaml");
+    await writeFile(agentPath, yaml.stringify(config));
+    return agentPath;
+  }
+
+  function createTestManager(configPath: string): FleetManager {
+    return new FleetManager({
+      configPath,
+      stateDir,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+  }
+
+  it("persists a wake from a job's turn_end, and the job still completes normally (does not stay running)", async () => {
+    await createAgentConfig("keeper", { name: "keeper" });
+    const configPath = await createConfig({
+      version: 1,
+      agents: [{ path: "./agents/keeper.yaml" }],
+    });
+    const manager = createTestManager(configPath);
+    await manager.initialize();
+
+    vi.spyOn(RuntimeFactory, "create").mockReturnValue(
+      stubRuntime(async function* (options) {
+        yield { type: "system", subtype: "init", session_id: "sess-job-1" };
+        await options.onLifecycleSignal?.({
+          kind: "turn_end",
+          sessionId: "sess-job-1",
+          sessionCrons: [{ id: "c1", schedule: "* * * * *", recurring: false, prompt: "WAKE" }],
+          backgroundTasks: [],
+        });
+        yield { type: "assistant", content: "done" };
+      }),
+    );
+
+    const result = await manager.trigger("keeper");
+    expect(result.success).toBe(true);
+
+    // Pins "the job does not stay running" — it reached `completed`, not some
+    // wait-for-the-wake state.
+    const jobsDir = join(stateDir, "jobs");
+    const job = await getJob(jobsDir, result.jobId);
+    expect(job?.status).toBe("completed");
+
+    const persisted = await new FleetStateWakePersistence({ stateDir }).load();
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({ id: "c1", agent: "keeper", sessionId: "sess-job-1" });
+  });
+
+  it("marks a resumed job's session live: a due wake for it is skipped until the job finishes", async () => {
+    await createAgentConfig("resumer", { name: "resumer" });
+    const configPath = await createConfig({
+      version: 1,
+      agents: [{ path: "./agents/resumer.yaml" }],
+    });
+    const manager = createTestManager(configPath);
+    await manager.initialize();
+
+    await new FleetStateWakePersistence({ stateDir }).save([
+      dueWake({ id: "w-live", agent: "resumer", sessionId: "sess-resume-1" }),
+    ]);
+
+    let releaseJob: () => void = () => {};
+    const jobGate = new Promise<void>((resolve) => {
+      releaseJob = resolve;
+    });
+
+    vi.spyOn(RuntimeFactory, "create").mockReturnValue(
+      stubRuntime(async function* (options) {
+        yield { type: "system", subtype: "init", session_id: "sess-resume-1" };
+        await jobGate; // hold the job "mid-flight" until the test releases it
+        yield { type: "assistant", content: "done" };
+      }),
+    );
+    // The wake-fire path (`openChatSession`) instantiates `SDKRuntime` directly
+    // (not via `RuntimeFactory.create`) — stub it too so the post-release
+    // dispatch below doesn't spawn a real `claude` subprocess.
+    vi.spyOn(SDKRuntime.prototype, "openSession").mockReturnValue(fakeSession());
+
+    const triggerPromise = manager.trigger("resumer", undefined, { resume: "sess-resume-1" });
+    // Let the job start (trackJob registers the live mark synchronously inside
+    // trigger(), before executor.execute() is even awaited — but give the
+    // stubbed runtime a tick to actually be invoked).
+    await new Promise((r) => setTimeout(r, 20));
+
+    const midFlight = await manager.getSessionLifecycle()!.dispatchDue(new Date());
+    expect(midFlight).toEqual([]); // guarded: session is job-live
+
+    releaseJob();
+    const result = await triggerPromise;
+    expect(result.success).toBe(true);
+
+    const afterJob = await manager.getSessionLifecycle()!.dispatchDue(new Date());
+    expect(afterJob.map((e) => e.id)).toEqual(["w-live"]);
+  });
+
+  it("no SessionLifecycleManager present → trigger behaves exactly as today, no throw", async () => {
+    await createAgentConfig("bare", { name: "bare" });
+    const configPath = await createConfig({
+      version: 1,
+      agents: [{ path: "./agents/bare.yaml" }],
+    });
+    const manager = createTestManager(configPath);
+    await manager.initialize();
+    // Simulate a fleet with no lifecycle manager wired (e.g. a lightweight
+    // embedding context) — trackJob is then simply never called.
+    vi.spyOn(manager, "getSessionLifecycle").mockReturnValue(null);
+
+    vi.spyOn(RuntimeFactory, "create").mockReturnValue(
+      stubRuntime(async function* (options) {
+        yield { type: "system", subtype: "init", session_id: "sess-bare-1" };
+        // A signal still arrives (SDKRuntime always calls it); with no
+        // lifecycle manager there is simply no tracker to feed.
+        await options.onLifecycleSignal?.({
+          kind: "turn_end",
+          sessionId: "sess-bare-1",
+          sessionCrons: [{ id: "c-bare", schedule: "* * * * *", recurring: false, prompt: "WAKE" }],
+          backgroundTasks: [],
+        });
+        yield { type: "assistant", content: "done" };
+      }),
+    );
+
+    const result = await manager.trigger("bare");
+    expect(result.success).toBe(true);
+    expect(await new FleetStateWakePersistence({ stateDir }).load()).toEqual([]);
+  });
+
+  it("the scheduled path (ScheduleExecutor) captures a wake the same way as a manual trigger", async () => {
+    await createAgentConfig("scheduled-keeper", { name: "scheduled-keeper" });
+    const configPath = await createConfig({
+      version: 1,
+      agents: [{ path: "./agents/scheduled-keeper.yaml" }],
+    });
+    const manager = createTestManager(configPath);
+    await manager.initialize();
+
+    vi.spyOn(RuntimeFactory, "create").mockReturnValue(
+      stubRuntime(async function* (options) {
+        yield { type: "system", subtype: "init", session_id: "sess-sched-1" };
+        await options.onLifecycleSignal?.({
+          kind: "turn_end",
+          sessionId: "sess-sched-1",
+          sessionCrons: [
+            { id: "c-sched", schedule: "* * * * *", recurring: false, prompt: "WAKE-SCHED" },
+          ],
+          backgroundTasks: [],
+        });
+        yield { type: "assistant", content: "done" };
+      }),
+    );
+
+    const agent = manager.getConfig()!.agents.find((a) => a.qualifiedName === "scheduled-keeper")!;
+    const executor = new ScheduleExecutor(manager);
+    const info: TriggerInfo = {
+      agent,
+      scheduleName: "daily",
+      schedule: {
+        type: "interval",
+        interval: "1h",
+        prompt: "go",
+        enabled: true,
+        resume_session: false,
+      },
+      scheduleState: { status: "idle", last_run_at: null, next_run_at: null, last_error: null },
+    };
+    await executor.executeSchedule(info);
+
+    const persisted = await new FleetStateWakePersistence({ stateDir }).load();
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({
+      id: "c-sched",
+      agent: "scheduled-keeper",
+      sessionId: "sess-sched-1",
+    });
+  });
+
+  it("restart survival: a wake persisted by a job is picked up by a freshly constructed manager over the same stateDir", async () => {
+    await createAgentConfig("keeper2", { name: "keeper2" });
+    const configPath = await createConfig({
+      version: 1,
+      agents: [{ path: "./agents/keeper2.yaml" }],
+    });
+    const manager = createTestManager(configPath);
+    await manager.initialize();
+
+    vi.spyOn(RuntimeFactory, "create").mockReturnValue(
+      stubRuntime(async function* (options) {
+        yield { type: "system", subtype: "init", session_id: "sess-restart-1" };
+        await options.onLifecycleSignal?.({
+          kind: "turn_end",
+          sessionId: "sess-restart-1",
+          sessionCrons: [
+            { id: "c-restart", schedule: "* * * * *", recurring: false, prompt: "WAKE-AGAIN" },
+          ],
+          backgroundTasks: [],
+        });
+        yield { type: "assistant", content: "done" };
+      }),
+    );
+    await manager.trigger("keeper2");
+
+    // Force the persisted wake overdue, then simulate a daemon restart: a
+    // brand-new FleetManager instance over the identical stateDir.
+    const persistence = new FleetStateWakePersistence({ stateDir });
+    const wakes = await persistence.load();
+    await persistence.save(
+      wakes.map((w) => ({ ...w, nextRunAt: new Date(Date.now() - 1000).toISOString() })),
+    );
+
+    const restarted = createTestManager(configPath);
+    await restarted.initialize();
+    vi.spyOn(RuntimeFactory, "create").mockReturnValue(stubRuntime(async function* () {}));
+    vi.spyOn(SDKRuntime.prototype, "openSession").mockReturnValue(fakeSession());
+
+    const dispatched = await restarted.getSessionLifecycle()!.dispatchDue(new Date());
+    expect(dispatched.map((e) => e.id)).toEqual(["c-restart"]);
+  });
+});

--- a/packages/core/src/fleet-manager/__tests__/job-session-wake-capture.test.ts
+++ b/packages/core/src/fleet-manager/__tests__/job-session-wake-capture.test.ts
@@ -65,6 +65,25 @@ function dueWake(overrides: Partial<SessionWakeEntry> = {}): SessionWakeEntry {
   };
 }
 
+/**
+ * Fires `onLifecycleSignal` the way production actually does — fire-and-forget
+ * on a deferred microtask (`SDKRuntime.execute()` never awaits the consumer,
+ * and `session-hooks.ts`'s `emit()` defers via `Promise.resolve().then()`) —
+ * rather than the earlier stub shape of `await options.onLifecycleSignal?.()`,
+ * which pinned an ordering guarantee the real runtime doesn't provide. Tests
+ * that need the signal to have landed call `flushMicrotasks()` afterward.
+ */
+function emitLifecycleSignal(
+  options: RuntimeExecuteOptions,
+  signal: Parameters<NonNullable<RuntimeExecuteOptions["onLifecycleSignal"]>>[0],
+): void {
+  void Promise.resolve().then(() => options.onLifecycleSignal?.(signal));
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
 describe("job-path session wake capture (vulpes-pack#148)", () => {
   let tempDir: string;
   let configDir: string;
@@ -118,7 +137,7 @@ describe("job-path session wake capture (vulpes-pack#148)", () => {
     vi.spyOn(RuntimeFactory, "create").mockReturnValue(
       stubRuntime(async function* (options) {
         yield { type: "system", subtype: "init", session_id: "sess-job-1" };
-        await options.onLifecycleSignal?.({
+        emitLifecycleSignal(options, {
           kind: "turn_end",
           sessionId: "sess-job-1",
           sessionCrons: [{ id: "c1", schedule: "* * * * *", recurring: false, prompt: "WAKE" }],
@@ -137,6 +156,9 @@ describe("job-path session wake capture (vulpes-pack#148)", () => {
     const job = await getJob(jobsDir, result.jobId);
     expect(job?.status).toBe("completed");
 
+    // The signal was deferred (fire-and-forget, as production delivers it) —
+    // give its microtask a turn to land before reading the persisted wake.
+    await flushMicrotasks();
     const persisted = await new FleetStateWakePersistence({ stateDir }).load();
     expect(persisted).toHaveLength(1);
     expect(persisted[0]).toMatchObject({ id: "c1", agent: "keeper", sessionId: "sess-job-1" });
@@ -206,7 +228,7 @@ describe("job-path session wake capture (vulpes-pack#148)", () => {
         yield { type: "system", subtype: "init", session_id: "sess-bare-1" };
         // A signal still arrives (SDKRuntime always calls it); with no
         // lifecycle manager there is simply no tracker to feed.
-        await options.onLifecycleSignal?.({
+        emitLifecycleSignal(options, {
           kind: "turn_end",
           sessionId: "sess-bare-1",
           sessionCrons: [{ id: "c-bare", schedule: "* * * * *", recurring: false, prompt: "WAKE" }],
@@ -218,6 +240,7 @@ describe("job-path session wake capture (vulpes-pack#148)", () => {
 
     const result = await manager.trigger("bare");
     expect(result.success).toBe(true);
+    await flushMicrotasks();
     expect(await new FleetStateWakePersistence({ stateDir }).load()).toEqual([]);
   });
 
@@ -233,7 +256,7 @@ describe("job-path session wake capture (vulpes-pack#148)", () => {
     vi.spyOn(RuntimeFactory, "create").mockReturnValue(
       stubRuntime(async function* (options) {
         yield { type: "system", subtype: "init", session_id: "sess-sched-1" };
-        await options.onLifecycleSignal?.({
+        emitLifecycleSignal(options, {
           kind: "turn_end",
           sessionId: "sess-sched-1",
           sessionCrons: [
@@ -261,6 +284,7 @@ describe("job-path session wake capture (vulpes-pack#148)", () => {
     };
     await executor.executeSchedule(info);
 
+    await flushMicrotasks();
     const persisted = await new FleetStateWakePersistence({ stateDir }).load();
     expect(persisted).toHaveLength(1);
     expect(persisted[0]).toMatchObject({
@@ -282,7 +306,7 @@ describe("job-path session wake capture (vulpes-pack#148)", () => {
     vi.spyOn(RuntimeFactory, "create").mockReturnValue(
       stubRuntime(async function* (options) {
         yield { type: "system", subtype: "init", session_id: "sess-restart-1" };
-        await options.onLifecycleSignal?.({
+        emitLifecycleSignal(options, {
           kind: "turn_end",
           sessionId: "sess-restart-1",
           sessionCrons: [
@@ -294,6 +318,7 @@ describe("job-path session wake capture (vulpes-pack#148)", () => {
       }),
     );
     await manager.trigger("keeper2");
+    await flushMicrotasks();
 
     // Force the persisted wake overdue, then simulate a daemon restart: a
     // brand-new FleetManager instance over the identical stateDir.

--- a/packages/core/src/fleet-manager/job-control.ts
+++ b/packages/core/src/fleet-manager/job-control.ts
@@ -202,6 +202,16 @@ export class JobControl {
     const abortController = new AbortController();
     let registeredJobId: string | undefined;
 
+    // Wake capture (vulpes-pack#148): without this, a `ScheduleWakeup`/session
+    // cron the job registers is silently dropped the instant the job completes
+    // — nothing was ever wired to `onLifecycleSignal` on this path. `trackJob`
+    // also marks the (possibly not-yet-known) session id "live" for the run so
+    // a due wake for it can't cold-resume it out from under this job. `null`
+    // when the fleet has no lifecycle manager (e.g. lightweight test contexts);
+    // the tracker is then simply absent and behavior is unchanged from today.
+    const lifecycleManager = this.ctx.getSessionLifecycle?.() ?? undefined;
+    const lifecycleTracker = lifecycleManager?.trackJob(agentName, sessionId);
+
     // Execute the job - this creates the job record and runs it
     // Note: Job output is written to JSONL by JobExecutor; log streaming picks it up
     // If onMessage callback is provided, it will be called for each SDK message
@@ -251,11 +261,13 @@ export class JobControl {
         injectedMcpServers: options?.injectedMcpServers,
         systemPromptAppend: options?.systemPromptAppend,
         abortController,
+        onLifecycleSignal: lifecycleTracker?.onLifecycleSignal,
       });
     } finally {
       if (registeredJobId) {
         this.ctx.unregisterJob?.(registeredJobId);
       }
+      lifecycleTracker?.release();
     }
 
     // If the run was cancelled mid-flight, cancelJob() has already recorded the

--- a/packages/core/src/fleet-manager/schedule-executor.ts
+++ b/packages/core/src/fleet-manager/schedule-executor.ts
@@ -110,6 +110,14 @@ export class ScheduleExecutor {
       const abortController = new AbortController();
       let registeredJobId: string | undefined;
 
+      // Wake capture (vulpes-pack#148): mirrors JobControl.trigger() — without
+      // this a scheduled job's `ScheduleWakeup`/session cron is silently
+      // dropped when the job completes. Scheduled jobs never resume an
+      // explicit session here, so trackJob learns the session id off the
+      // job's first lifecycle signal.
+      const lifecycleManager = this.ctx.getSessionLifecycle?.() ?? undefined;
+      const lifecycleTracker = lifecycleManager?.trackJob(agent.qualifiedName);
+
       // Execute the job with streaming output
       let result: Awaited<ReturnType<typeof executor.execute>>;
       try {
@@ -149,11 +157,13 @@ export class ScheduleExecutor {
             }
           },
           abortController,
+          onLifecycleSignal: lifecycleTracker?.onLifecycleSignal,
         });
       } finally {
         if (registeredJobId) {
           this.ctx.unregisterJob?.(registeredJobId);
         }
+        lifecycleTracker?.release();
       }
 
       // If the run was cancelled mid-flight (e.g. shutdown bulk-cancel),

--- a/packages/core/src/runner/job-executor.ts
+++ b/packages/core/src/runner/job-executor.ts
@@ -437,6 +437,7 @@ export class JobExecutor {
             abortController: options.abortController,
             injectedMcpServers: options.injectedMcpServers,
             systemPromptAppend: options.systemPromptAppend,
+            onLifecycleSignal: options.onLifecycleSignal,
           });
         } catch (initError) {
           // Wrap initialization errors with context

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -11,9 +11,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 type FakeMessage = Record<string, unknown>;
 
 // A controllable async generator standing in for the SDK's query() stream.
-// The queue is fed by the test; `query()` returns an object whose
-// `[Symbol.asyncIterator]` walks it, and whose `return()` marks it closed
-// (mirrors the real SDK Query handle `execute()` calls on the way out).
+// The queue is fed by the test; `query()` returns the Query object itself
+// (`iterable` below), which `execute()` calls `q.return()` on directly — NOT
+// only the iterator `[Symbol.asyncIterator]()` returns. A mock exposing
+// `return()` solely on the iterator lets `q.return()` throw (silently caught
+// by execute()'s own try/catch), so `isClosed()` never flips even though the
+// test looks green — hence `return()` is defined on `iterable` itself here,
+// same as the real SDK's `Query` (an AsyncGenerator, callable directly).
 function makeControllableStream() {
   const pending: FakeMessage[] = [];
   const waiters: Array<(msg: FakeMessage | typeof DONE) => void> = [];
@@ -24,6 +28,12 @@ function makeControllableStream() {
     const waiter = waiters.shift();
     if (waiter) waiter(message);
     else pending.push(message);
+  }
+
+  async function doReturn() {
+    closed = true;
+    for (const w of waiters.splice(0)) w(DONE);
+    return { done: true as const, value: undefined };
   }
 
   const iterable = {
@@ -38,13 +48,10 @@ function makeControllableStream() {
           if (message === DONE) return { done: true, value: undefined };
           return { done: false, value: message };
         },
-        async return() {
-          closed = true;
-          for (const w of waiters.splice(0)) w(DONE);
-          return { done: true, value: undefined };
-        },
+        return: doReturn,
       };
     },
+    return: doReturn,
   };
 
   return { push, iterable, isClosed: () => closed };
@@ -110,6 +117,42 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
     // Both background_tasks_changed messages passed through as normal
     // content; the terminal result was released only once tasks drained.
     expect(seen.map((m) => m.type)).toEqual(["system", "system", "result"]);
+    expect(stream.isClosed()).toBe(true);
+  });
+
+  it("does not release the held terminal on an unrelated activity signal", async () => {
+    // Regression for a bug CodeRabbit caught on PR #459: onLifecycleSignal
+    // used to overwrite liveBackgroundTasks on EVERY signal, including
+    // `activity` (fired on the next assistant message, always backgroundTasks
+    // []) — wiping a real pending count and releasing the terminal early.
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // An assistant message is what tapLifecycleStream treats as `activity` —
+    // must NOT clear the held task count.
+    stream.push({ type: "assistant", message: { content: [] } });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
   });
 
   it("does not hold the terminal result when ceiling is 0", async () => {
@@ -133,6 +176,7 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
 
     await drain;
     expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+    expect(stream.isClosed()).toBe(true);
   });
 
   it("gives up and yields the terminal once the ceiling elapses", async () => {
@@ -158,5 +202,6 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
     await drain; // resolves once the 20ms ceiling fires
     const results = seen.filter((m) => m.type === "result");
     expect(results).toHaveLength(1);
+    expect(stream.isClosed()).toBe(true);
   });
 });

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -30,7 +30,7 @@ function makeControllableStream() {
     else pending.push(message);
   }
 
-  async function doReturn() {
+  async function doReturn(): Promise<{ done: true; value: undefined }> {
     closed = true;
     for (const w of waiters.splice(0)) w(DONE);
     return { done: true as const, value: undefined };

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -71,6 +71,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { ResolvedAgent } from "../../../config/index.js";
+import type { SessionLifecycleSignal } from "../../../session/types.js";
 import type { RuntimeExecuteOptions } from "../interface.js";
 import { SDKRuntime } from "../sdk-runtime.js";
 
@@ -82,6 +83,16 @@ function stopCallbackFromLastQueryCall(): (input: unknown) => Promise<unknown> {
     Stop: Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>;
   };
   return hooks.Stop[0].hooks[0];
+}
+
+/** Grab the PostToolUse-hook callback `execute()` registered on its last `query()` call. */
+function postToolUseCallbackFromLastQueryCall(): (input: unknown) => Promise<unknown> {
+  const lastCall = vi.mocked(query).mock.calls.at(-1)!;
+  const options = (lastCall[0] as { options: Record<string, unknown> }).options;
+  const hooks = options.hooks as {
+    PostToolUse: Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>;
+  };
+  return hooks.PostToolUse[0].hooks[0];
 }
 
 const agent = { name: "keeper", qualifiedName: "keeper" } as unknown as ResolvedAgent;
@@ -304,6 +315,244 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
     // no-snapshot test above for why this is needed.
     stream.push({ type: "assistant", message: { content: [] } });
 
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+  });
+});
+
+// vulpes-pack#148 — RuntimeExecuteOptions.onLifecycleSignal was documented
+// "ignored" by execute() and nothing consumed it: a job's ScheduleWakeup/
+// session cron never reached anywhere and evaporated on job completion. These
+// pin the composition contract a job-path consumer (SessionLifecycleManager.
+// trackJob) relies on: it rides along on the same signals as the internal
+// bg-wait tracker, in addition to it, never instead of it.
+describe("SDKRuntime.execute() onLifecycleSignal consumer composition (vulpes-pack#148)", () => {
+  it("delivers all four SessionLifecycleSignal kinds to a supplied consumer", async () => {
+    const runtime = new SDKRuntime();
+    const signals: SessionLifecycleSignal[] = [];
+    const onLifecycleSignal = vi.fn((signal: SessionLifecycleSignal) => {
+      signals.push(signal);
+    });
+    const drain = (async () => {
+      for await (const _message of runtime.execute(baseOptions({ onLifecycleSignal }))) {
+        // drain
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    stream.push({ type: "assistant", message: { content: [] } });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const postToolUseCallback = postToolUseCallbackFromLastQueryCall();
+    await postToolUseCallback({
+      hook_event_name: "PostToolUse",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      tool_name: "CronDelete",
+      tool_input: { id: "c1" },
+      tool_response: {},
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const stopCallback = stopCallbackFromLastQueryCall();
+    await stopCallback({
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+      background_tasks: [],
+      session_crons: [{ id: "c2", schedule: "+60s", recurring: false, prompt: "WAKE" }],
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    stream.push({ type: "result", subtype: "success" });
+    await drain;
+
+    const kinds = signals.map((s) => s.kind);
+    expect(kinds).toContain("background_tasks_changed");
+    expect(kinds).toContain("activity");
+    expect(kinds).toContain("cron_deleted");
+    expect(kinds).toContain("turn_end");
+
+    const turnEnd = signals.find((s) => s.kind === "turn_end");
+    expect(turnEnd?.sessionCrons).toEqual([
+      { id: "c2", schedule: "+60s", recurring: false, prompt: "WAKE" },
+    ]);
+    const cronDeleted = signals.find((s) => s.kind === "cron_deleted");
+    expect(cronDeleted?.deletedCronIds).toEqual(["c1"]);
+  });
+
+  it("holds the terminal exactly as without a consumer, and the consumer sees the same hasSnapshot: false", async () => {
+    // Byte-for-byte composition check: attaching a consumer must not change
+    // the #458/#459 anchor semantics at all.
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const signals: SessionLifecycleSignal[] = [];
+    const onLifecycleSignal = (signal: SessionLifecycleSignal) => {
+      signals.push(signal);
+    };
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions({ onLifecycleSignal }))) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    // A turn_end fired without the background_tasks/session_crons envelope —
+    // must not clobber the live task count, even with a consumer attached.
+    const stopCallback = stopCallbackFromLastQueryCall();
+    await stopCallback({
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+    });
+    stream.push({ type: "assistant", message: { content: [] } });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+
+    // The consumer still saw the non-authoritative turn_end (hasSnapshot: false).
+    const turnEnd = signals.find((s) => s.kind === "turn_end");
+    expect(turnEnd?.hasSnapshot).toBe(false);
+  });
+
+  it("a throwing consumer does not break the message loop or drop messages", async () => {
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const onLifecycleSignal = vi.fn(() => {
+      throw new Error("consumer boom");
+    });
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions({ onLifecycleSignal }))) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "assistant", message: { content: [] } });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+    // Terminal still held (the throwing consumer didn't corrupt bg-task tracking).
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await drain;
+
+    // Every non-terminal message still reached the consumer of the stream itself.
+    expect(seen.map((m) => m.type)).toEqual(["system", "assistant", "system", "result"]);
+    expect(onLifecycleSignal.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("a rejecting (async) consumer does not break the message loop", async () => {
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const onLifecycleSignal = vi.fn(() => Promise.reject(new Error("consumer boom async")));
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions({ onLifecycleSignal }))) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await drain;
+
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+    expect(stream.isClosed()).toBe(true);
+  });
+
+  it("holds the terminal for a live background task AND delivers its concurrent session cron", async () => {
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const signals: SessionLifecycleSignal[] = [];
+    const onLifecycleSignal = (signal: SessionLifecycleSignal) => {
+      signals.push(signal);
+    };
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions({ onLifecycleSignal }))) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Authoritative turn_end reports BOTH a live background task and a pending
+    // session cron in the same snapshot.
+    const stopCallback = stopCallbackFromLastQueryCall();
+    await stopCallback({
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+      background_tasks: [{ id: "t1", type: "shell", status: "running", description: "server" }],
+      session_crons: [{ id: "c1", schedule: "+60s", recurring: false, prompt: "WAKE" }],
+    });
+    stream.push({ type: "assistant", message: { content: [] } });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Still held — the task is live per the authoritative snapshot.
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+    const turnEnd = signals.find((s) => s.kind === "turn_end");
+    expect(turnEnd?.sessionCrons).toEqual([
+      { id: "c1", schedule: "+60s", recurring: false, prompt: "WAKE" },
+    ]);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
     await drain;
     expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
   });

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -268,7 +268,7 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
   });
 
   it("releases the held terminal on a turn_end Stop hook that authoritatively reports empty background_tasks", async () => {
-    // Gegenprobe: a genuine empty snapshot (the field present, just empty)
+    // Counter-check: a genuine empty snapshot (the field present, just empty)
     // must still release as before — only an omitted field is a non-snapshot.
     const runtime = new SDKRuntime();
     const seen: FakeMessage[] = [];

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -69,9 +69,20 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   tool: vi.fn(() => ({})),
 }));
 
+import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { ResolvedAgent } from "../../../config/index.js";
 import type { RuntimeExecuteOptions } from "../interface.js";
 import { SDKRuntime } from "../sdk-runtime.js";
+
+/** Grab the Stop-hook callback `execute()` registered on its last `query()` call. */
+function stopCallbackFromLastQueryCall(): (input: unknown) => Promise<unknown> {
+  const lastCall = vi.mocked(query).mock.calls.at(-1)!;
+  const options = (lastCall[0] as { options: Record<string, unknown> }).options;
+  const hooks = options.hooks as {
+    Stop: Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>;
+  };
+  return hooks.Stop[0].hooks[0];
+}
 
 const agent = { name: "keeper", qualifiedName: "keeper" } as unknown as ResolvedAgent;
 
@@ -203,5 +214,97 @@ describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
     const results = seen.filter((m) => m.type === "result");
     expect(results).toHaveLength(1);
     expect(stream.isClosed()).toBe(true);
+  });
+
+  it("does not release the held terminal on a turn_end Stop hook fired without a background_tasks snapshot", async () => {
+    // Regression for the prod #459 follow-up (job-2026-08-26-6opnmq): the
+    // CLI's Stop-hook payload builder is conditional and can omit
+    // `background_tasks`/`session_crons` entirely for a turn, independent of
+    // the SDK's own per-field `?`-optionality. `input.background_tasks ?? []`
+    // used to read that omission as an authoritative "nothing pending",
+    // clobbering the live count tracked from `background_tasks_changed` and
+    // releasing the held terminal — killing the still-running background
+    // subagent.
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    // Simulate the CLI firing Stop without the background_tasks/session_crons
+    // envelope at all (not even `background_tasks: undefined`).
+    const stopCallback = stopCallbackFromLastQueryCall();
+    await stopCallback({
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+    });
+    // Force the execute() loop to re-check its release condition (it only
+    // re-evaluates on the next stream message, not on the out-of-band hook
+    // call itself) with a message that carries no task snapshot of its own.
+    stream.push({ type: "assistant", message: { content: [] } });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+  });
+
+  it("releases the held terminal on a turn_end Stop hook that authoritatively reports empty background_tasks", async () => {
+    // Gegenprobe: a genuine empty snapshot (the field present, just empty)
+    // must still release as before — only an omitted field is a non-snapshot.
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    const stopCallback = stopCallbackFromLastQueryCall();
+    await stopCallback({
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+      background_tasks: [],
+      session_crons: [],
+    });
+    // Force the execute() loop to re-check its release condition — see the
+    // no-snapshot test above for why this is needed.
+    stream.push({ type: "assistant", message: { content: [] } });
+
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
   });
 });

--- a/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
+++ b/packages/core/src/runner/runtime/__tests__/sdk-runtime-bg-wait.test.ts
@@ -1,0 +1,162 @@
+/**
+ * issue #458: a one-shot `execute()` run must not hand JobExecutor the
+ * terminal message (letting it tear the query down) while a
+ * `run_in_background` Agent-tool subagent it spawned is still live — it
+ * should hold the terminal message until `background_tasks_changed` reports
+ * an empty set, capped by `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type FakeMessage = Record<string, unknown>;
+
+// A controllable async generator standing in for the SDK's query() stream.
+// The queue is fed by the test; `query()` returns an object whose
+// `[Symbol.asyncIterator]` walks it, and whose `return()` marks it closed
+// (mirrors the real SDK Query handle `execute()` calls on the way out).
+function makeControllableStream() {
+  const pending: FakeMessage[] = [];
+  const waiters: Array<(msg: FakeMessage | typeof DONE) => void> = [];
+  const DONE = Symbol("done");
+  let closed = false;
+
+  function push(message: FakeMessage) {
+    const waiter = waiters.shift();
+    if (waiter) waiter(message);
+    else pending.push(message);
+  }
+
+  const iterable = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          if (closed) return { done: true, value: undefined };
+          if (pending.length > 0) return { done: false, value: pending.shift() };
+          const message = await new Promise<FakeMessage | typeof DONE>((resolve) => {
+            waiters.push(resolve);
+          });
+          if (message === DONE) return { done: true, value: undefined };
+          return { done: false, value: message };
+        },
+        async return() {
+          closed = true;
+          for (const w of waiters.splice(0)) w(DONE);
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+
+  return { push, iterable, isClosed: () => closed };
+}
+
+let activeStream: ReturnType<typeof makeControllableStream> | undefined;
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(() => {
+    const stream = makeControllableStream();
+    activeStream = stream;
+    return stream.iterable;
+  }),
+  createSdkMcpServer: vi.fn(() => ({})),
+  tool: vi.fn(() => ({})),
+}));
+
+import type { ResolvedAgent } from "../../../config/index.js";
+import type { RuntimeExecuteOptions } from "../interface.js";
+import { SDKRuntime } from "../sdk-runtime.js";
+
+const agent = { name: "keeper", qualifiedName: "keeper" } as unknown as ResolvedAgent;
+
+function baseOptions(overrides: Partial<RuntimeExecuteOptions> = {}): RuntimeExecuteOptions {
+  return { prompt: "hi", agent, ...overrides };
+}
+
+afterEach(() => {
+  activeStream = undefined;
+  delete process.env.CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS;
+});
+
+describe("SDKRuntime.execute() background-task hold (issue #458)", () => {
+  it("holds the terminal result until background_tasks_changed reports empty", async () => {
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    // Let execute() start and register its iterator.
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+
+    // Give the loop a couple of ticks to process both messages.
+    await new Promise((r) => setTimeout(r, 10));
+    // Non-terminal messages (like the background_tasks_changed system message
+    // itself) still pass straight through — only the terminal `result` is held.
+    expect(seen.some((m) => m.type === "result")).toBe(false);
+
+    stream.push({ type: "system", subtype: "background_tasks_changed", tasks: [] });
+    await drain;
+
+    // Both background_tasks_changed messages passed through as normal
+    // content; the terminal result was released only once tasks drained.
+    expect(seen.map((m) => m.type)).toEqual(["system", "system", "result"]);
+  });
+
+  it("does not hold the terminal result when ceiling is 0", async () => {
+    process.env.CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS = "0";
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+
+    await drain;
+    expect(seen.filter((m) => m.type === "result")).toHaveLength(1);
+  });
+
+  it("gives up and yields the terminal once the ceiling elapses", async () => {
+    process.env.CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS = "20";
+    const runtime = new SDKRuntime();
+    const seen: FakeMessage[] = [];
+    const drain = (async () => {
+      for await (const message of runtime.execute(baseOptions())) {
+        seen.push(message);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 0));
+    const stream = activeStream!;
+    stream.push({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "t1" }],
+    });
+    stream.push({ type: "result", subtype: "success" });
+    // Background task never drains — no further push.
+
+    await drain; // resolves once the 20ms ceiling fires
+    const results = seen.filter((m) => m.type === "result");
+    expect(results).toHaveLength(1);
+  });
+});

--- a/packages/core/src/runner/runtime/interface.ts
+++ b/packages/core/src/runner/runtime/interface.ts
@@ -61,14 +61,21 @@ export interface RuntimeExecuteOptions {
   includePartialMessages?: boolean;
 
   /**
-   * Streaming sessions only: observe the session's background-work lifecycle.
+   * Observe the run's session-lifecycle signals: turn boundaries (the SDK
+   * main-agent `Stop` hook), live background-task changes
+   * (`background_tasks_changed`), mid-turn activity, and explicit `CronDelete`
+   * retirements — with a snapshot of the session's pending timer-class wakeups
+   * (`sessionCrons`) and continuous-class background work (`backgroundTasks`).
    *
-   * Called at each turn boundary (the SDK main-agent `Stop` hook) and when
-   * the live background-task set changes (`background_tasks_changed`), with a
-   * snapshot of the session's pending timer-class wakeups (`sessionCrons`) and
-   * continuous-class background work (`backgroundTasks`). The session-reaper
-   * uses this to decide when to close an idle session and to capture wakeups for
-   * re-triggering. Ignored by {@link RuntimeInterface.execute}.
+   * Originally streaming-session-only (the session-reaper's own consumer, via
+   * `SessionLifecycleManager.manage`). {@link SDKRuntime.execute} also
+   * supports it now for its one-shot job path: it composes the caller's sink
+   * AFTER its own internal background-task tracking (the #458/#459 bg-wait),
+   * fire-and-forget and swallowing any throw/rejection, so a consumer must not
+   * rely on ordering against the raw message stream or assume its errors
+   * surface anywhere. See `SessionLifecycleManager.trackJob` (vulpes-pack#148)
+   * for the job-path consumer. The CLI and Docker runtimes still ignore this —
+   * neither wires the Stop-hook signals `execute()` needs to populate it.
    */
   onLifecycleSignal?: (
     signal: import("../../session/types.js").SessionLifecycleSignal,

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -220,7 +220,15 @@ export class SDKRuntime implements RuntimeInterface {
     // loop is waiting on that same tick).
     let liveBackgroundTasks: BackgroundTaskSummary[] = [];
     const onLifecycleSignal = (signal: SessionLifecycleSignal) => {
-      liveBackgroundTasks = signal.backgroundTasks;
+      // `activity` and `cron_deleted` carry no task snapshot (always `[]`,
+      // see SessionLifecycleSignal's own doc) — only `turn_end` and
+      // `background_tasks_changed` are authoritative. Taking every signal
+      // here would let an `activity` signal (fired on the next assistant
+      // message) wipe a real pending-task count to `[]` and release a held
+      // terminal early.
+      if (signal.kind === "turn_end" || signal.kind === "background_tasks_changed") {
+        liveBackgroundTasks = signal.backgroundTasks;
+      }
     };
     sdkOptions.hooks = {
       ...(sdkOptions.hooks ?? {}),
@@ -305,17 +313,21 @@ export class SDKRuntime implements RuntimeInterface {
           // else: keep looping, still holding.
         }
       }
+
+      // Inside the same try/finally as the loop above (not after it): a
+      // `yield` suspends the generator, and if the consumer aborts iteration
+      // right here (breaks its `for await`, calls `.return()`) without this
+      // being in the try, the `finally` below — and therefore input.end()/
+      // q.return() — would never run, leaking the query.
+      if (pendingTerminal) yield pendingTerminal;
     } finally {
       if (ceilingTimer) clearTimeout(ceilingTimer);
-    }
-
-    if (pendingTerminal) yield pendingTerminal;
-
-    input.end();
-    try {
-      await q.return(undefined);
-    } catch {
-      // Already closed / never started — nothing to clean up.
+      input.end();
+      try {
+        await q.return(undefined);
+      } catch {
+        // Already closed / never started — nothing to clean up.
+      }
     }
   }
 

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -226,7 +226,16 @@ export class SDKRuntime implements RuntimeInterface {
       // here would let an `activity` signal (fired on the next assistant
       // message) wipe a real pending-task count to `[]` and release a held
       // terminal early.
-      if (signal.kind === "turn_end" || signal.kind === "background_tasks_changed") {
+      // `hasSnapshot === false` means a `turn_end` fired without the CLI's
+      // background_tasks envelope (see SessionLifecycleSignal.hasSnapshot) —
+      // `signal.backgroundTasks` is then just an empty stand-in, not "drained
+      // to empty". Keep whatever we already tracked instead of clobbering it,
+      // which previously released a held terminal (and its live background
+      // subagent got killed) mid-wait. See edspencer/herdctl#459 follow-up.
+      if (
+        (signal.kind === "turn_end" || signal.kind === "background_tasks_changed") &&
+        signal.hasSnapshot !== false
+      ) {
         liveBackgroundTasks = signal.backgroundTasks;
       }
     };

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  type BackgroundTaskSummary,
   createSdkMcpServer,
   query,
   type SDKUserMessage,
@@ -16,12 +17,32 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import { buildLifecycleHooks, tapLifecycleStream } from "../../session/session-hooks.js";
+import type { SessionLifecycleSignal } from "../../session/types.js";
+import { isTerminalMessage } from "../message-processor.js";
 import { toSDKOptions } from "../sdk-adapter.js";
 import type { InjectedMcpServerDef, SDKMessage } from "../types.js";
 import { withClaudeConfigDir } from "./claude-config-dir.js";
 import { defaultClaudeHome } from "./cli-session-path.js";
 import type { RuntimeExecuteOptions, RuntimeInterface, RuntimeSession } from "./interface.js";
 import { MessageQueue } from "./message-queue.js";
+
+/**
+ * Ceiling for holding a one-shot `execute()` run's terminal message while a
+ * `run_in_background` Agent-tool subagent it spawned is still live (issue #458).
+ * Mirrors `claude -p`'s own `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` (default
+ * 10 min since Claude Code 2.1.182; `0` disables the wait) — the SDK runtime
+ * gets the same background-subagent grace the CLI runtime already gets.
+ */
+const DEFAULT_BG_WAIT_CEILING_MS = 10 * 60_000;
+function bgWaitCeilingMs(): number {
+  const raw = process.env.CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS;
+  if (raw === undefined || raw === "") return DEFAULT_BG_WAIT_CEILING_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_BG_WAIT_CEILING_MS;
+}
+
+/** Sentinel distinguishing "the ceiling timer won the race" from a real message. */
+const BG_WAIT_TIMED_OUT = Symbol("bg-wait-timed-out");
 
 /**
  * Build a streaming-input user message from plain text.
@@ -179,21 +200,122 @@ export class SDKRuntime implements RuntimeInterface {
   async *execute(options: RuntimeExecuteOptions): AsyncIterable<SDKMessage> {
     const sdkOptions = this.buildSdkOptions(options);
 
-    // Execute via SDK query(). Thread through the AbortController so the run is
-    // cancellable: the SDK `query()` options accept an `abortController` and stop
-    // the query when it aborts. This is what makes cancelJob able to interrupt an
-    // in-flight SDK turn (the CLI runtime aborts its subprocess separately).
-    const messages = query({
-      prompt: options.prompt,
+    // issue #458: a one-shot string-prompt `query()` ends its own generator the
+    // moment the top-level turn's terminal message arrives — abandoning any
+    // `run_in_background` Agent-tool subagent that hasn't finished yet, because
+    // JobExecutor's `for await` loop breaks on that same terminal message
+    // (nothing left to consult it wants to keep the query alive for). Fixed by
+    // borrowing openSession()'s streaming-input + lifecycle-hook wiring: a
+    // queue-backed prompt keeps the underlying query open, the Stop/
+    // background_tasks_changed hooks report whether background work is still
+    // live, and the terminal message is held back (up to bgWaitCeilingMs, the
+    // same grace `claude -p` gives via `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`)
+    // until it drains — instead of tearing the session down out from under it.
+    // Updated two ways: synchronously in this loop below (from the same
+    // `background_tasks_changed` stream message `tapLifecycleStream` reacts
+    // to — inspected directly here, not via its `sink`, which fires on a
+    // deferred microtask and would race the very message that triggered it),
+    // and from the Stop hook's authoritative end-of-turn snapshot via
+    // `onLifecycleSignal` below (fine to be async there — nothing in this
+    // loop is waiting on that same tick).
+    let liveBackgroundTasks: BackgroundTaskSummary[] = [];
+    const onLifecycleSignal = (signal: SessionLifecycleSignal) => {
+      liveBackgroundTasks = signal.backgroundTasks;
+    };
+    sdkOptions.hooks = {
+      ...(sdkOptions.hooks ?? {}),
+      ...buildLifecycleHooks(onLifecycleSignal),
+    };
+
+    const input = new MessageQueue<SDKUserMessage>();
+    if (options.prompt) {
+      input.push(toUserMessage(options.prompt));
+    }
+
+    // Thread the AbortController through so teardown has a lever beyond the
+    // generator's own `return()` (mirrors the original one-shot call).
+    const abortController = options.abortController ?? new AbortController();
+    const q = query({
+      prompt: input as AsyncIterable<SDKUserMessage>,
       options: {
         ...(sdkOptions as Record<string, unknown>),
-        abortController: options.abortController,
+        abortController,
       },
     });
+    const messages = tapLifecycleStream(
+      q as unknown as AsyncIterable<SDKMessage>,
+      onLifecycleSignal,
+    );
+    const iterator = messages[Symbol.asyncIterator]();
 
-    // Stream messages from SDK
-    for await (const message of messages) {
-      yield message as SDKMessage;
+    const ceilingMs = bgWaitCeilingMs();
+    let pendingTerminal: SDKMessage | undefined;
+    // Armed once, on the first message we hold back — a single deadline for
+    // the whole wait, not reset per message.
+    let ceilingTimer: ReturnType<typeof setTimeout> | undefined;
+    let ceilingPromise: Promise<typeof BG_WAIT_TIMED_OUT> | undefined;
+    const armCeiling = (): Promise<typeof BG_WAIT_TIMED_OUT> => {
+      if (!ceilingPromise) {
+        ceilingPromise = new Promise((resolve) => {
+          ceilingTimer = setTimeout(() => resolve(BG_WAIT_TIMED_OUT), ceilingMs);
+          ceilingTimer.unref?.();
+        });
+      }
+      return ceilingPromise;
+    };
+
+    try {
+      while (true) {
+        const nextResult = pendingTerminal
+          ? await Promise.race([iterator.next(), armCeiling()])
+          : await iterator.next();
+
+        if (nextResult === BG_WAIT_TIMED_OUT) break; // ceiling hit; yield the held terminal below
+        if (nextResult.done) break;
+
+        const message = nextResult.value;
+        // Read synchronously off the raw message, ahead of (and independent
+        // from) tapLifecycleStream's own deferred `sink` call for the same
+        // message — see the comment on `liveBackgroundTasks` above.
+        if (
+          message &&
+          (message as { type?: string }).type === "system" &&
+          (message as { subtype?: string }).subtype === "background_tasks_changed"
+        ) {
+          liveBackgroundTasks =
+            ((message as { tasks?: BackgroundTaskSummary[] }).tasks as BackgroundTaskSummary[]) ??
+            [];
+        }
+
+        if (isTerminalMessage(message)) {
+          // Supersedes any terminal already held — e.g. a re-invocation turn
+          // (the background task's own completion) produces a newer one.
+          pendingTerminal = message;
+        } else {
+          // Always forwarded, including while a terminal is held: a
+          // re-invocation's own content (assistant/tool messages) must reach
+          // the consumer, not just its eventual terminal.
+          yield message;
+        }
+
+        if (pendingTerminal) {
+          // ceilingMs === 0 mirrors `-p`'s "0 = don't wait" — stop holding
+          // immediately rather than arming a zero-length timer.
+          if (liveBackgroundTasks.length === 0 || ceilingMs === 0) break;
+          // else: keep looping, still holding.
+        }
+      }
+    } finally {
+      if (ceilingTimer) clearTimeout(ceilingTimer);
+    }
+
+    if (pendingTerminal) yield pendingTerminal;
+
+    input.end();
+    try {
+      await q.return(undefined);
+    } catch {
+      // Already closed / never started — nothing to clean up.
     }
   }
 

--- a/packages/core/src/runner/runtime/sdk-runtime.ts
+++ b/packages/core/src/runner/runtime/sdk-runtime.ts
@@ -219,7 +219,7 @@ export class SDKRuntime implements RuntimeInterface {
     // `onLifecycleSignal` below (fine to be async there — nothing in this
     // loop is waiting on that same tick).
     let liveBackgroundTasks: BackgroundTaskSummary[] = [];
-    const onLifecycleSignal = (signal: SessionLifecycleSignal) => {
+    const trackBackgroundTasks = (signal: SessionLifecycleSignal) => {
       // `activity` and `cron_deleted` carry no task snapshot (always `[]`,
       // see SessionLifecycleSignal's own doc) — only `turn_end` and
       // `background_tasks_changed` are authoritative. Taking every signal
@@ -237,6 +237,25 @@ export class SDKRuntime implements RuntimeInterface {
         signal.hasSnapshot !== false
       ) {
         liveBackgroundTasks = signal.backgroundTasks;
+      }
+    };
+    // Compose: this internal bg-wait tracker runs first and synchronously (the
+    // anchor decision above depends on it), then the caller's own
+    // `onLifecycleSignal` consumer (e.g. `SessionLifecycleManager.trackJob`,
+    // vulpes-pack#148) rides along on the same signals. A throwing/rejecting
+    // consumer must never break this message loop or release a held terminal
+    // early, so both failure shapes are swallowed here.
+    const onLifecycleSignal = (signal: SessionLifecycleSignal) => {
+      trackBackgroundTasks(signal);
+      try {
+        const consumerResult = options.onLifecycleSignal?.(signal);
+        if (consumerResult && typeof consumerResult.catch === "function") {
+          void consumerResult.catch(() => {
+            // Swallow — a consumer sink must not break the message loop.
+          });
+        }
+      } catch {
+        // Swallow — a consumer sink must not break the message loop.
       }
     };
     sdkOptions.hooks = {

--- a/packages/core/src/runner/types.ts
+++ b/packages/core/src/runner/types.ts
@@ -110,6 +110,18 @@ export interface RunnerOptionsWithCallbacks extends RunnerOptions {
   onMessage?: MessageCallback;
   /** Called when the job is created, before execution starts */
   onJobCreated?: JobCreatedCallback;
+  /**
+   * Observe the run's session-lifecycle signals (turn boundaries,
+   * background-task changes). Threaded straight through to
+   * `RuntimeExecuteOptions.onLifecycleSignal` — see that type's doc. Wired by
+   * `JobControl.trigger`/`ScheduleExecutor` via
+   * `SessionLifecycleManager.trackJob` so a job's `ScheduleWakeup`/session
+   * cron is captured into the fleet's wake registry instead of being silently
+   * dropped when the job completes (vulpes-pack#148).
+   */
+  onLifecycleSignal?: (
+    signal: import("../session/types.js").SessionLifecycleSignal,
+  ) => void | Promise<void>;
 }
 
 // =============================================================================

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -93,6 +93,51 @@ describe("buildLifecycleHooks", () => {
     expect(signal.backgroundTasks).toEqual([]);
   });
 
+  it("marks hasSnapshot false when the CLI omits the background_tasks envelope entirely", async () => {
+    // The CLI's Stop-hook payload builder wraps background_tasks/
+    // session_crons in one conditional envelope and can omit the key
+    // outright — distinct from the field being present with value
+    // `undefined` (the previous test). See #459 follow-up.
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    const inputWithoutEnvelope = {
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+      // no background_tasks / session_crons keys at all
+    } as unknown as HookInput;
+
+    await cb(inputWithoutEnvelope, undefined, { signal: new AbortController().signal });
+
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.hasSnapshot).toBe(false);
+    expect(signal.backgroundTasks).toEqual([]);
+    expect(signal.sessionCrons).toEqual([]);
+  });
+
+  it("marks hasSnapshot true (via a present key) even when the value is explicitly undefined", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    await cb(stopInput({ session_crons: undefined, background_tasks: undefined }), undefined, {
+      signal: new AbortController().signal,
+    });
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.hasSnapshot).toBe(true);
+  });
+
+  it("marks hasSnapshot true on a normal turn_end carrying a real snapshot", async () => {
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    await cb(stopInput(), undefined, { signal: new AbortController().signal });
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.hasSnapshot).toBe(true);
+  });
+
   it("does nothing for non-stop hook inputs", async () => {
     const sink = vi.fn();
     const hooks = buildLifecycleHooks(sink);

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -138,6 +138,34 @@ describe("buildLifecycleHooks", () => {
     expect(signal.hasSnapshot).toBe(true);
   });
 
+  it("marks hasSnapshot false and ignores the snapshot when background_tasks is present but malformed", async () => {
+    // `?? []` only normalizes nullish — a non-array/invalid SDK payload must
+    // not sneak through as SessionCronSummary[]/BackgroundTaskSummary[].
+    // Field present + invalid shape is treated like field absent: logged and
+    // dropped, not crashed on.
+    const sink = vi.fn();
+    const hooks = buildLifecycleHooks(sink);
+    const cb = hooks!.Stop![0].hooks[0];
+    const malformedInput = {
+      hook_event_name: "Stop",
+      session_id: "sess-1",
+      transcript_path: "/tmp/t.jsonl",
+      cwd: "/tmp",
+      stop_hook_active: false,
+      background_tasks: "not-an-array",
+      session_crons: [{ id: "c1", schedule: "35 13 * * *", recurring: false, prompt: "go" }],
+    } as unknown as HookInput;
+
+    await expect(
+      cb(malformedInput, undefined, { signal: new AbortController().signal }),
+    ).resolves.toEqual({ continue: true });
+
+    const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
+    expect(signal.hasSnapshot).toBe(false);
+    expect(signal.backgroundTasks).toEqual([]);
+    expect(signal.sessionCrons).toEqual([]);
+  });
+
   it("does nothing for non-stop hook inputs", async () => {
     const sink = vi.fn();
     const hooks = buildLifecycleHooks(sink);

--- a/packages/core/src/session/__tests__/session-hooks.test.ts
+++ b/packages/core/src/session/__tests__/session-hooks.test.ts
@@ -118,7 +118,12 @@ describe("buildLifecycleHooks", () => {
     expect(signal.sessionCrons).toEqual([]);
   });
 
-  it("marks hasSnapshot true (via a present key) even when the value is explicitly undefined", async () => {
+  it("marks hasSnapshot false when the key is present but explicitly undefined", async () => {
+    // Array.isArray(undefined) is false, so a present-but-undefined key reads
+    // the same as an absent key — the stricter of the two readings. `in`
+    // would have called this "present" (true even for
+    // `{ background_tasks: undefined }`), reintroducing the old `?? []`
+    // clobber for this shape.
     const sink = vi.fn();
     const hooks = buildLifecycleHooks(sink);
     const cb = hooks!.Stop![0].hooks[0];
@@ -126,7 +131,9 @@ describe("buildLifecycleHooks", () => {
       signal: new AbortController().signal,
     });
     const signal = sink.mock.calls[0][0] as SessionLifecycleSignal;
-    expect(signal.hasSnapshot).toBe(true);
+    expect(signal.hasSnapshot).toBe(false);
+    expect(signal.sessionCrons).toEqual([]);
+    expect(signal.backgroundTasks).toEqual([]);
   });
 
   it("marks hasSnapshot true on a normal turn_end carrying a real snapshot", async () => {

--- a/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
+++ b/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
@@ -436,6 +436,60 @@ describe("SessionLifecycleManager.trackJob (vulpes-pack#148)", () => {
     expect((await slm2.dispatchDue(NOW)).map((e) => e.id)).toEqual(["w-after-release"]);
   });
 
+  it("keeps a session live until every concurrent job tracking it has released (refcount)", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([
+      dueWake({ id: "w-refcount", sessionId: "sess-shared" }),
+    ]);
+    const openChatSession = vi.fn().mockResolvedValue(fakeSession());
+    const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
+
+    // Two jobs concurrently resume the same session id (e.g. `dispatchDue`
+    // firing a wake for it while a second job is already mid-flight against
+    // it — see edspencer/herdctl#460).
+    const trackerA = slm.trackJob("team/agent", "sess-shared");
+    const trackerB = slm.trackJob("team/agent", "sess-shared");
+
+    trackerA.release();
+    // A `Set`-based live mark would have unpinned the session right here —
+    // trackerB is still running against it.
+    expect(await slm.dispatchDue(NOW)).toEqual([]);
+    expect(openChatSession).not.toHaveBeenCalled();
+
+    trackerB.release();
+    const dispatched = await slm.dispatchDue(NOW);
+    expect(dispatched.map((e) => e.id)).toEqual(["w-refcount"]);
+  });
+
+  it("a lifecycle signal that arrives after release() does not re-pin the session live or persist a wake", async () => {
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession: vi.fn().mockResolvedValue(fakeSession()),
+      resolveNextRun,
+    });
+    const tracker = slm.trackJob("team/agent"); // fresh job, learns its id off the first signal
+    tracker.release(); // the job's own turn already completed before any signal arrived
+
+    // A straggler signal (e.g. a deferred `emit()` microtask from a Stop hook
+    // firing right as the job finished) must be a full no-op: it must neither
+    // persist the wake it carries nor re-pin the session live — otherwise
+    // nothing left holding this tracker will ever release it, and every
+    // future dispatch for that session id silently stops firing.
+    await tracker.onLifecycleSignal(
+      turnEndSignal({
+        sessionId: "sess-straggler",
+        sessionCrons: [{ id: "c-straggler", schedule: "+60s", recurring: false, prompt: "WAKE" }],
+      }),
+    );
+    expect(await new FleetStateWakePersistence({ stateDir }).load()).toEqual([]);
+
+    // A wake for that same session id, seeded independently, must still fire
+    // normally — the straggler must not have pinned it live.
+    await new FleetStateWakePersistence({ stateDir }).save([
+      dueWake({ id: "w-straggler", sessionId: "sess-straggler" }),
+    ]);
+    expect((await slm.dispatchDue(NOW)).map((e) => e.id)).toEqual(["w-straggler"]);
+  });
+
   it("a rejecting registry.reconcile never propagates out of onLifecycleSignal", async () => {
     const slm = new SessionLifecycleManager({
       stateDir,

--- a/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
+++ b/packages/core/src/session/__tests__/session-lifecycle-manager.test.ts
@@ -12,6 +12,16 @@ import {
 } from "../session-lifecycle-manager.js";
 import type { SessionLifecycleSignal, SessionWakeEntry } from "../types.js";
 
+function turnEndSignal(overrides: Partial<SessionLifecycleSignal> = {}): SessionLifecycleSignal {
+  return {
+    kind: "turn_end",
+    sessionId: "sess-job-1",
+    sessionCrons: [],
+    backgroundTasks: [],
+    ...overrides,
+  };
+}
+
 const NOW = new Date("2026-07-09T12:00:00.000Z");
 const resolveNextRun = (_s: string, from: Date) => new Date(from.getTime() + 5 * 60_000);
 
@@ -222,6 +232,226 @@ describe("SessionLifecycleManager", () => {
     const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
     expect(await slm.dispatchDue(NOW)).toEqual([]);
     expect(openChatSession).not.toHaveBeenCalled();
+  });
+});
+
+// vulpes-pack#148 — wiring session wakes into the job path. Before this,
+// RuntimeExecuteOptions.onLifecycleSignal was documented "ignored" by
+// execute() and neither job call site fed it anywhere: a job that called
+// ScheduleWakeup completed and its wake evaporated. `trackJob` is the
+// capture-only sink that closes that gap without a second reaper.
+describe("SessionLifecycleManager.trackJob (vulpes-pack#148)", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(join(tmpdir(), "herdctl-slm-trackjob-"));
+  });
+
+  afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("persists a wake from an authoritative turn_end, keyed to the qualified agent name", async () => {
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession: vi.fn(),
+      resolveNextRun,
+    });
+    const tracker = slm.trackJob("team/agent");
+
+    await tracker.onLifecycleSignal(
+      turnEndSignal({
+        sessionCrons: [{ id: "c1", schedule: "+60s", recurring: false, prompt: "WAKE" }],
+      }),
+    );
+
+    const persisted = await new FleetStateWakePersistence({ stateDir }).load();
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({
+      id: "c1",
+      agent: "team/agent",
+      sessionId: "sess-job-1",
+      prompt: "WAKE",
+    });
+  });
+
+  // The test that matters most: pins the #459 hasSnapshot semantics on the job
+  // path too. A turn_end fired without the CLI's background_tasks/session_crons
+  // envelope must NOT reconcile — reading its empty arrays as authoritative
+  // would silently delete a wake a PRIOR turn in the same job already captured.
+  it("does not reconcile a turn_end with hasSnapshot: false — a captured wake survives", async () => {
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession: vi.fn(),
+      resolveNextRun,
+    });
+    const tracker = slm.trackJob("team/agent");
+
+    await tracker.onLifecycleSignal(
+      turnEndSignal({
+        sessionCrons: [{ id: "c1", schedule: "+60s", recurring: false, prompt: "WAKE" }],
+      }),
+    );
+    // A later turn_end in the same job fires without the envelope at all.
+    await tracker.onLifecycleSignal(turnEndSignal({ sessionCrons: [], hasSnapshot: false }));
+
+    const persisted = await new FleetStateWakePersistence({ stateDir }).load();
+    expect(persisted.map((w) => w.id)).toEqual(["c1"]);
+  });
+
+  // Counter-check: an authoritative empty report (hasSnapshot undefined/true)
+  // DOES reconcile — a retired one-shot is dropped as normal.
+  it("reconciles an authoritative empty turn_end — a retired wake is dropped", async () => {
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession: vi.fn(),
+      resolveNextRun,
+    });
+    const tracker = slm.trackJob("team/agent");
+
+    await tracker.onLifecycleSignal(
+      turnEndSignal({
+        sessionCrons: [{ id: "c1", schedule: "+60s", recurring: false, prompt: "WAKE" }],
+      }),
+    );
+    await tracker.onLifecycleSignal(turnEndSignal({ sessionCrons: [] }));
+
+    const persisted = await new FleetStateWakePersistence({ stateDir }).load();
+    expect(persisted).toEqual([]);
+  });
+
+  it("removes a wake on a cron_deleted signal", async () => {
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession: vi.fn(),
+      resolveNextRun,
+    });
+    const tracker = slm.trackJob("team/agent");
+
+    await tracker.onLifecycleSignal(
+      turnEndSignal({
+        sessionCrons: [{ id: "c1", schedule: "+60s", recurring: false, prompt: "WAKE" }],
+      }),
+    );
+    await tracker.onLifecycleSignal({
+      kind: "cron_deleted",
+      sessionId: "sess-job-1",
+      sessionCrons: [],
+      backgroundTasks: [],
+      deletedCronIds: ["c1"],
+    });
+
+    const persisted = await new FleetStateWakePersistence({ stateDir }).load();
+    expect(persisted).toEqual([]);
+  });
+
+  it("ignores activity and background_tasks_changed signals (no registry write)", async () => {
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession: vi.fn(),
+      resolveNextRun,
+    });
+    const reconcileSpy = vi.spyOn(slm.registry, "reconcile");
+    const tracker = slm.trackJob("team/agent");
+
+    await tracker.onLifecycleSignal({
+      kind: "activity",
+      sessionId: "sess-job-1",
+      sessionCrons: [],
+      backgroundTasks: [],
+    });
+    await tracker.onLifecycleSignal({
+      kind: "background_tasks_changed",
+      sessionId: "sess-job-1",
+      sessionCrons: [],
+      backgroundTasks: [{ id: "t1", type: "shell", status: "running", description: "server" }],
+    });
+
+    expect(reconcileSpy).not.toHaveBeenCalled();
+    expect(await new FleetStateWakePersistence({ stateDir }).load()).toEqual([]);
+  });
+
+  it("marks a resumed job's session live: dispatchDue skips it, then fires it after release()", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([
+      dueWake({ id: "w-live", sessionId: "sess-job-1" }),
+    ]);
+    const openChatSession = vi.fn().mockResolvedValue(fakeSession());
+    const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
+
+    const tracker = slm.trackJob("team/agent", "sess-job-1");
+    expect(await slm.dispatchDue(NOW)).toEqual([]);
+    expect(openChatSession).not.toHaveBeenCalled();
+
+    tracker.release();
+    const dispatched = await slm.dispatchDue(NOW);
+    expect(dispatched.map((e) => e.id)).toEqual(["w-live"]);
+  });
+
+  it("marks a fresh job's session live off the first signal's sessionId", async () => {
+    await new FleetStateWakePersistence({ stateDir }).save([
+      dueWake({ id: "w-fresh", sessionId: "sess-new" }),
+    ]);
+    const openChatSession = vi.fn().mockResolvedValue(fakeSession());
+    const slm = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
+
+    // No resume target — trackJob doesn't know the session id yet, but a due
+    // wake for a session it hasn't heard of must still fire normally.
+    const tracker = slm.trackJob("team/agent");
+    expect((await slm.dispatchDue(NOW)).map((e) => e.id)).toEqual(["w-fresh"]);
+
+    // Re-seed the same wake (dispatchDue above consumed the one-shot) and have
+    // the job's first signal arrive for "sess-new" — it should now be live.
+    await new FleetStateWakePersistence({ stateDir }).save([
+      dueWake({ id: "w-fresh-2", sessionId: "sess-new" }),
+    ]);
+    await tracker.onLifecycleSignal({
+      kind: "activity",
+      sessionId: "sess-new",
+      sessionCrons: [],
+      backgroundTasks: [],
+    });
+    expect(await slm.dispatchDue(NOW)).toEqual([]);
+    expect(openChatSession).toHaveBeenCalledTimes(1); // unchanged since the first dispatchDue above
+
+    tracker.release();
+    expect((await slm.dispatchDue(NOW)).map((e) => e.id)).toEqual(["w-fresh-2"]);
+  });
+
+  it("release() is idempotent and safe to call without any signal ever arriving", async () => {
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession: vi.fn(),
+      resolveNextRun,
+    });
+    const tracker = slm.trackJob("team/agent", "sess-job-1");
+    tracker.release();
+    expect(() => tracker.release()).not.toThrow();
+
+    // The live mark is gone — a due wake for that session now fires normally.
+    await new FleetStateWakePersistence({ stateDir }).save([
+      dueWake({ id: "w-after-release", sessionId: "sess-job-1" }),
+    ]);
+    const openChatSession = vi.fn().mockResolvedValue(fakeSession());
+    const slm2 = new SessionLifecycleManager({ stateDir, openChatSession, resolveNextRun });
+    expect((await slm2.dispatchDue(NOW)).map((e) => e.id)).toEqual(["w-after-release"]);
+  });
+
+  it("a rejecting registry.reconcile never propagates out of onLifecycleSignal", async () => {
+    const slm = new SessionLifecycleManager({
+      stateDir,
+      openChatSession: vi.fn(),
+      resolveNextRun,
+    });
+    vi.spyOn(slm.registry, "reconcile").mockRejectedValue(new Error("state io error"));
+    const tracker = slm.trackJob("team/agent");
+
+    await expect(
+      tracker.onLifecycleSignal(
+        turnEndSignal({
+          sessionCrons: [{ id: "c1", schedule: "+60s", recurring: false, prompt: "WAKE" }],
+        }),
+      ),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -460,7 +460,7 @@ describe("SessionReaper", () => {
   });
 
   it("still reaps a genuinely idle session on a turn_end that authoritatively reports empty background_tasks", async () => {
-    // Gegenprobe: a real empty snapshot (field present, genuinely empty) must
+    // Counter-check: a real empty snapshot (field present, genuinely empty) must
     // still reap as before — only an omitted field is a non-snapshot.
     const registry = fakeRegistry();
     const onReap = vi.fn();

--- a/packages/core/src/session/__tests__/session-reaper.test.ts
+++ b/packages/core/src/session/__tests__/session-reaper.test.ts
@@ -436,6 +436,44 @@ describe("SessionReaper", () => {
     expect(session.close).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a background-task session alive on a turn_end without a background_tasks snapshot (#459 follow-up)", async () => {
+    // The CLI's Stop-hook payload builder can omit background_tasks/
+    // session_crons entirely for a turn_end, independent of the SDK's own
+    // per-field optionality — session-hooks.ts then reports hasSnapshot:
+    // false. Reading its empty backgroundTasks as authoritative would reap a
+    // session with real live background work. See job-2026-08-26-6opnmq.
+    const registry = fakeRegistry();
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry, onReap });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ backgroundTasks: [TASK] })); // turn_end → keepAlive
+    await managed.handleSignal(
+      signal({ backgroundTasks: [], hasSnapshot: false }), // no-snapshot turn_end
+    );
+
+    expect(managed.isLive()).toBe(true);
+    expect(onReap).not.toHaveBeenCalled();
+    expect(registry.reconcile).toHaveBeenCalledTimes(1); // not called for the no-snapshot signal
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("still reaps a genuinely idle session on a turn_end that authoritatively reports empty background_tasks", async () => {
+    // Gegenprobe: a real empty snapshot (field present, genuinely empty) must
+    // still reap as before — only an omitted field is a non-snapshot.
+    const registry = fakeRegistry();
+    const onReap = vi.fn();
+    const reaper = new SessionReaper({ registry, onReap });
+    const session = fakeSession();
+    const managed = reaper.manage(session, "team/agent");
+
+    await managed.handleSignal(signal({ backgroundTasks: [] }));
+
+    expect(managed.isLive()).toBe(false);
+    expect(onReap).toHaveBeenCalledWith({ agent: "team/agent", sessionId: "sess-1" });
+  });
+
   // A resume that may replay a stale async-input backlog runs the replayed backlog
   // as its OWN turn ahead of the caller's queued prompt turn. Reaping on the
   // backlog turn's turn_end would close the session out from under the queued turn

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -95,11 +95,24 @@ function deletedCronId(input: PostToolUseHookInput): string | null {
 export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"] {
   const stopCallback = async (input: HookInput) => {
     if (isMainAgentStop(input)) {
+      // The CLI builds `background_tasks`/`session_crons` as one conditional
+      // envelope and can omit BOTH fields for a given Stop, independent of the
+      // SDK's own per-field `?`-optionality. Detect via `in` — not `??` on the
+      // value — so "key absent" (no snapshot reported) isn't conflated with
+      // "key present, empty array" (authoritative: nothing pending). See
+      // {@link SessionLifecycleSignal.hasSnapshot}.
+      const hasSnapshot = "background_tasks" in input;
       const sessionCrons: SessionCronSummary[] = input.session_crons ?? [];
       const backgroundTasks: BackgroundTaskSummary[] = input.background_tasks ?? [];
       // Never let a sink failure reject the hook (which would disrupt turn flow);
       // log and continue. `emit` observes the async rejection off the hot path.
-      emit(sink, { kind: "turn_end", sessionId: input.session_id, sessionCrons, backgroundTasks });
+      emit(sink, {
+        kind: "turn_end",
+        sessionId: input.session_id,
+        sessionCrons,
+        backgroundTasks,
+        hasSnapshot,
+      });
     }
     return { continue: true };
   };

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -20,11 +20,28 @@ import type {
   SessionCronSummary,
   StopHookInput,
 } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 import type { SDKMessage } from "../runner/types.js";
 import { createLogger } from "../utils/logger.js";
 import type { SessionLifecycleSignal } from "./types.js";
 
 const logger = createLogger("session-hooks");
+
+// Loose shape checks for the Stop hook's `background_tasks`/`session_crons`
+// snapshot — an external SDK payload, so validated rather than trusted
+// outright. Only the fields herdctl actually reads are required;
+// `.passthrough()` keeps the rest (e.g. `command`, `agent_type`) intact for
+// downstream consumers instead of stripping them.
+const backgroundTaskSummarySchema = z
+  .object({ id: z.string(), type: z.string(), status: z.string(), description: z.string() })
+  .passthrough();
+const sessionCronSummarySchema = z
+  .object({ id: z.string(), schedule: z.string(), recurring: z.boolean(), prompt: z.string() })
+  .passthrough();
+const stopSnapshotSchema = z.object({
+  background_tasks: z.array(backgroundTaskSummarySchema).optional(),
+  session_crons: z.array(sessionCronSummarySchema).optional(),
+});
 
 /** Receiver for lifecycle signals (the session-reaper's `handleSignal`). */
 export type LifecycleSignalSink = (signal: SessionLifecycleSignal) => void | Promise<void>;
@@ -101,9 +118,23 @@ export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"]
       // value — so "key absent" (no snapshot reported) isn't conflated with
       // "key present, empty array" (authoritative: nothing pending). See
       // {@link SessionLifecycleSignal.hasSnapshot}.
-      const hasSnapshot = "background_tasks" in input;
-      const sessionCrons: SessionCronSummary[] = input.session_crons ?? [];
-      const backgroundTasks: BackgroundTaskSummary[] = input.background_tasks ?? [];
+      const fieldPresent = "background_tasks" in input;
+      // `?? []` only normalizes nullish — it can't catch a non-array or
+      // malformed SDK payload sneaking through as SessionCronSummary[]/
+      // BackgroundTaskSummary[] (the reaper would then reconcile/decide off
+      // invalid state). Validate the shape too; an invalid payload is logged
+      // and treated the same as an absent field (hasSnapshot: false).
+      const parsed = stopSnapshotSchema.safeParse(input);
+      const hasSnapshot = fieldPresent && parsed.success;
+      if (fieldPresent && !parsed.success) {
+        logger.warn(
+          `Stop hook for session ${input.session_id} carried a malformed background_tasks/session_crons snapshot; ignoring it: ${parsed.error.message}`,
+        );
+      }
+      const sessionCrons: SessionCronSummary[] =
+        (parsed.success ? parsed.data.session_crons : undefined) ?? [];
+      const backgroundTasks: BackgroundTaskSummary[] =
+        (parsed.success ? parsed.data.background_tasks : undefined) ?? [];
       // Never let a sink failure reject the hook (which would disrupt turn flow);
       // log and continue. `emit` observes the async rejection off the hot path.
       emit(sink, {

--- a/packages/core/src/session/session-hooks.ts
+++ b/packages/core/src/session/session-hooks.ts
@@ -114,11 +114,12 @@ export function buildLifecycleHooks(sink: LifecycleSignalSink): Options["hooks"]
     if (isMainAgentStop(input)) {
       // The CLI builds `background_tasks`/`session_crons` as one conditional
       // envelope and can omit BOTH fields for a given Stop, independent of the
-      // SDK's own per-field `?`-optionality. Detect via `in` — not `??` on the
-      // value — so "key absent" (no snapshot reported) isn't conflated with
-      // "key present, empty array" (authoritative: nothing pending). See
+      // SDK's own per-field `?`-optionality. Detect via `Array.isArray` — not
+      // `in` (true even for `{ background_tasks: undefined }`, reintroducing
+      // the old `?? []` clobber) and not `??` on the value — so "no snapshot
+      // reported" isn't conflated with "authoritative empty snapshot". See
       // {@link SessionLifecycleSignal.hasSnapshot}.
-      const fieldPresent = "background_tasks" in input;
+      const fieldPresent = Array.isArray(input.background_tasks);
       // `?? []` only normalizes nullish — it can't catch a non-array or
       // malformed SDK payload sneaking through as SessionCronSummary[]/
       // BackgroundTaskSummary[] (the reaper would then reconcile/decide off

--- a/packages/core/src/session/session-lifecycle-manager.ts
+++ b/packages/core/src/session/session-lifecycle-manager.ts
@@ -15,8 +15,8 @@ import { calculateNextCronTrigger } from "../scheduler/cron.js";
 import { createLogger } from "../utils/logger.js";
 import { FleetStateWakePersistence } from "./fleet-state-wake-persistence.js";
 import { type ManagedSession, type ManageSessionOptions, SessionReaper } from "./session-reaper.js";
-import type { BackgroundTaskSummary, SessionWakeEntry } from "./types.js";
-import { WakeRegistry } from "./wake-registry.js";
+import type { BackgroundTaskSummary, SessionLifecycleSignal, SessionWakeEntry } from "./types.js";
+import { applyWakeSignal, WakeRegistry } from "./wake-registry.js";
 import type { NextRunResolver } from "./wake-store.js";
 
 type Logger = ReturnType<typeof createLogger>;
@@ -64,6 +64,30 @@ export type SessionWakeHandler = (
   session: RuntimeSession,
   entry: SessionWakeEntry,
 ) => void | Promise<void>;
+
+/**
+ * Per-job handle returned by {@link SessionLifecycleManager.trackJob}.
+ *
+ * Feeds a job's turn-boundary signals into wake capture (so a `ScheduleWakeup`/
+ * session cron registered mid-job survives the job's own completion instead of
+ * being silently dropped, vulpes-pack#148) and marks the job's session id
+ * "live" for its duration so a due wake for that same session can't cold-resume
+ * it out from under the running job. Unlike {@link ManagedSession}, this owns no
+ * `RuntimeSession` and never closes anything — `decideReap`'s
+ * keep-alive-while-background-tasks half is already handled inline by
+ * `SDKRuntime.execute()`'s own bg-wait (#458/#459); a job simply completes when
+ * its turn ends, and any wake it captured fires later as its own
+ * reaper-managed resumed session.
+ */
+export interface JobLifecycleTracker {
+  /**
+   * Pass to `RuntimeExecuteOptions.onLifecycleSignal`. Never throws/rejects —
+   * a wake-capture failure must not surface into the job's execution loop.
+   */
+  onLifecycleSignal: (signal: SessionLifecycleSignal) => Promise<void>;
+  /** Release the job's live-session mark. Idempotent; call from the job's `finally`. */
+  release: () => void;
+}
 
 export interface SessionLifecycleManagerOptions {
   /** State directory (`.herdctl`) backing the durable wake set. */
@@ -127,6 +151,13 @@ export class SessionLifecycleManager {
   private readonly logger: Logger;
   private sessionWakeHandler?: SessionWakeHandler;
   private resolveInjectedMcpServers?: ResolveInjectedMcpServers;
+  /**
+   * Session ids a `trackJob` job is currently running against, marked live for
+   * exactly the job's duration (see {@link JobLifecycleTracker}). Consulted by
+   * the registry's `isSessionLive` alongside the reaper's own live set so a due
+   * wake never cold-resumes a session a job already has open.
+   */
+  private readonly jobSessions = new Set<string>();
 
   constructor(options: SessionLifecycleManagerOptions) {
     this.openChatSession = options.openChatSession;
@@ -140,7 +171,7 @@ export class SessionLifecycleManager {
       persistence: new FleetStateWakePersistence({ stateDir: options.stateDir }),
       resolveNextRun: options.resolveNextRun ?? defaultResolveNextRun,
       fire: (entry) => this.fire(entry),
-      isSessionLive: (id) => this.reaper.isSessionLive(id),
+      isSessionLive: (id) => this.reaper.isSessionLive(id) || this.jobSessions.has(id),
       concurrency: options.concurrency,
       logger: this.logger,
     });
@@ -155,6 +186,44 @@ export class SessionLifecycleManager {
   /** Begin managing a freshly-opened streaming session's lifecycle. */
   manage(session: RuntimeSession, agent: string, options?: ManageSessionOptions): ManagedSession {
     return this.reaper.manage(session, agent, options);
+  }
+
+  /**
+   * Track a running job for wake capture: see {@link JobLifecycleTracker}.
+   *
+   * `resumeSessionId` marks the session live immediately for a job resuming an
+   * existing session; a fresh job (no resume target) learns and marks its
+   * session id off the first signal instead — every {@link
+   * SessionLifecycleSignal} carries a resolved `sessionId`, resumed or not.
+   */
+  trackJob(agent: string, resumeSessionId?: string): JobLifecycleTracker {
+    let trackedId = resumeSessionId;
+    if (trackedId) this.jobSessions.add(trackedId);
+    let released = false;
+
+    const onLifecycleSignal = async (signal: SessionLifecycleSignal): Promise<void> => {
+      if (!trackedId) {
+        trackedId = signal.sessionId;
+        this.jobSessions.add(trackedId);
+      }
+      try {
+        await applyWakeSignal(this.registry, agent, signal, this.logger);
+      } catch (error) {
+        // applyWakeSignal already logs+swallows internally; last-resort guard
+        // so nothing here can ever propagate into the job's execution loop.
+        this.logger.warn(
+          `trackJob onLifecycleSignal threw for ${agent} (${signal.sessionId}): ${(error as Error).message}`,
+        );
+      }
+    };
+
+    const release = (): void => {
+      if (released) return;
+      released = true;
+      if (trackedId) this.jobSessions.delete(trackedId);
+    };
+
+    return { onLifecycleSignal, release };
   }
 
   /** Fire every wake now due. Wire as the scheduler's `onTick`. */

--- a/packages/core/src/session/session-lifecycle-manager.ts
+++ b/packages/core/src/session/session-lifecycle-manager.ts
@@ -152,12 +152,34 @@ export class SessionLifecycleManager {
   private sessionWakeHandler?: SessionWakeHandler;
   private resolveInjectedMcpServers?: ResolveInjectedMcpServers;
   /**
-   * Session ids a `trackJob` job is currently running against, marked live for
-   * exactly the job's duration (see {@link JobLifecycleTracker}). Consulted by
-   * the registry's `isSessionLive` alongside the reaper's own live set so a due
-   * wake never cold-resumes a session a job already has open.
+   * Refcount of `trackJob` jobs currently running against each session id,
+   * marked live for exactly the job's duration (see {@link
+   * JobLifecycleTracker}). Consulted by the registry's `isSessionLive`
+   * alongside the reaper's own live set so a due wake never cold-resumes a
+   * session a job already has open.
+   *
+   * A `Map<string, number>` refcount rather than a `Set<string>`: two jobs can
+   * legitimately run against the same session id concurrently (e.g. a resumed
+   * job overlapping a fresh job that hasn't learned its session id yet), and a
+   * `Set`'s unconditional delete-on-release let the first job to finish clear
+   * the live mark out from under the second, still-running one — `dispatchDue`
+   * would then see the session as not-live and `openSession` would cold-resume
+   * it while the second job still held it open.
    */
-  private readonly jobSessions = new Set<string>();
+  private readonly jobSessions = new Map<string, number>();
+
+  /** Increment a session id's job refcount. */
+  private retainJobSession(id: string): void {
+    this.jobSessions.set(id, (this.jobSessions.get(id) ?? 0) + 1);
+  }
+
+  /** Decrement a session id's job refcount, clearing the entry at zero. */
+  private releaseJobSession(id: string): void {
+    const count = this.jobSessions.get(id);
+    if (count === undefined) return;
+    if (count <= 1) this.jobSessions.delete(id);
+    else this.jobSessions.set(id, count - 1);
+  }
 
   constructor(options: SessionLifecycleManagerOptions) {
     this.openChatSession = options.openChatSession;
@@ -198,13 +220,18 @@ export class SessionLifecycleManager {
    */
   trackJob(agent: string, resumeSessionId?: string): JobLifecycleTracker {
     let trackedId = resumeSessionId;
-    if (trackedId) this.jobSessions.add(trackedId);
+    if (trackedId) this.retainJobSession(trackedId);
     let released = false;
 
     const onLifecycleSignal = async (signal: SessionLifecycleSignal): Promise<void> => {
+      // A signal that arrives after `release()` (a straggler from a job whose
+      // own turn already completed) must not re-pin the session live —
+      // otherwise it silently blocks every future wake for that session id
+      // forever, since nothing left in this tracker will ever release it.
+      if (released) return;
       if (!trackedId) {
         trackedId = signal.sessionId;
-        this.jobSessions.add(trackedId);
+        this.retainJobSession(trackedId);
       }
       try {
         await applyWakeSignal(this.registry, agent, signal, this.logger);
@@ -220,7 +247,7 @@ export class SessionLifecycleManager {
     const release = (): void => {
       if (released) return;
       released = true;
-      if (trackedId) this.jobSessions.delete(trackedId);
+      if (trackedId) this.releaseJobSession(trackedId);
     };
 
     return { onLifecycleSignal, release };

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -22,7 +22,7 @@ import type { RuntimeSession } from "../runner/runtime/interface.js";
 import { createLogger } from "../utils/logger.js";
 import { decideReap } from "./reaper-policy.js";
 import type { BackgroundTaskSummary, SessionLifecycleSignal } from "./types.js";
-import type { WakeRegistry } from "./wake-registry.js";
+import { applyWakeSignal, type WakeRegistry } from "./wake-registry.js";
 
 type Logger = ReturnType<typeof createLogger>;
 
@@ -275,15 +275,7 @@ export class SessionReaper {
     // delete) and so deliberately keeps recurring wakes (#409). Firing continues
     // regardless of the surrounding reap decision, so handle it and return.
     if (signal.kind === "cron_deleted") {
-      for (const id of signal.deletedCronIds ?? []) {
-        try {
-          await this.registry.remove(id);
-        } catch (error) {
-          this.logger.warn(
-            `Failed to retire wake ${id} after CronDelete in session ${signal.sessionId} (${managed.agent}): ${(error as Error).message}`,
-          );
-        }
-      }
+      await applyWakeSignal(this.registry, managed.agent, signal, this.logger);
       return;
     }
 
@@ -328,14 +320,8 @@ export class SessionReaper {
     // Capture pending crons first so they survive whatever we decide next. A
     // reconcile I/O failure loses that turn's capture but must NOT block the reap
     // — leaving the session alive is the leak this module exists to prevent — so
-    // log and press on with the decision.
-    try {
-      await this.registry.reconcile(managed.agent, signal.sessionId, signal.sessionCrons);
-    } catch (error) {
-      this.logger.warn(
-        `Failed to reconcile wakes for session ${signal.sessionId} (${managed.agent}): ${(error as Error).message}`,
-      );
-    }
+    // applyWakeSignal logs and swallows it; press on with the decision.
+    await applyWakeSignal(this.registry, managed.agent, signal, this.logger);
 
     const decision = decideReap(signal);
     if (decision.action === "keepAlive") {

--- a/packages/core/src/session/session-reaper.ts
+++ b/packages/core/src/session/session-reaper.ts
@@ -311,6 +311,17 @@ export class SessionReaper {
       return;
     }
 
+    // The CLI's Stop-hook payload builder can omit the background_tasks/
+    // session_crons envelope entirely for a given turn_end (independent of the
+    // SDK's own per-field optionality) — `signal.hasSnapshot === false` then
+    // means the arrays below are just empty stand-ins, not an authoritative
+    // "nothing pending". Reading them as authoritative would reap a session
+    // with real live background work out from under it. Do nothing and keep
+    // whatever state this session already has; the next signal that does carry
+    // a snapshot (background_tasks_changed or a later turn_end) re-decides.
+    // See edspencer/herdctl#459 follow-up.
+    if (signal.hasSnapshot === false) return;
+
     // turn_end: the authoritative snapshot supersedes any pending grace reap.
     managed.cancelPendingReap();
 

--- a/packages/core/src/session/types.ts
+++ b/packages/core/src/session/types.ts
@@ -54,6 +54,20 @@ export interface SessionLifecycleSignal {
    * {@link WakeRegistry.remove} so a herdctl-owned recurring wake stops firing.
    */
   deletedCronIds?: string[];
+  /**
+   * `turn_end` only: `false` when the CLI's Stop-hook payload builder omitted
+   * the `background_tasks`/`session_crons` envelope entirely for this turn
+   * (it's built conditionally, independent of the SDK's own per-field
+   * `?`-optionality) — `sessionCrons`/`backgroundTasks` are then just `?? []`
+   * stand-ins, not an authoritative "nothing pending" snapshot. A consumer
+   * must keep its last-known state instead of reading the stand-in as "drained
+   * to empty" (that clobber killed a live background subagent by releasing
+   * `SDKRuntime.execute()`'s held terminal and let `SessionReaper` reap a
+   * session with real background work — see edspencer/herdctl#459 follow-up).
+   * Omitted (`undefined`) means "authoritative", matching every other kind,
+   * whose arrays are always authoritative per their own doc above.
+   */
+  hasSnapshot?: boolean;
 }
 
 /**

--- a/packages/core/src/session/wake-registry.ts
+++ b/packages/core/src/session/wake-registry.ts
@@ -13,7 +13,7 @@
  */
 
 import { createLogger } from "../utils/logger.js";
-import type { SessionCronSummary, SessionWakeEntry } from "./types.js";
+import type { SessionCronSummary, SessionLifecycleSignal, SessionWakeEntry } from "./types.js";
 
 /** The structural logger returned by {@link createLogger}. */
 type Logger = ReturnType<typeof createLogger>;
@@ -57,6 +57,49 @@ export interface WakeRegistryOptions {
   /** Recurring-wake lifetime; defaults to the 7-day harness parity. */
   maxAgeMs?: number;
   logger?: Logger;
+}
+
+/**
+ * Apply one turn-boundary lifecycle signal to a wake registry: reconcile an
+ * authoritative `turn_end`'s pending crons, or retire the wake(s) a
+ * `cron_deleted` named. `activity` and a non-authoritative `turn_end`
+ * (`hasSnapshot === false`) are no-ops — see {@link SessionLifecycleSignal}'s
+ * own doc for why an unreported snapshot must not be read as "nothing
+ * pending". `background_tasks_changed` never reports `sessionCrons` and is
+ * likewise a no-op here.
+ *
+ * Shared by {@link SessionReaper.processSignal} (streaming sessions) and
+ * {@link SessionLifecycleManager.trackJob} (the job path, vulpes-pack#148) so
+ * both funnel through one reconciliation rule instead of two parallel
+ * readings of the same signal. Errors are logged and swallowed — capture must
+ * never throw out of a caller's hot path.
+ */
+export async function applyWakeSignal(
+  registry: WakeRegistry,
+  agent: string,
+  signal: SessionLifecycleSignal,
+  logger?: Logger,
+): Promise<void> {
+  if (signal.kind === "cron_deleted") {
+    for (const id of signal.deletedCronIds ?? []) {
+      try {
+        await registry.remove(id);
+      } catch (error) {
+        logger?.warn(
+          `Failed to retire wake ${id} after CronDelete in session ${signal.sessionId} (${agent}): ${(error as Error).message}`,
+        );
+      }
+    }
+    return;
+  }
+  if (signal.kind !== "turn_end" || signal.hasSnapshot === false) return;
+  try {
+    await registry.reconcile(agent, signal.sessionId, signal.sessionCrons);
+  } catch (error) {
+    logger?.warn(
+      `Failed to reconcile wakes for session ${signal.sessionId} (${agent}): ${(error as Error).message}`,
+    );
+  }
 }
 
 const DEFAULT_CONCURRENCY = 4;


### PR DESCRIPTION
## Summary

Builds on #459 (which already fixed the `hasSnapshot` clobber in `SDKRuntime.execute()`'s bg-wait). This PR closes the other half of the gap #458 originally reported: a job that registers a session cron (`ScheduleWakeup`/`CronCreate`/`/loop`) has it silently dropped the instant the job's turn ends — there was no reaper duplication to fix, just a signal nobody was listening to.

**Correction to the #458 write-up while investigating:** `SessionReaper` *is* instantiated (`SessionLifecycleManager`, built by `FleetManager.createSessionLifecycle()`), and `job-executor.ts` contains no unconditional `closeSession()` — that half of #458 already reads correctly against current `main`/this branch. The real gap is narrower: `RuntimeExecuteOptions.onLifecycleSignal` was documented "ignored by `RuntimeInterface.execute`", and `SDKRuntime.execute()` only ever fed its own internal background-task tracker — the two job call sites (`JobControl.trigger`, `ScheduleExecutor.executeSchedule`) never wired anything into it at all.

## What changed

1. **`applyWakeSignal`** (`wake-registry.ts`) — the reconcile/retire rule `SessionReaper.processSignal` already applied, pulled out into a standalone function so a second consumer can reuse it instead of re-implementing a parallel reading of `SessionLifecycleSignal`. `session-reaper.ts` now calls it too (pure dedup, no behavior change — pinned by the existing reaper test suite).
2. **`SessionLifecycleManager.trackJob(agent, resumeSessionId?)`** — a capture-only handle for the job path. It is **not** a second reaper: it owns no `RuntimeSession` and never closes anything. `decideReap`'s keep-alive-while-background-tasks half is already handled inline by `SDKRuntime.execute()`'s own bg-wait (#458/#459); a job simply completes when its turn ends. `trackJob`'s `onLifecycleSignal` feeds `turn_end`/`cron_deleted` signals into `applyWakeSignal`, and marks the job's session id "live" in a new `jobSessions` set consulted by the wake registry's `isSessionLive` — so a due wake for that session can't cold-resume it out from under the still-running job.
3. **`SDKRuntime.execute()`** now actually reads `options.onLifecycleSignal`: composed *after* its own internal bg-wait tracker (unchanged anchor semantics), fire-and-forget, swallowing both a synchronous throw and a rejected promise so a misbehaving consumer can never break the message loop or release a held terminal early.
4. **`JobControl.trigger`** and **`ScheduleExecutor.executeSchedule`** — the two job call sites — now call `trackJob()` before executing and `release()` in the existing `finally`, threading the tracker's `onLifecycleSignal` down through `JobExecutor`.

**Net effect:** a job that calls `ScheduleWakeup` now has that wake persisted into the fleet's durable wake set (`session_wakes` in `.herdctl/state.yaml` — no schema changes needed, it already existed for streaming sessions) and re-fired later as a resumed session, instead of evaporating. The job itself still completes normally — see "Non-goals" below for why "stay running until the wake" was rejected.

## Non-goals (deliberately out of scope)

- **CLI and Docker runtimes.** Neither emits Stop-hook signals through `execute()`, so jobs under `runtime: cli` still drop session crons. Unchanged, and worth flagging if that's a live pain point.
- **No job record / usage accounting for wake-fired turns.** They still run as a headless drain in `SessionLifecycleManager.fire()` — no job id, no `job:created`/`job:output`, invisible in a dashboard. Pre-existing behavior for streaming-session wakes; jobs feeding the same registry just makes it more visible. See open question 2.
- **"Job stays running until the wake fires"** was considered and rejected: `max_concurrent` defaults to 1 so one sleeping job blocks every trigger for that agent; an in-memory hold dies silently on daemon restart where a persisted wake survives for free; `duration_seconds`/usage accounting would be garbage; and it contradicts `reaper-policy.ts`'s own documented policy that timer-class `sessionCrons` don't keep a session alive.
- **No `deferResumeUntilReaped` for `triggerJob`.** `openChatSession` has this guard (#403); a manual trigger racing a wake-fired resume of the same session id is a pre-existing gap, not introduced or fixed here.
- No change to `decideReap` itself, and no dashboard surface for pending wakes.

## Test plan

- `session-lifecycle-manager.test.ts` — `trackJob` persists a wake from an authoritative `turn_end`; does **not** reconcile on `hasSnapshot: false` (carries the #459 semantics onto the job path — the test that matters most, since a non-authoritative signal must not clobber a wake a prior turn in the same job already captured); does reconcile an authoritative empty snapshot; removes a wake on `cron_deleted`; ignores `activity`/`background_tasks_changed`; marks a resumed/fresh job's session live so `dispatchDue` skips its due wake until `release()`; never lets a rejecting registry propagate out of `onLifecycleSignal`.
- `sdk-runtime-bg-wait.test.ts` — a supplied `onLifecycleSignal` consumer receives all four signal kinds; sees byte-for-byte the same hold/`hasSnapshot` anchor behavior as without a consumer attached; survives a throwing or rejecting consumer without breaking the message loop; still holds correctly when a live background task and a session cron land on the same `turn_end`.
- `job-session-wake-capture.test.ts` (new) — end-to-end through a real `FleetManager` with a stubbed `RuntimeFactory.create()`: a job's `turn_end` wake is persisted and the job still completes normally; a resumed job's session is guarded from a concurrent wake fire until it finishes; a fleet with no `SessionLifecycleManager` degrades to today's behavior (no throw); the scheduled path (`ScheduleExecutor`) captures the same way as a manual trigger; a persisted wake survives being picked up by a freshly constructed manager over the same `stateDir` (daemon-restart survival).

All new tests independently verified red against the pre-change source (temporarily reverted the non-test commits, ran the suite, restored). `cd packages/core && npx vitest run --coverage=false` — 117 files / 3768 passed / 1 pre-existing skip (unrelated flaky webhook-hook test, passes in isolation). `npx tsc --noEmit` clean.

## Open questions for the maintainer

1. **Always-on or opt-in?** This makes SDK-runtime jobs capture session wakes unconditionally. Today the cron is silently lost, which is never what the agent asked for, and retirement paths (`CronDelete`, the 7-day recurring-wake prune) already exist — so I went unconditional. But it *is* a behavior change for every existing SDK job that calls `ScheduleWakeup`: herdctl will start re-firing crons that previously evaporated. Worth a config flag instead?
2. **Should a wake-fired turn produce a job record?** Today `fire()` drains headlessly — no job id, no events, no usage accounting, invisible in a dashboard. With jobs now feeding the wake registry this becomes the dominant source of wakes, so the gap gets more visible. I'd treat this as a separate, larger change (teaching `fire()` to route through the job machinery) rather than fold it in here.
3. **Stale wakes for a since-renamed/removed agent.** A persisted wake whose agent no longer resolves makes `fire()` throw on every tick. Pre-existing for chat-session wakes; jobs will make it more common. Should `dispatchDue` drop or quarantine unresolvable-agent wakes?
4. **Post-ceiling capture.** If the 10-minute `bgWaitCeilingMs` fires and `execute()` bails with a held terminal, the last authoritative `turn_end` was already captured and nothing further is attempted. Confirming that matches the intended behavior — the alternative (a synthetic final capture at teardown) would have no authoritative snapshot to draw from, so I didn't build it.


## Update: review fixes

**Fixed a real concurrency bug found via repro:** `jobSessions` was a `Set<string>`. Two jobs racing against the same session id (e.g. `dispatchDue` firing a wake for a session while a second `resume` job is already mid-flight against it) let the first job to finish `release()` its live mark out from under the second, still-running one — `openSession` could then cold-resume a session a job still had open. Fixed by making `jobSessions` a `Map<string, number>` refcount: `trackJob` increments on retain, `release()` decrements and only clears the live mark at zero. Covered by a new test in `session-lifecycle-manager.test.ts` ("keeps a session live until every concurrent job tracking it has released"), independently verified red against the pre-fix `Set` (reverted the source change, ran the suite, restored).

**Fixed a related staleness gap:** `release()` didn't fence a late `onLifecycleSignal` call. A straggler signal arriving after a job's tracker released (e.g. a deferred `emit()` microtask landing right as the job finishes) would re-add the session id to `jobSessions` — and since nothing is left holding that tracker, nothing would ever release it again, permanently blocking every future wake for that session id. `trackJob` now tracks a `released` flag and `onLifecycleSignal` is a full no-op once `release()` has run (skips both the live-mark and `applyWakeSignal`). Covered by a new test ("a lifecycle signal that arrives after release() does not re-pin the session live or persist a wake").

**Made the test stubs honest about ordering:** `job-session-wake-capture.test.ts` previously did `await options.onLifecycleSignal?.(...)` inline inside the stubbed runtime generator. Production never awaits this — `SDKRuntime.execute()` calls the consumer fire-and-forget (`void consumerResult.catch(...)`), and `session-hooks.ts`'s `emit()` defers delivery onto a `Promise.resolve().then()` microtask. The inline-await stub was pinning an ordering guarantee the real runtime doesn't provide. Replaced with an `emitLifecycleSignal()` helper that matches the deferred fire-and-forget shape, with explicit `flushMicrotasks()` calls at the points where an assertion needs the signal to have landed.

## Known limitations (documented, not fixed here)

- **Two call sites still aren't wired to `trackJob`:** `scheduler/schedule-runner.ts`'s `runScheduledAgent` (the `resume_session` path — a different/older scheduler entry point than `ScheduleExecutor`) and `packages/web`'s `web-chat-manager.ts` both call `JobExecutor.execute()` directly without a tracker, so a session cron registered on either of those paths is still silently dropped. The root seam to fix this properly would be `JobExecutor.execute()` itself (thread `onLifecycleSignal` through there once, rather than at each of the four call sites individually) — deferring that call to the maintainer since it reshapes `JobExecutor`'s contract.
- **`herdctl trigger`'s wait-mode `process.exit()` can race the fire-and-forget wake capture.** Since `onLifecycleSignal` delivery is deferred onto a microtask (not awaited anywhere in the chain), and `trigger.ts`'s wait-mode calls `process.exit(exitCode)` immediately after `streamJobOutput` drains, a hard exit landing before that microtask (and its downstream `applyWakeSignal` state write) resolves can lose the wake in the worst case. Pre-existing shape of the fire-and-forget contract this PR builds on, not introduced by this change — flagging it since jobs feeding the wake registry make it more likely to matter in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled and manually triggered jobs so session wake events are reliably captured and restored after restarts.
  * Prevented active resumed sessions from being incorrectly dispatched while still running.
  * Preserved existing wake and background-task state when lifecycle snapshots are missing or malformed.
  * Improved handling of background tasks so completed results wait for active work to finish, within a configurable limit.
  * Prevented lifecycle tracking errors from interrupting job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->