### PR TITLE
docs: update What's New page (2026-09-06)

### DIFF
--- a/agents/changelog/state.md
+++ b/agents/changelog/state.md
@@ -1,14 +1,14 @@
 ---
-last_checked_commit: 03b4ccc
-last_run: "2026-08-13T00:00:00Z"
-entries_added: 11
-branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "docs/whats-new-catchup-2026-08-13"]
+last_checked_commit: 684a56d
+last_run: "2026-09-06T08:09:25Z"
+entries_added: 2
+branches_created: ["docs/changelog-update-2026-02-22", "docs/changelog-update-2026-02-23-manual", "changelog/auto-update-2026-02-25", "changelog/auto-update-2026-02-26", "changelog/auto-update-2026-03-01", "changelog/auto-update-2026-03-06", "changelog/auto-update-2026-03-13", "docs/whats-new-catchup-2026-08-13", "changelog/auto-update-2026-09-06"]
 status: completed
 ---
 
 # Changelog Update State
 
-**Last Updated:** 2026-08-13T00:00:00Z
+**Last Updated:** 2026-09-06T08:09:25Z
 
 This document tracks the state of the changelog updater agent, enabling
 incremental reviews that analyze only new commits since the last check.
@@ -19,10 +19,10 @@ incremental reviews that analyze only new commits since the last check.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| Last checked commit | 03b4ccc | chore: version packages (#451) |
-| Last run | 2026-08-13T00:00:00Z | Catch-up: reset stale seed (was 6053872, Mar 13) and filled the gap |
-| Entries added (last run) | 11 | Stop/reap sessions, plugins+MCP config, faster job listings, session adoption, custom Claude home, session hardening, token accounting, inline images, token streaming, embeddable scheduler, event contract fixes |
-| Branches created | docs/whats-new-catchup-2026-08-13 | Current update branch |
+| Last checked commit | 684a56d | docs: update audit state from 2026-09-05 run |
+| Last run | 2026-09-06T08:09:25Z | Daily update: 5 commits analyzed |
+| Entries added (last run) | 2 | Session ID hardening, dashboard chat fixes |
+| Branches created | changelog/auto-update-2026-09-06 | Current update branch |
 
 ---
 
@@ -30,6 +30,7 @@ incremental reviews that analyze only new commits since the last check.
 
 | Date | Commits Analyzed | Entries Added | Action | Branch |
 |------|-----------------|---------------|--------|--------|
+| 2026-09-06 | 5 | 2 | created-branch | changelog/auto-update-2026-09-06 |
 | 2026-08-13 | 71 | 11 | created-branch | docs/whats-new-catchup-2026-08-13 |
 | 2026-03-13 | 7 | 3 | Ready for PR | changelog/auto-update-2026-03-13 |
 | 2026-03-06 | 11 | 3 | Ready for PR | changelog/auto-update-2026-03-06 |

--- a/docs/src/content/docs/whats-new.md
+++ b/docs/src/content/docs/whats-new.md
@@ -7,6 +7,20 @@ A summary of notable changes across the herdctl packages. For the full technical
 
 ---
 
+### Hardened Session ID Tracking for Co-located Agents
+**August 16, 2026**
+
+When multiple agents share the same working directory and spawn new Claude Code sessions concurrently, herdctl now mints and assigns a unique session ID to each agent instead of inferring ownership by guessing which transcript file is "newest." This prevents agents from trading session IDs—a bug where Agent A could adopt Agent B's transcript and vice versa, causing streamed responses to appear in the wrong chat, history to resume incorrectly, and sessions to vanish from listings. The fix also makes session attribution deterministic when conflicts occur, so outcomes are consistent rather than dependent on file size or machine load.
+
+---
+
+### Dashboard Chat and Session Listing Fixes
+**August 13, 2026** · `@herdctl/web@0.11.1`
+
+The web dashboard's chat interface now times out after 15 seconds when loading messages (previously it could hang forever) and offers a Retry button on failures. Empty sessions show a clear "No messages found" state instead of the misleading "Send a message to start" prompt. The "Show all" button in directory groups actually expands beyond the first 10 sessions and supports paging through large groups. Search results no longer produce empty directory groups with confusing per-group "no sessions" messages—groups that match only by path or agent name now show all their sessions, while non-matching groups are dropped entirely.
+
+---
+
 ### Stop and Force-Close Live Sessions from Your App
 **August 12, 2026** · `@herdctl/core@5.33.0` · `@herdctl/core@5.31.0`
 


### PR DESCRIPTION
Automated changelog update added 2 new entries.

## Entries Added

1. **Hardened Session ID Tracking for Co-located Agents** (Aug 16) -- Fixed session ID trading bug when multiple agents share a working directory
2. **Dashboard Chat and Session Listing Fixes** (Aug 13) -- @herdctl/web v0.11.1 with chat timeouts, retry, and improved session listing

## Commits Analyzed

5 commits from 03b4ccc to 684a56d

Generated by changelog-update-daily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Co-located agents now receive unique session IDs, improving session tracking reliability.
  - Web dashboard chat now supports retrying messages after a loading timeout.
- **Bug Fixes**
  - Added a clear empty state when no chat messages are available.
  - Fixed directory group expansion, paging, and search results that produced empty groups.
- **Documentation**
  - Added “What’s New” entries covering these updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->