### PR TITLE
docs: update What's New page (2026-08-29)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 03b4ccc
-last_run: "2026-08-13T00:00:00Z"
-entries_added: 11
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "docs/whats-new-catchup-2026-08-13"]
+last_checked_commit: 9b1e34a
+last_run: "2026-08-29T17:34:00Z"
+entries_added: 2
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "docs/whats-new-catchup-2026-08-13", "changelog/auto-update-2026-08-29"]
 status: completed
 ---
 
 # Changelog Update State
 
-**Last Updated:** 2026-08-13T00:00:00Z
+**Last Updated:** 2026-08-29T17:34:00Z
 
 This document tracks the state of the changelog updater agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 03b4ccc | chore: version packages (#451) |
-| Last run | 2026-08-13T00:00:00Z | Catch-up: reset stale seed (was 6053872, Mar 13) and filled the gap |
-| Entries added (last run) | 11 | Stop/reap sessions, plugins+MCP config, faster job listings, session adoption, custom Claude home, session hardening, token accounting, inline images, token streaming, embeddable scheduler, event contract fixes |
-| Branches created | docs/whats-new-catchup-2026-08-13 | Current update branch |
+| Last checked commit | 9b1e34a | fix(core): mint the CLI session id instead of inferring it (#357) (#431) |
+| Last run | 2026-08-29T17:34:00Z | Regular update: 5 commits analyzed, 2 entries added |
+| Entries added (last run) | 2 | Session ID tracking fix, Web dashboard chat improvements |
+| Branches created | changelog/auto-update-2026-08-29 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-08-29 | 5 | 2 | created-branch | changelog/auto-update-2026-08-29 |
 | 2026-08-13 | 71 | 11 | created-branch | docs/whats-new-catchup-2026-08-13 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,20 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Session ID Tracking Fix for Co-located Agents
+**August 16, 2026** · `@herdctl/core@5.33.1`
+
+herdctl now correctly tracks session IDs when multiple agents share the same working directory. Previously, when two agents spawned concurrently in the same directory, they could swap session IDs and bind to each other's transcripts — streaming the wrong conversation, resuming incorrect history, or disappearing from chat lists. The runtime now mints its own session ID and passes it to the Claude CLI using `--session-id`, eliminating the race condition entirely. Session attribution is also deterministic when conflicts occur (newest session wins by timestamp).
+
+---
+
+### Web Dashboard Chat and Session Management Improvements
+**August 15, 2026** · `@herdctl/web@0.11.1`
+
+The web dashboard now handles chat sessions more reliably. Chat messages that fail to load time out after 15 seconds with a retry button instead of hanging indefinitely. The "Show all" button in directory groups now properly expands beyond the initial 10 sessions and can page through larger groups. Search results are more consistent — directory groups that match by name now show all their sessions, and the no-results state is deterministic. WebSocket messages sent immediately on connect are no longer dropped on cold or loaded servers.
+
+---
+
 ### Stop and Force-Close Live Sessions from Your App
 **August 12, 2026** · `@herdctl/core@5.33.0` · `@herdctl/core@5.31.0`
 


### PR DESCRIPTION
Automated changelog update added 2 new entries.

## Entries Added

1. **Session ID Tracking Fix for Co-located Agents** (2026-08-16, @herdctl/core v5.33.1)
   - Fixed race condition where multiple agents sharing the same working directory could swap session IDs
   - Runtime now mints its own session ID and passes it to Claude CLI via `--session-id`
   - Session attribution is now deterministic when conflicts occur

2. **Web Dashboard Chat and Session Management Improvements** (2026-08-15, @herdctl/web v0.11.1)
   - Chat messages that fail to load now time out after 15 seconds with a retry button
   - "Show all" button properly expands directory groups beyond initial 10 sessions
   - Search results are more consistent and deterministic
   - WebSocket messages sent immediately on connect are no longer dropped

## Commits Analyzed
5 commits from 03b4ccc to 9b1e34a

Generated by changelog-update-daily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session tracking for co-located agents to prevent transcripts from being assigned to the wrong session.
  * Failed chat messages now time out after 15 seconds and offer a retry option.
  * Fixed WebSocket messages being dropped immediately after connection.
  * Improved search consistency with a clear no-results state.

* **Improvements**
  * Directory groups can now expand beyond the initial 10 sessions with paging.
  * Added release notes for the latest core and web updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->